### PR TITLE
Fixed error with file columns missing from metadata

### DIFF
--- a/MarkMpn.Sql4Cds.Engine/Sql2FetchXml.cs
+++ b/MarkMpn.Sql4Cds.Engine/Sql2FetchXml.cs
@@ -3114,7 +3114,7 @@ namespace MarkMpn.Sql4Cds.Engine
                     var attrName = GetColumnAttribute(entityTable, field);
                     var attribute = entityTable.Metadata.Attributes.SingleOrDefault(a => a.LogicalName.Equals(attrName, StringComparison.OrdinalIgnoreCase));
 
-                    if (!String.IsNullOrEmpty(attribute?.AttributeOf))
+                    if (!String.IsNullOrEmpty(attribute?.AttributeOf) && entityTable.Metadata.Attributes.Any(a => a.LogicalName == attribute.AttributeOf))
                     {
                         var baseAttribute = entityTable.Metadata.Attributes.Single(a => a.LogicalName == attribute.AttributeOf);
                         var virtualAttributeHandled = false;
@@ -3316,7 +3316,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 var attrName = GetColumnAttribute(entityTable, field);
                 var attr = entityTable.Metadata.Attributes.SingleOrDefault(a => a.LogicalName.Equals(attrName, StringComparison.OrdinalIgnoreCase));
 
-                if (!String.IsNullOrEmpty(attr.AttributeOf))
+                if (!String.IsNullOrEmpty(attr.AttributeOf) && entityTable.Metadata.Attributes.Any(a => a.LogicalName == attr.AttributeOf))
                 {
                     var virtualAttributeHandled = false;
                     var baseAttribute = entityTable.Metadata.Attributes.Single(a => a.LogicalName == attr.AttributeOf);
@@ -3390,7 +3390,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 var attrName = GetColumnAttribute(entityTable, field);
                 var attr = entityTable.Metadata.Attributes.SingleOrDefault(a => a.LogicalName.Equals(attrName, StringComparison.OrdinalIgnoreCase));
 
-                if (!String.IsNullOrEmpty(attr.AttributeOf))
+                if (!String.IsNullOrEmpty(attr.AttributeOf) && entityTable.Metadata.Attributes.Any(a => a.LogicalName == attr.AttributeOf))
                 {
                     var virtualAttributeHandled = false;
                     var baseAttribute = entityTable.Metadata.Attributes.Single(a => a.LogicalName == attr.AttributeOf);
@@ -3469,7 +3469,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 var attrName = GetColumnAttribute(entityTable, field);
                 var attr = entityTable.Metadata.Attributes.SingleOrDefault(a => a.LogicalName.Equals(attrName, StringComparison.OrdinalIgnoreCase));
 
-                if (!String.IsNullOrEmpty(attr.AttributeOf))
+                if (!String.IsNullOrEmpty(attr.AttributeOf) && entityTable.Metadata.Attributes.Any(a => a.LogicalName == attr.AttributeOf))
                 {
                     var virtualAttributeHandled = false;
                     var baseAttribute = entityTable.Metadata.Attributes.Single(a => a.LogicalName == attr.AttributeOf);

--- a/MarkMpn.Sql4Cds/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds/Autocomplete.cs
@@ -714,7 +714,7 @@ namespace MarkMpn.Sql4Cds
                 _attribute = attribute;
 
                 if (!String.IsNullOrEmpty(_attribute.AttributeOf) && metadata.TryGetMinimalData(attribute.EntityLogicalName, out var entity))
-                    _attributeOf = entity.Attributes.Single(a => a.LogicalName == _attribute.AttributeOf);
+                    _attributeOf = entity.Attributes.SingleOrDefault(a => a.LogicalName == _attribute.AttributeOf);
             }
 
             public override string ToolTipTitle


### PR DESCRIPTION
Fixes #45 

Metadata for file attributes is not returned so is not available for Intellisense to use.

Please [vote for this idea](https://experience.dynamics.com/ideas/idea/?ideaid=34623aca-63d2-ea11-bf21-0003ff68d921) to include these attributes in the returned metadata!