### PR TITLE
Various Fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -613,6 +613,10 @@ namespace MarkMpn.Sql4Cds.Engine
             if (expr.Type == typeof(int?) && type == typeof(OptionSetValue))
                 return Expr.Call(() => CreateOptionSetValue(Arg<int?>()), expr);
 
+            // Extract IDs from EntityReferences
+            if (expr.Type == typeof(EntityReference) && type == typeof(Guid?))
+                return Expr.Call(() => GetEntityReferenceId(Arg<EntityReference>()), expr);
+
             // Check for compatible class types
             if (expr.Type.IsClass && type.IsClass)
             {
@@ -628,6 +632,11 @@ namespace MarkMpn.Sql4Cds.Engine
             }
 
             throw new NotSupportedException($"Cannot convert from {expr.Type} to {type}");
+        }
+
+        private static Guid? GetEntityReferenceId(EntityReference entityReference)
+        {
+            return entityReference.Id;
         }
 
         private static bool? StringToBool(string str)

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -11,8 +11,9 @@
     <iconUrl>https://markcarrington.dev/sql4cds-icon/</iconUrl>
     <description>Convert SQL queries to FetchXml and execute them against CDS</description>
     <summary>Convert SQL queries to FetchXml and execute them against CDS</summary>
-    <releaseNotes>Extended TDS endpoint supoprt
-Fixed inserts into multi-select picklist attributes</releaseNotes>
+    <releaseNotes>Fixed handling ORDER BY &lt;index&gt; clause when using GROUP BY and JOIN together
+Improved error reporting when using ORDER BY &lt;index&gt; with invalid column number
+Show correct error when alternative aggregate query fails</releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>SQL CDS</tags>

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -13,6 +13,7 @@
     <summary>Convert SQL queries to FetchXml and execute them against CDS</summary>
     <releaseNotes>Fixed handling ORDER BY &lt;index&gt; clause when using GROUP BY and JOIN together
 Improved error reporting when using ORDER BY &lt;index&gt; with invalid column number
+Fixed inserting values into N:N intersect tables
 Show correct error when alternative aggregate query fails</releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds.Engine/Query.cs
+++ b/MarkMpn.Sql4Cds.Engine/Query.cs
@@ -239,6 +239,10 @@ namespace MarkMpn.Sql4Cds.Engine
                     throw;
 
                 AggregateAlternative.Execute(org, metadata, options);
+
+                if (AggregateAlternative.Result is Exception altEx)
+                    throw altEx;
+
                 return (EntityCollection)AggregateAlternative.Result;
             }
         }

--- a/MarkMpn.Sql4Cds.Engine/Sql2FetchXml.cs
+++ b/MarkMpn.Sql4Cds.Engine/Sql2FetchXml.cs
@@ -3976,7 +3976,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 throw new NotSupportedQueryFragmentException("Unhandled SELECT clause", expr);
 
             // Find the appropriate table and add the attribute to the table
-            GetColumnTableAlias(col, tables, out table);
+            GetColumnTableAlias(col, tables, out table, calculatedColumns);
             var attrName = GetColumnAttribute(table, col);
             var requestedAttrName = attrName;
 
@@ -4369,7 +4369,7 @@ namespace MarkMpn.Sql4Cds.Engine
         private void ValidateAttributeName(EntityTable table, ColumnReferenceExpression col)
         {
             var attrName = GetColumnAttribute(table, col);
-            if (!table.Metadata.Attributes.Any(attr => attr.LogicalName.Equals(attrName, StringComparison.OrdinalIgnoreCase)))
+            if (!table.Metadata.Attributes.Any(attr => attr.LogicalName.Equals(attrName, StringComparison.OrdinalIgnoreCase)) && !table.GetItems().OfType<FetchAttributeType>().Any(a => (a.alias ?? "").Equals(attrName, StringComparison.OrdinalIgnoreCase)))
                 throw new NotSupportedQueryFragmentException("Unknown attribute", col);
         }
 

--- a/MarkMpn.Sql4Cds.Engine/Sql2FetchXml.cs
+++ b/MarkMpn.Sql4Cds.Engine/Sql2FetchXml.cs
@@ -422,7 +422,23 @@ namespace MarkMpn.Sql4Cds.Engine
                         throw new NotSupportedQueryFragmentException("Unknown attribute name", columns[i]);
 
                     if (attr.IsValidForCreate == false)
