### PR TITLE
Fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
@@ -2854,6 +2854,41 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             ");
         }
 
+        [TestMethod]
+        public void CharIndex()
+        {
+            var context = new XrmFakedContext();
+            context.InitializeMetadata(Assembly.GetExecutingAssembly());
+
+            var org = context.GetOrganizationService();
+            var metadata = new AttributeMetadataCache(org);
+            var sql2FetchXml = new Sql2FetchXml(metadata, true);
+
+            var query = "SELECT CHARINDEX('a', fullname) AS ci0, CHARINDEX('a', fullname, 1) AS ci1, CHARINDEX('a', fullname, 2) AS ci2, CHARINDEX('a', fullname, 3) AS ci3, CHARINDEX('a', fullname, 8) AS ci8 FROM contact";
+
+            var queries = sql2FetchXml.Convert(query);
+
+            var contact1 = Guid.NewGuid();
+
+            context.Data["contact"] = new Dictionary<Guid, Entity>
+            {
+                [contact1] = new Entity("contact", contact1)
+                {
+                    ["fullname"] = "Mark Carrington",
+                    ["contactid"] = contact1
+                }
+            };
+
+            var select = queries[0];
+            select.Execute(context.GetOrganizationService(), new AttributeMetadataCache(context.GetOrganizationService()), this);
+            var result = (EntityCollection)select.Result;
+            Assert.AreEqual(2, result.Entities[0].GetAttributeValue<int>("ci0"));
+            Assert.AreEqual(2, result.Entities[0].GetAttributeValue<int>("ci1"));
+            Assert.AreEqual(2, result.Entities[0].GetAttributeValue<int>("ci2"));
+            Assert.AreEqual(7, result.Entities[0].GetAttributeValue<int>("ci3"));
+            Assert.AreEqual(0, result.Entities[0].GetAttributeValue<int>("ci8"));
+        }
+
         private void AssertFetchXml(Query[] queries, string fetchXml)
         {
             Assert.AreEqual(1, queries.Length);

--- a/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
@@ -2846,8 +2846,8 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                         <attribute name='contactid'/>
                         <attribute name='parentcustomerid'/>
                         <link-entity name='account' from='accountid' to='parentcustomerid' link-type='inner' alias='account'>
-                            <attribute name='accountid'/>
                             <attribute name='name'/>
+                            <attribute name='accountid'/>
                         </link-entity>
                     </entity>
                 </fetch>

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -480,6 +480,38 @@ namespace MarkMpn.Sql4Cds.Engine
 
             return expression.TrimEnd(' ');
         }
+
+        /// <summary>
+        /// Searches for one character expression inside a second character expression, returning the starting position of the first expression if found
+        /// </summary>
+        /// <param name="find">A character expression containing the sequence to find</param>
+        /// <param name="search">A character expression to search.</param>
+        /// <returns></returns>
+        public static int? CharIndex(string find, string search)
+        {
+            return CharIndex(find, search, 0);
+        }
+
+        /// <summary>
+        /// Searches for one character expression inside a second character expression, returning the starting position of the first expression if found
+        /// </summary>
+        /// <param name="find">A character expression containing the sequence to find</param>
+        /// <param name="search">A character expression to search.</param>
+        /// <param name="startLocation">An integer or bigint expression at which the search starts. If start_location is not specified, has a negative value, or has a zero (0) value, the search starts at the beginning of expressionToSearch.</param>
+        /// <returns></returns>
+        public static int? CharIndex(string find, string search, int? startLocation)
+        {
+            if (find == null || search == null || startLocation == null)
+                return null;
+
+            if (startLocation <= 0)
+                startLocation = 1;
+
+            if (startLocation > search.Length)
+                return 0;
+
+            return search.IndexOf(find, startLocation.Value - 1, StringComparison.OrdinalIgnoreCase) + 1;
+        }
     }
 
     /// <summary>

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -11,7 +11,9 @@
     <iconUrl>https://markcarrington.dev/sql4cds-icon/</iconUrl>
     <description>Convert SQL queries to FetchXml and execute them against CDS</description>
     <summary>Convert SQL queries to FetchXml and execute them against CDS</summary>
-    <releaseNotes>Show virtual ___name and ___type attributes across multiple pages of results</releaseNotes>
+    <releaseNotes>Identify queries that hit the legacy paging limit
+Avoid 50K row limit for custom aggregates
+Implemented CHARINDEX function</releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>SQL CDS</tags>

--- a/MarkMpn.Sql4Cds.Engine/Query.cs
+++ b/MarkMpn.Sql4Cds.Engine/Query.cs
@@ -325,6 +325,9 @@ namespace MarkMpn.Sql4Cds.Engine
                 count += nextPage.Entities.Count;
                 res = nextPage;
             }
+
+            if (count == 50000 && !res.MoreRecords && String.IsNullOrEmpty(FetchXml.pagingcookie))
+                throw new ApplicationException("Maximum 50,000 records retrieved using legacy paging before query was complete");
         }
 
         private void OnRetrievedEntity(Entity entity)

--- a/MarkMpn.Sql4Cds.Engine/Sql2FetchXml.cs
+++ b/MarkMpn.Sql4Cds.Engine/Sql2FetchXml.cs
@@ -2039,6 +2039,16 @@ namespace MarkMpn.Sql4Cds.Engine
 
             if (sortedGroupings.Count > 0)
             {
+                // If the main entity don't have sorts, remove them all to prevent falling back to
+                // legacy paging
+                if (!tables[0].GetItems().OfType<FetchOrderType>().Any())
+                {
+                    foreach (var table in tables)
+                        table.RemoveItems(obj => obj is FetchOrderType);
+
+                    sortedGroupings.Clear();
+                }
+
                 // Sort the groupings according to how the sort orders will be applied
                 var sorts = GetSorts(tables[0].Entity);
                 var i = 0;

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -22,8 +22,9 @@ plugins or integrations by writing familiar SQL and converting it.
 
 Using the preview T-SQL endpoint, SELECT queries can also be run that aren't convertible to FetchXML.</description>
     <summary>Convert SQL queries to FetchXML and execute them against CDS</summary>
-    <releaseNotes>Show virtual ___name and ___type attributes across multiple pages of results
-Show settings option in main Configuration menu</releaseNotes>
+    <releaseNotes>Identify queries that hit the legacy paging limit
+Avoid 50K row limit for custom aggregates
+Implemented CHARINDEX function</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>


### PR DESCRIPTION
Improved legacy paging handling (fixes #56):
* Produce an error when the legacy paging limit of 50K records is hit to avoid misleading results
* Do not apply sorts for custom aggregates that would trigger legacy paging

Implemented `CHARINDEX` function (fixes #57)