### PR TITLE
Update conversion of date/time filters for UTC changes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
@@ -2748,33 +2748,6 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         }
 
         [TestMethod]
-        public void FilterOnUtcDateTimeColumn()
-        {
-            var context = new XrmFakedContext();
-            context.InitializeMetadata(Assembly.GetExecutingAssembly());
-
-            var org = context.GetOrganizationService();
-            var metadata = new AttributeMetadataCache(org);
-            var sql2FetchXml = new Sql2FetchXml(metadata, true);
-
-            var query = @"
-                SELECT name FROM account WHERE createdonutc >= '2021-01-01'";
-
-            var queries = sql2FetchXml.Convert(query);
-
-            AssertFetchXml(queries, @"
-                <fetch>
-                    <entity name='account'>
-                        <attribute name='name' />
-                        <filter>
-                            <condition attribute='createdon' operator='ge' value='2021-01-01 00:00:00Z' />
-                        </filter>
-                    </entity>
-                </fetch>
-            ");
-        }
-
-        [TestMethod]
         public void OrderByAggregateByIndex()
         {
             var context = new XrmFakedContext();

--- a/MarkMpn.Sql4Cds.SSMS/FetchXml2SqlCommand.cs
+++ b/MarkMpn.Sql4Cds.SSMS/FetchXml2SqlCommand.cs
@@ -136,7 +136,7 @@ namespace MarkMpn.Sql4Cds.SSMS
             {
                 ConvertFetchXmlOperatorsTo = FetchXmlOperatorConversion.SqlCalculations,
                 UseParametersForLiterals = true,
-                UseUtcDateTimeColumns = true
+                ConvertDateTimeToUtc = true
             }, out var paramValues);
 
             ServiceCache.ScriptFactory.CreateNewBlankScript(ScriptType.Sql, ServiceCache.ScriptFactory.CurrentlyActiveWndConnectionInfo.UIConnectionInfo, null);
@@ -174,10 +174,15 @@ namespace MarkMpn.Sql4Cds.SSMS
 
                 editPoint.Insert($"DECLARE {param.Key} {paramType} = ");
 
+                var value = param.Value.ToString();
+
+                if (param.Value is DateTime dt)
+                    value = dt.ToString("s");
+
                 if (quoteValues)
-                    editPoint.Insert("'" + param.Value.ToString().Replace("'", "''") + "'\r\n");
-                else
-                    editPoint.Insert(param.Value.ToString() + "\r\n");
+                    value = "'" + value.Replace("'", "''") + "'";
+
+                editPoint.Insert(value + "\r\n");
             }
 
             if (paramValues.Count > 0)


### PR DESCRIPTION
Ref https://markcarrington.dev/2021/02/25/tds-endpoint-time-zone-change/

Following update to TDS endpoint to remove `utc`-suffix columns and have regular datetime columns stored as UTC, this update changes the conversion process to use the native columns and convert the filter values as appropriate.