-                        throw new NotSupportedQueryFragmentException("Column cannot be set on INSERT", columns[i]);
+                    {
+                        if (meta.IsIntersect == false)
+                            throw new NotSupportedQueryFragmentException("Column cannot be set on INSERT", columns[i]);
+
+                        if (target == "listmember")
+                        {
+                            if (attr.LogicalName != "listid" && attr.LogicalName != "entityid")
+                                throw new NotSupportedQueryFragmentException("Column cannot be set on INSERT", columns[i]);
+                        }
+                        else
+                        {
+                            var relationship = meta.ManyToManyRelationships.Single();
+
+                            if (attr.LogicalName != relationship.Entity1IntersectAttribute && attr.LogicalName != relationship.Entity2IntersectAttribute)
+                                throw new NotSupportedQueryFragmentException("Column cannot be set on INSERT", columns[i]);
+                        }
+                    }
 
                     if (row.ColumnValues[i] is Literal literal)
                     {
@@ -1078,6 +1094,7 @@ namespace MarkMpn.Sql4Cds.Engine
 
                 case AttributeTypeCode.Memo:
                 case AttributeTypeCode.String:
+                case AttributeTypeCode.EntityName:
                     return value.ToString();
 
                 case AttributeTypeCode.Money:

--- a/MarkMpn.Sql4Cds.Engine/Sql2FetchXml.cs
+++ b/MarkMpn.Sql4Cds.Engine/Sql2FetchXml.cs
@@ -2657,7 +2657,12 @@ namespace MarkMpn.Sql4Cds.Engine
                 {
                     if (sort.Expression is IntegerLiteral colIndex)
                     {
-                        var colName = columns[Int32.Parse(colIndex.Value, CultureInfo.InvariantCulture) - 1];
+                        var index = Int32.Parse(colIndex.Value, CultureInfo.InvariantCulture) - 1;
+
+                        if (index >= columns.Length)
+                            throw new NotSupportedQueryFragmentException("The ORDER BY position number is out of range of the number of items in the select list.", colIndex);
+
+                        var colName = columns[index];
 
                         col = new ColumnReferenceExpression { MultiPartIdentifier = new MultiPartIdentifier() };
 

--- a/MarkMpn.Sql4Cds.SSMS/CommandBase.cs
+++ b/MarkMpn.Sql4Cds.SSMS/CommandBase.cs
@@ -91,13 +91,13 @@ namespace MarkMpn.Sql4Cds.SSMS
 
             var serverParts = conStr.DataSource.Split(',');
 
-            if (serverParts.Length != 2)
+            if (serverParts.Length > 2)
                 return false;
 
             if (!serverParts[0].EndsWith(".dynamics.com"))
                 return false;
 
-            if (serverParts[1] != "5558")
+            if (serverParts.Length > 1 && serverParts[1] != "5558")
                 return false;
 
             return true;

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -24,6 +24,7 @@ Using the preview T-SQL endpoint, SELECT queries can also be run that aren't con
     <summary>Convert SQL queries to FetchXML and execute them against CDS</summary>
     <releaseNotes>Fixed handling ORDER BY &lt;index&gt; clause when using GROUP BY and JOIN together
 Improved error reporting when using ORDER BY &lt;index&gt; with invalid column number
+Fixed inserting values into N:N intersect tables
 Show correct error when alternative aggregate query fails</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -22,8 +22,9 @@ plugins or integrations by writing familiar SQL and converting it.
 
 Using the preview T-SQL endpoint, SELECT queries can also be run that aren't convertible to FetchXML.</description>
     <summary>Convert SQL queries to FetchXML and execute them against CDS</summary>
-    <releaseNotes>Extended TDS endpoint supoprt
-Fixed inserts into multi-select picklist attributes</releaseNotes>
+    <releaseNotes>Fixed handling ORDER BY &lt;index&gt; clause when using GROUP BY and JOIN together
+Improved error reporting when using ORDER BY &lt;index&gt; with invalid column number
+Show correct error when alternative aggregate query fails</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/PluginControl.cs
+++ b/MarkMpn.Sql4Cds/PluginControl.cs
@@ -243,7 +243,7 @@ namespace MarkMpn.Sql4Cds
                 tsbPreviewFetchXml.PerformClick();
             else if (keyData == (Keys.Control | Keys.M))
                 tsbIncludeFetchXml.PerformClick();
-            else if (keyData == Keys.F5)
+            else if (keyData == Keys.F5 || keyData == (Keys.Control | Keys.E))
                 tsbExecute.PerformClick();
             else
                 return base.ProcessCmdKey(ref msg, keyData);


### PR DESCRIPTION
* If an aggregate query exceeds the allowed row limit for FetchXML and needs to be processed manually, and that alternative query fails, expose the correct error to the user
* If using `ORDER BY <index>` syntax, give a more useful error if the index is out of range
* Apply the correct ordering for  `ORDER BY <index>` syntax on an aggregate query with joins
* Do not require port 5558 for Dataverse connections in SSMS - fixes #49
* Fixed `INSERT INTO <table> (<cols>) VALUES (<values>)` for intersect tables and lookup values - fixes #50
* Allow Ctrl+E shortcut for executing query