### PR TITLE
Autocomplete & FetchXML Conversion fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine/FetchXml2Sql.cs
+++ b/MarkMpn.Sql4Cds.Engine/FetchXml2Sql.cs
@@ -663,6 +663,10 @@ namespace MarkMpn.Sql4Cds.Engine
                     }
                 };
             }
+            else if (condition.value == null)
+            {
+                value = new NullLiteral();
+            }
             else if (attr == null)
             {
                 value = new StringLiteral { Value = condition.value };

--- a/MarkMpn.Sql4Cds/ObjectExplorer.cs
+++ b/MarkMpn.Sql4Cds/ObjectExplorer.cs
@@ -114,7 +114,9 @@ namespace MarkMpn.Sql4Cds
 
         public void AddConnection(ConnectionDetail con)
         {
-            EntityCache.TryGetEntities(con.ServiceClient, out _);
+            var svc = con.ServiceClient;
+
+            EntityCache.TryGetEntities(svc, out _);
 
             var conNode = treeView.Nodes.Add(con.ConnectionName);
             conNode.Tag = con;
@@ -133,9 +135,9 @@ namespace MarkMpn.Sql4Cds
             {
                 var tsqlNode = conNode.Nodes.Add("TDS Endpoint");
 
-                if (TSqlEndpoint.IsEnabled(con.ServiceClient))
+                if (TSqlEndpoint.IsEnabled(svc))
                 {
-                    if (!String.IsNullOrEmpty(con.ServiceClient.CurrentAccessToken))
+                    if (!String.IsNullOrEmpty(svc.CurrentAccessToken))
                     {
                         tsqlNode.ImageIndex = 21;
                         tsqlNode.SelectedImageIndex = 21;

--- a/MarkMpn.Sql4Cds/PluginControl.cs
+++ b/MarkMpn.Sql4Cds/PluginControl.cs
@@ -55,11 +55,13 @@ namespace MarkMpn.Sql4Cds
 
         private void AddConnection(ConnectionDetail con)
         {
-            _metadata[con] = new AttributeMetadataCache(con.ServiceClient);
+            var svc = con.ServiceClient;
+
+            _metadata[con] = new AttributeMetadataCache(svc);
             _objectExplorer.AddConnection(con);
 
             // Start loading the entity list in the background
-            EntityCache.TryGetEntities(con.ServiceClient, out _);
+            EntityCache.TryGetEntities(svc, out _);
         }
 
         private void PluginControl_Load(object sender, EventArgs e)

--- a/MarkMpn.Sql4Cds/SqlQueryControl.cs
+++ b/MarkMpn.Sql4Cds/SqlQueryControl.cs
@@ -128,7 +128,7 @@ namespace MarkMpn.Sql4Cds
             Icon = _sqlIcon;
         }
 
-        public IOrganizationService Service { get; }
+        public CrmServiceClient Service { get; }
         public IAttributeMetadataCache Metadata { get; }
         public Action<MessageBusEventArgs> OutgoingMessageHandler { get; }
         public string Filename
@@ -335,7 +335,7 @@ namespace MarkMpn.Sql4Cds
                 if (!wordEnd.Success)
                     return;
 
-                EntityCache.TryGetEntities(_con.ServiceClient, out var entities);
+                EntityCache.TryGetEntities(Service, out var entities);
 
                 var metaEntities = MetaMetadata.GetMetadata().Select(m => m.GetEntityMetadata());
 
@@ -404,7 +404,7 @@ namespace MarkMpn.Sql4Cds
                     yield break;
 
                 var text = _control._editor.Text;
-                EntityCache.TryGetEntities(_control._con.ServiceClient, out var entities);
+                EntityCache.TryGetEntities(_control.Service, out var entities);
 
                 var metaEntities = MetaMetadata.GetMetadata().Select(m => m.GetEntityMetadata());
 
@@ -1236,7 +1236,7 @@ namespace MarkMpn.Sql4Cds
 
         private void SyncUsername()
         {
-            if (_con.ServiceClient.CallerId == Guid.Empty)
+            if (Service.CallerId == Guid.Empty)
             {
                 usernameDropDownButton.Text = _con.UserName;
                 usernameDropDownButton.Image = null;
@@ -1244,7 +1244,7 @@ namespace MarkMpn.Sql4Cds
             }
             else
             {
-                var user = Service.Retrieve("systemuser", _con.ServiceClient.CallerId, new ColumnSet("domainname"));
+                var user = Service.Retrieve("systemuser", Service.CallerId, new ColumnSet("domainname"));
 
                 usernameDropDownButton.Text = user.GetAttributeValue<string>("domainname");
                 usernameDropDownButton.Image = Properties.Resources.StatusWarning_16x;
@@ -1263,7 +1263,7 @@ namespace MarkMpn.Sql4Cds
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     _ai.TrackEvent("Execute", new Dictionary<string, string> { ["QueryType"] = typeof(ImpersonateQuery).Name, ["Source"] = "XrmToolBox" });
-                    _con.ServiceClient.CallerId = dlg.Entity.Id;
+                    Service.CallerId = dlg.Entity.Id;
                     SyncUsername();
                 }
             }
@@ -1272,7 +1272,7 @@ namespace MarkMpn.Sql4Cds
         private void revertToolStripMenuItem_Click(object sender, EventArgs e)
         {
             _ai.TrackEvent("Execute", new Dictionary<string, string> { ["QueryType"] = typeof(RevertQuery).Name, ["Source"] = "XrmToolBox" });
-            _con.ServiceClient.CallerId = Guid.Empty;
+            Service.CallerId = Guid.Empty;
             SyncUsername();
         }
     }


### PR DESCRIPTION
`ConnectionDetail.ServiceClient` property getter issues an API request on each access, so we now cache that value to improve performance during autocomplete suggestion generation

Fix an issue when converting FetchXML to SQL when using conditions that do not take a value, e.g. `null` or `not-null`, on attributes  of numeric types.