### PR TITLE
Initial v5 fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -3037,5 +3037,28 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                     </entity>
                 </fetch>");
         }
+
+        [TestMethod]
+        public void HelpfulErrorMessageOnMissingGroupBy()
+        {
+            var context = new XrmFakedContext();
+            context.InitializeMetadata(Assembly.GetExecutingAssembly());
+
+            var org = context.GetOrganizationService();
+            var metadata = new AttributeMetadataCache(org);
+            var planBuilder = new ExecutionPlanBuilder(metadata, new StubTableSizeCache(), this);
+
+            var query = @"SELECT new_name, min(new_optionsetvalue) FROM new_customentity";
+
+            try
+            {
+                planBuilder.Build(query);
+                Assert.Fail();
+            }
+            catch (NotSupportedQueryFragmentException ex)
+            {
+                Assert.AreEqual("Column is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause: new_name", ex.Message);
+            }
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
@@ -2833,6 +2833,37 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             Assert.AreEqual(0, result.Entities[0].GetAttributeValue<int>("ci8"));
         }
 
+        [TestMethod]
+        public void CastDateTimeToDate()
+        {
+            var context = new XrmFakedContext();
+            context.InitializeMetadata(Assembly.GetExecutingAssembly());
+
+            var org = context.GetOrganizationService();
+            var metadata = new AttributeMetadataCache(org);
+            var sql2FetchXml = new Sql2FetchXml(metadata, true);
+
+            var query = "SELECT CAST(createdon AS date) AS converted FROM contact";
+
+            var queries = sql2FetchXml.Convert(query);
+
+            var contact1 = Guid.NewGuid();
+
+            context.Data["contact"] = new Dictionary<Guid, Entity>
+            {
+                [contact1] = new Entity("contact", contact1)
+                {
+                    ["createdon"] = new DateTime(2000, 1, 1, 12, 34, 56),
+                    ["contactid"] = contact1
+                }
+            };
+
+            var select = queries[0];
+            select.Execute(context.GetOrganizationService(), new AttributeMetadataCache(context.GetOrganizationService()), this);
+            var result = (EntityCollection)select.Result;
+            Assert.AreEqual(new DateTime(2000, 1, 1), result.Entities[0].GetAttributeValue<DateTime>("converted"));
+        }
+
         private void AssertFetchXml(Query[] queries, string fetchXml)
         {
             Assert.AreEqual(1, queries.Length);

--- a/MarkMpn.Sql4Cds.Engine/AttributeMetadataCache.cs
+++ b/MarkMpn.Sql4Cds.Engine/AttributeMetadataCache.cs
@@ -146,7 +146,9 @@ namespace MarkMpn.Sql4Cds.Engine
                                         nameof(AttributeMetadata.Description),
                                         nameof(AttributeMetadata.AttributeType),
                                         nameof(AttributeMetadata.IsValidForUpdate),
-                                        nameof(AttributeMetadata.IsValidForCreate)
+                                        nameof(AttributeMetadata.IsValidForCreate),
+                                        nameof(AttributeMetadata.IsValidForRead),
+                                        nameof(LookupAttributeMetadata.Targets)
                                     }
                                 }
                             },

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
@@ -607,7 +607,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                     try
                     {
-                        var dt = SqlDateTime.Parse(lit.Value).Value;
+                        DateTime dt;
+
+                        if (lit is StringLiteral)
+                            dt = SqlDateTime.Parse(lit.Value).Value;
+                        else if (lit is IntegerLiteral || lit is NumericLiteral || lit is RealLiteral)
+                            dt = new DateTime(1900, 1, 1).AddDays(Double.Parse(lit.Value));
+                        else
+                            throw new NotSupportedQueryFragmentException("Invalid datetime value", lit);
+
                         DateTimeOffset dto;
 
                         if (options.UseLocalTimeZone)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
@@ -233,7 +233,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     expr = SqlTypeConverter.Convert(expr, destSqlType);
                     var convertedExpr = SqlTypeConverter.Convert(expr, destType);
 
-                    if (attr is LookupAttributeMetadata lookupAttr)
+                    if (attr is LookupAttributeMetadata lookupAttr && lookupAttr.AttributeType != AttributeTypeCode.PartyList)
                     {
                         Expression targetExpr;
 
@@ -258,7 +258,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         );
                         destType = typeof(EntityReference);
                     }
-                    else if (attr is EnumAttributeMetadata)
+                    else if (attr is EnumAttributeMetadata && !(attr is MultiSelectPicklistAttributeMetadata))
                     {
                         convertedExpr = Expression.New(
                             typeof(OptionSetValue).GetConstructor(new[] { typeof(int) }),

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
@@ -225,13 +225,13 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 if (sourceType == typeof(object))
                 {
                     // null literal
-                    expr = Expression.Constant(null);
+                    expr = Expression.Constant(null, destType);
                 }
                 else
                 {
                     expr = SqlTypeConverter.Convert(expr, sourceType);
                     expr = SqlTypeConverter.Convert(expr, destSqlType);
-                    expr = SqlTypeConverter.Convert(expr, destType);
+                    var convertedExpr = SqlTypeConverter.Convert(expr, destType);
 
                     if (attr is LookupAttributeMetadata lookupAttr)
                     {
@@ -251,49 +251,45 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                             targetExpr = SqlTypeConverter.Convert(targetExpr, typeof(string));
                         }
 
-                        expr = Expression.Condition(
-                            SqlTypeConverter.NullCheck(expr),
-                            Expression.Convert(Expression.Constant(null), typeof(EntityReference)),
-                            Expression.New(
-                                typeof(EntityReference).GetConstructor(new[] { typeof(string), typeof(Guid) }),
-                                targetExpr,
-                                Expression.Convert(expr, typeof(Guid))
-                            )
-                        ); ;
+                        convertedExpr = Expression.New(
+                            typeof(EntityReference).GetConstructor(new[] { typeof(string), typeof(Guid) }),
+                            targetExpr,
+                            Expression.Convert(convertedExpr, typeof(Guid))
+                        );
+                        destType = typeof(EntityReference);
                     }
                     else if (attr is EnumAttributeMetadata)
                     {
-                        expr = Expression.Condition(
-                            SqlTypeConverter.NullCheck(expr),
-                            Expression.Convert(Expression.Constant(null), typeof(OptionSetValue)),
-                            Expression.New(
-                                typeof(OptionSetValue).GetConstructor(new[] { typeof(int) }),
-                                Expression.Convert(expr, typeof(int))
-                            )
+                        convertedExpr = Expression.New(
+                            typeof(OptionSetValue).GetConstructor(new[] { typeof(int) }),
+                            Expression.Convert(convertedExpr, typeof(int))
                         );
+                        destType = typeof(OptionSetValue);
                     }
                     else if (attr is MoneyAttributeMetadata)
                     {
-                        expr = Expression.Condition(
-                            SqlTypeConverter.NullCheck(expr),
-                            Expression.Convert(Expression.Constant(null), typeof(Money)),
-                            Expression.New(
-                                typeof(Money).GetConstructor(new[] { typeof(decimal) }),
-                                Expression.Convert(expr, typeof(decimal))
-                            )
+                        convertedExpr = Expression.New(
+                            typeof(Money).GetConstructor(new[] { typeof(decimal) }),
+                            Expression.Convert(expr, typeof(decimal))
                         );
+                        destType = typeof(Money);
                     }
                     else if (attr is DateTimeAttributeMetadata)
                     {
-                        expr = Expression.Condition(
-                            SqlTypeConverter.NullCheck(expr),
-                            Expression.Convert(Expression.Constant(null), typeof(DateTime?)),
+                        convertedExpr = Expression.Convert(
                             Expr.Call(() => DateTime.SpecifyKind(Expr.Arg<DateTime>(), Expr.Arg<DateTimeKind>()),
                                 expr,
                                 Expression.Constant(dateTimeKind)
-                            )
+                            ),
+                            typeof(DateTime?)
                         );
                     }
+
+                    // Check for null on the value BEFORE converting from the SQL to BCL type to avoid e.g. SqlDateTime.Null being converted to 1900-01-01
+                    expr = Expression.Condition(
+                        SqlTypeConverter.NullCheck(expr),
+                        Expression.Constant(null, destType),
+                        convertedExpr);
 
                     if (expr.Type.IsValueType)
                         expr = SqlTypeConverter.Convert(expr, typeof(object));

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ComputeScalarNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ComputeScalarNode.cs
@@ -57,7 +57,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 schema.Aliases.Add(alias);
 
             foreach (var calc in Columns)
-                schema.Schema[calc.Key] = calc.Value.GetType(sourceSchema, parameterTypes);
+                schema.Schema[calc.Key] = calc.Value.GetType(sourceSchema, null, parameterTypes);
 
             return schema;
         }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -1210,7 +1210,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             else if (value is SqlString str)
                 literal = new StringLiteral { Value = str.ToString() };
             else if (value is SqlDateTime dt)
-                literal = new StringLiteral { Value = dt.ToString() };
+                literal = new StringLiteral { Value = dt.Value.ToString("yyyy-MM-ddTHH:mm:ss.fff") };
             else if (value is SqlGuid g)
                 literal = new StringLiteral { Value = g.ToString() };
             else

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -24,14 +24,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// </summary>
         /// <param name="expr">The expression to get the type of</param>
         /// <param name="schema">The schema of the node that the expression will be evaluated in the context of</param>
+        /// <param name="nonAggregateSchema">For aggregate queries, the schema of the data prior to applying the aggregation</param>
         /// <param name="parameterTypes">A mapping of parameter names to their types that are available to the expression</param>
         /// <returns>The type of value that will be returned by the expression</returns>
-        public static Type GetType(this TSqlFragment expr, NodeSchema schema, IDictionary<string,Type> parameterTypes)
+        public static Type GetType(this TSqlFragment expr, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string,Type> parameterTypes)
         {
             var entityParam = Expression.Parameter(typeof(Entity));
             var parameterParam = Expression.Parameter(typeof(IDictionary<string, object>));
 
-            var expression = ToExpression(expr, schema, parameterTypes, entityParam, parameterParam);
+            var expression = ToExpression(expr, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             return expression.Type;
         }
 
@@ -47,7 +48,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             var entityParam = Expression.Parameter(typeof(Entity));
             var parameterParam = Expression.Parameter(typeof(IDictionary<string, object>));
 
-            var expression = ToExpression(expr, schema, parameterTypes, entityParam, parameterParam);
+            var expression = ToExpression(expr, schema, null, parameterTypes, entityParam, parameterParam);
             expression = Expr.Box(expression);
 
             return Expression.Lambda<Func<Entity, IDictionary<string, object>, object>>(expression, entityParam, parameterParam).Compile();
@@ -56,7 +57,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// <summary>
         /// Compiles a boolean expression to a function
         /// </summary>
-        /// <param name="expr">The expression to be compiled</param>
+        /// <param name="b">The expression to be compiled</param>
         /// <param name="schema">The schema of the node that the expression will be evaluated in the context of</param>
         /// <param name="parameterTypes">A mapping of parameter names to their types that are available to the expression</param>
         /// <returns>A function that accepts a <see cref="Entity"/> representing the data values of a record and a <see cref="IDictionary{string, object}"/> holding parameter values and returns the value of the expression</returns>
@@ -65,70 +66,70 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             var entityParam = Expression.Parameter(typeof(Entity));
             var parameterParam = Expression.Parameter(typeof(IDictionary<string, object>));
 
-            var expression = ToExpression(b, schema, parameterTypes, entityParam, parameterParam);
+            var expression = ToExpression(b, schema, null, parameterTypes, entityParam, parameterParam);
             expression = Expression.IsTrue(expression);
             return Expression.Lambda<Func<Entity, IDictionary<string, object>, bool>>(expression, entityParam, parameterParam).Compile();
         }
 
-        private static Expression ToExpression(this TSqlFragment expr, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this TSqlFragment expr, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             if (expr is ColumnReferenceExpression col)
-                return ToExpression(col, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(col, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is IdentifierLiteral guid)
-                return ToExpression(guid, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(guid, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is IntegerLiteral i)
-                return ToExpression(i, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(i, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is MoneyLiteral money)
-                return ToExpression(money, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(money, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is NullLiteral n)
-                return ToExpression(n, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(n, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is NumericLiteral num)
-                return ToExpression(num, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(num, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is RealLiteral real)
-                return ToExpression(real, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(real, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is StringLiteral str)
-                return ToExpression(str, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(str, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is OdbcLiteral odbc)
-                return ToExpression(odbc, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(odbc, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is BooleanBinaryExpression boolBin)
-                return ToExpression(boolBin, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(boolBin, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is BooleanComparisonExpression cmp)
-                return ToExpression(cmp, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(cmp, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is BooleanParenthesisExpression boolParen)
-                return ToExpression(boolParen, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(boolParen, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is InPredicate inPred)
-                return ToExpression(inPred, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(inPred, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is BooleanIsNullExpression isNull)
-                return ToExpression(isNull, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(isNull, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is LikePredicate like)
-                return ToExpression(like, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(like, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is BooleanNotExpression not)
-                return ToExpression(not, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(not, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is FullTextPredicate fullText)
-                return ToExpression(fullText, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(fullText, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is Microsoft.SqlServer.TransactSql.ScriptDom.BinaryExpression bin)
-                return ToExpression(bin, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(bin, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is FunctionCall func)
-                return ToExpression(func, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(func, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is ParenthesisExpression paren)
-                return ToExpression(paren, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(paren, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is Microsoft.SqlServer.TransactSql.ScriptDom.UnaryExpression unary)
-                return ToExpression(unary, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(unary, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is VariableReference var)
-                return ToExpression(var, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(var, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is SimpleCaseExpression simpleCase)
-                return ToExpression(simpleCase, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(simpleCase, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is SearchedCaseExpression searchedCase)
-                return ToExpression(searchedCase, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(searchedCase, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is ConvertCall convert)
-                return ToExpression(convert, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(convert, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else if (expr is CastCall cast)
-                return ToExpression(cast, schema, parameterTypes, entityParam, parameterParam);
+                return ToExpression(cast, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             else
                 throw new NotSupportedQueryFragmentException("Unhandled expression type", expr);
         }
 
-        private static Expression ToExpression(ColumnReferenceExpression col, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(ColumnReferenceExpression col, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             var name = col.GetColumnName();
 
@@ -136,6 +137,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             {
                 if (!schema.Aliases.TryGetValue(name, out var normalized))
                 {
+                    if (nonAggregateSchema != null && nonAggregateSchema.ContainsColumn(name, out _))
+                        throw new NotSupportedQueryFragmentException("Column is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause", col);
+
                     var ex = new NotSupportedQueryFragmentException("Unknown column", col);
 
                     if (col.MultiPartIdentifier.Identifiers.Count == 1 && col.MultiPartIdentifier.Identifiers[0].QuoteType == QuoteType.DoubleQuote)
@@ -155,42 +159,42 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return Expression.Convert(expr, type);
         }
 
-        private static Expression ToExpression(IdentifierLiteral guid, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(IdentifierLiteral guid, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             return Expression.Constant(new SqlGuid(guid.Value));
         }
 
-        private static Expression ToExpression(IntegerLiteral i, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(IntegerLiteral i, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             return Expression.Constant(new SqlInt32(Int32.Parse(i.Value)));
         }
 
-        private static Expression ToExpression(MoneyLiteral money, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(MoneyLiteral money, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             return Expression.Constant(new SqlDecimal(Decimal.Parse(money.Value)));
         }
 
-        private static Expression ToExpression(NullLiteral n, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(NullLiteral n, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             return Expression.Constant(null);
         }
 
-        private static Expression ToExpression(NumericLiteral num, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(NumericLiteral num, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             return Expression.Constant(new SqlDecimal(Decimal.Parse(num.Value)));
         }
 
-        private static Expression ToExpression(RealLiteral real, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(RealLiteral real, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             return Expression.Constant(new SqlSingle(Single.Parse(real.Value)));
         }
 
-        private static Expression ToExpression(StringLiteral str, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(StringLiteral str, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             return Expression.Constant(new SqlString(str.Value, CultureInfo.CurrentCulture.LCID, SqlCompareOptions.IgnoreCase | SqlCompareOptions.IgnoreNonSpace));
         }
 
-        private static Expression ToExpression(OdbcLiteral odbc, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(OdbcLiteral odbc, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             switch (odbc.OdbcLiteralType)
             {
@@ -208,7 +212,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             }
         }
 
-        private static Expression ToExpression(BooleanComparisonExpression cmp, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(BooleanComparisonExpression cmp, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             // Special case for field = func() where func is defined in FetchXmlConditionMethods
             if (cmp.FirstExpression is ColumnReferenceExpression col &&
@@ -216,8 +220,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 cmp.SecondExpression is FunctionCall func
                 )
             {
-                var parameters = func.Parameters.Select(p => p.ToExpression(schema, parameterTypes, entityParam, parameterParam)).ToList();
-                parameters.Insert(0, col.ToExpression(schema, parameterTypes, entityParam, parameterParam));
+                var parameters = func.Parameters.Select(p => p.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam)).ToList();
+                parameters.Insert(0, col.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam));
                 var paramTypes = parameters.Select(p => p.Type).ToArray();
 
                 var fetchXmlComparison = GetMethod(typeof(FetchXmlConditionMethods), func, paramTypes, false);
@@ -226,8 +230,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     return Expr.Call(fetchXmlComparison, parameters.ToArray());
             }
 
-            var lhs = cmp.FirstExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
-            var rhs = cmp.SecondExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var lhs = cmp.FirstExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
+            var rhs = cmp.SecondExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
             if (!SqlTypeConverter.CanMakeConsistentTypes(lhs.Type, rhs.Type, out var type))
                 throw new NotSupportedQueryFragmentException($"No implicit conversion exists for types {lhs} and {rhs}", cmp);
@@ -266,10 +270,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             }
         }
 
-        private static Expression ToExpression(BooleanBinaryExpression bin, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(BooleanBinaryExpression bin, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
-            var lhs = bin.FirstExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
-            var rhs = bin.SecondExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var lhs = bin.FirstExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
+            var rhs = bin.SecondExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
             if (bin.BinaryExpressionType == BooleanBinaryExpressionType.And)
                 return Expression.AndAlso(lhs, rhs);
@@ -277,15 +281,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return Expression.OrElse(lhs, rhs);
         }
 
-        private static Expression ToExpression(BooleanParenthesisExpression paren, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(BooleanParenthesisExpression paren, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
-            return paren.Expression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            return paren.Expression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
         }
 
-        private static Expression ToExpression(Microsoft.SqlServer.TransactSql.ScriptDom.BinaryExpression bin, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(Microsoft.SqlServer.TransactSql.ScriptDom.BinaryExpression bin, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
-            var lhs = bin.FirstExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
-            var rhs = bin.SecondExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var lhs = bin.FirstExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
+            var rhs = bin.SecondExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
             if (!SqlTypeConverter.CanMakeConsistentTypes(lhs.Type, rhs.Type, out var type))
                 throw new NotSupportedQueryFragmentException($"No implicit conversion exists for types {lhs.Type} and {rhs.Type}", bin);
@@ -327,7 +331,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             }
         }
 
-        private static MethodInfo GetMethod(FunctionCall func, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam, out Expression[] paramExpressions)
+        private static MethodInfo GetMethod(FunctionCall func, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam, out Expression[] paramExpressions)
         {
             // Special case for DATEPART / DATEDIFF / DATEADD - first parameter looks like a field but is actually an identifier
             if (func.FunctionName.Value.Equals("DATEPART", StringComparison.OrdinalIgnoreCase) ||
@@ -355,14 +359,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                             return Expression.Constant(col.MultiPartIdentifier.Identifiers.Single().Value);
                         }
 
-                        return param.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+                        return param.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
                     })
                     .ToArray();
             }
             else
             {
                 paramExpressions = func.Parameters
-                    .Select(param => param.ToExpression(schema, parameterTypes, entityParam, parameterParam))
+                    .Select(param => param.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam))
                     .ToArray();
             }
 
@@ -423,10 +427,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return correctParameterCount[0].Method;
         }
 
-        private static Expression ToExpression(this FunctionCall func, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this FunctionCall func, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             // Find the method to call and get the expressions for the parameter values
-            var method = GetMethod(func, schema, parameterTypes, entityParam, parameterParam, out var paramValues);
+            var method = GetMethod(func, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam, out var paramValues);
 
             // Convert the parameters to the expected types
             var parameters = method.GetParameters();
@@ -440,14 +444,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return Expression.Call(method, paramValues);
         }
 
-        private static Expression ToExpression(this ParenthesisExpression paren, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this ParenthesisExpression paren, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
-            return paren.Expression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            return paren.Expression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
         }
 
-        private static Expression ToExpression(this Microsoft.SqlServer.TransactSql.ScriptDom.UnaryExpression unary, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this Microsoft.SqlServer.TransactSql.ScriptDom.UnaryExpression unary, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
-            var value = unary.Expression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var value = unary.Expression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             
             switch (unary.UnaryExpressionType)
             {
@@ -465,18 +469,18 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             }
         }
 
-        private static Expression ToExpression(this InPredicate inPred, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this InPredicate inPred, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             if (inPred.Subquery != null)
                 throw new NotSupportedQueryFragmentException("Subquery should have been eliminated by query plan", inPred);
 
-            var exprValue = inPred.Expression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var exprValue = inPred.Expression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
             Expression result = null;
 
             foreach (var value in inPred.Values)
             {
-                var comparisonValue = value.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+                var comparisonValue = value.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
                 if (!SqlTypeConverter.CanMakeConsistentTypes(exprValue.Type, comparisonValue.Type, out var type))
                     throw new NotSupportedQueryFragmentException($"No implicit conversion exists for types {exprValue.Type} and {comparisonValue.Type}", inPred);
@@ -500,7 +504,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return result;
         }
 
-        private static Expression ToExpression(this VariableReference var, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this VariableReference var, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             if (parameterTypes == null || !parameterTypes.TryGetValue(var.Name, out var type))
                 throw new NotSupportedQueryFragmentException("Undefined variable", var);
@@ -509,9 +513,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return Expression.Convert(expr, type);
         }
 
-        private static Expression ToExpression(this BooleanIsNullExpression isNull, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this BooleanIsNullExpression isNull, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
-            var value = isNull.Expression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var value = isNull.Expression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             value = Expression.PropertyOrField(value, nameof(INullable.IsNull));
 
             if (isNull.IsNot)
@@ -521,11 +525,11 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return value;
         }
 
-        private static Expression ToExpression(this LikePredicate like, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this LikePredicate like, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
-            var value = like.FirstExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
-            var pattern = like.SecondExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
-            var escape = like.EscapeExpression?.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var value = like.FirstExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
+            var pattern = like.SecondExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
+            var escape = like.EscapeExpression?.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
             if (value.Type != typeof(SqlString))
             {
@@ -672,14 +676,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return result;
         }
 
-        private static Expression ToExpression(this SimpleCaseExpression simpleCase, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this SimpleCaseExpression simpleCase, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             // Convert all the different elements to expressions
-            var value = simpleCase.InputExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
-            var whenClauses = simpleCase.WhenClauses.Select(when => when.WhenExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam)).ToList();
+            var value = simpleCase.InputExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
+            var whenClauses = simpleCase.WhenClauses.Select(when => when.WhenExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam)).ToList();
             var caseTypes = new Type[whenClauses.Count];
-            var thenClauses = simpleCase.WhenClauses.Select(when => when.ThenExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam)).ToList();
-            var elseValue = simpleCase.ElseExpression?.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var thenClauses = simpleCase.WhenClauses.Select(when => when.ThenExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam)).ToList();
+            var elseValue = simpleCase.ElseExpression?.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
             // First pass to determine final return type
             Type type = null;
@@ -751,12 +755,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return result;
         }
 
-        private static Expression ToExpression(this SearchedCaseExpression searchedCase, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this SearchedCaseExpression searchedCase, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             // Convert all the different elements to expressions
-            var whenClauses = searchedCase.WhenClauses.Select(when => when.WhenExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam)).ToList();
-            var thenClauses = searchedCase.WhenClauses.Select(when => when.ThenExpression.ToExpression(schema, parameterTypes, entityParam, parameterParam)).ToList();
-            var elseValue = searchedCase.ElseExpression?.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var whenClauses = searchedCase.WhenClauses.Select(when => when.WhenExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam)).ToList();
+            var thenClauses = searchedCase.WhenClauses.Select(when => when.ThenExpression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam)).ToList();
+            var elseValue = searchedCase.ElseExpression?.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
             // First pass to determine final return type
             Type type = null;
@@ -813,9 +817,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return result;
         }
 
-        private static Expression ToExpression(this BooleanNotExpression not, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this BooleanNotExpression not, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
-            var value = not.Expression.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var value = not.Expression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
             return Expression.Not(value);
         }
 
@@ -849,9 +853,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             [SqlDataTypeOption.VarChar] = typeof(SqlString)
         };
 
-        private static Expression ToExpression(this ConvertCall convert, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this ConvertCall convert, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
-            var value = convert.Parameter.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var value = convert.Parameter.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
             if (!(convert.DataType is SqlDataTypeReference dataType))
                 throw new NotSupportedQueryFragmentException("Unsupported data type reference", convert.DataType);
@@ -867,7 +871,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             // Special cases for styles
             if (convert.Style != null)
             {
-                var style = convert.Style.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+                var style = convert.Style.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
                 if (!SqlTypeConverter.CanChangeTypeImplicit(style.Type, typeof(SqlInt32)))
                     throw new NotSupportedQueryFragmentException($"No type conversion available from {style.Type} to {typeof(SqlInt32)}", convert.Style);
@@ -986,14 +990,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return SqlTypeConverter.UseDefaultCollation(new SqlString(value.Value.Substring(0, maxLength)));
         }
 
-        private static Expression ToExpression(this CastCall cast, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this CastCall cast, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
-            return ToExpression(new ConvertCall { Parameter = cast.Parameter, DataType = cast.DataType }, schema, parameterTypes, entityParam, parameterParam);
+            return ToExpression(new ConvertCall { Parameter = cast.Parameter, DataType = cast.DataType }, schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
         }
 
         private static readonly Regex _containsParser = new Regex("^\\S+( OR \\S+)*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static Expression ToExpression(this FullTextPredicate fullText, NodeSchema schema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
+        private static Expression ToExpression(this FullTextPredicate fullText, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             // Only support simple CONTAINS calls to handle multi-select optionsets for now
             if (fullText.FullTextFunctionType != FullTextFunctionType.Contains)
@@ -1011,7 +1015,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (fullText.LanguageTerm != null)
                 throw new NotSupportedQueryFragmentException("LANGUAGE is not currently supported", fullText.LanguageTerm);
 
-            var col = fullText.Columns[0].ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var col = fullText.Columns[0].ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
             if (!SqlTypeConverter.CanChangeTypeImplicit(col.Type, typeof(SqlString)))
                 throw new NotSupportedQueryFragmentException("Only string columns are supported", fullText.Columns[0]);
@@ -1027,7 +1031,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 return Expr.Call(() => Contains(Expr.Arg<SqlString>(), Expr.Arg<Regex[]>()), col, Expression.Constant(words));
             }
 
-            var value = fullText.Value.ToExpression(schema, parameterTypes, entityParam, parameterParam);
+            var value = fullText.Value.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
 
             if (!SqlTypeConverter.CanChangeTypeImplicit(value.Type, typeof(SqlString)))
                 throw new NotSupportedQueryFragmentException($"Expected string value to match, got {value.Type}", fullText.Value);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -516,7 +516,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         private static Expression ToExpression(this BooleanIsNullExpression isNull, NodeSchema schema, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ParameterExpression entityParam, ParameterExpression parameterParam)
         {
             var value = isNull.Expression.ToExpression(schema, nonAggregateSchema, parameterTypes, entityParam, parameterParam);
-            value = Expression.PropertyOrField(value, nameof(INullable.IsNull));
+            value = SqlTypeConverter.NullCheck(value);
 
             if (isNull.IsNot)
                 value = Expression.Not(value);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -890,7 +890,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (dataType.SqlDataTypeOption == SqlDataTypeOption.Date)
             {
                 // Remove the time part of the DateTime value
-                value = Expression.Condition(Expression.Equal(value, Expression.Constant(null)), Expression.Constant(null), Expression.Convert(Expression.Property(Expression.Convert(value, typeof(DateTime)), nameof(DateTime.Date)), typeof(object)));
+                value = Expression.Condition(SqlTypeConverter.NullCheck(value), Expression.Constant(SqlDateTime.Null), Expression.Convert(Expression.Property(Expression.Convert(value, typeof(DateTime)), nameof(DateTime.Date)), typeof(SqlDateTime)));
             }
 
             // Truncate results for [n][var]char

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -636,7 +636,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             {
                 AddSchemaAttribute(schema, fullName + "name", attrMetadata.LogicalName + "name", typeof(SqlString));
 
-                if (lookup.Targets?.Length > 1)
+                if (lookup.Targets?.Length > 1 && lookup.AttributeType != AttributeTypeCode.PartyList)
                     AddSchemaAttribute(schema, fullName + "type", attrMetadata.LogicalName + "type", typeof(SqlString));
             }
         }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -501,7 +501,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     var attrMetadata = meta.Attributes.Single(a => a.LogicalName == attribute.name);
                     var attrType = attrMetadata.GetAttributeSqlType();
 
-                    if (attribute.aggregateSpecified && (attribute.aggregate == Engine.FetchXml.AggregateType.count || attribute.aggregate == Engine.FetchXml.AggregateType.countcolumn))
+                    if (attribute.aggregateSpecified && (attribute.aggregate == Engine.FetchXml.AggregateType.count || attribute.aggregate == Engine.FetchXml.AggregateType.countcolumn) ||
+                        attribute.dategroupingSpecified)
                         attrType = typeof(SqlInt32);
 
                     string fullName;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -365,7 +365,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (!FetchXml.aggregate)
                 schema.PrimaryKey = $"{Alias}.{meta.PrimaryIdAttribute}";
 
-            AddAttributes(schema, metadata, entity.name, Alias, entity.Items);
+            AddSchemaAttributes(schema, metadata, entity.name, Alias, entity.Items);
             
             return schema;
         }
@@ -385,9 +385,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             if (Alias == entityName)
             {
-                var meta = metadata[Entity.name].Attributes.SingleOrDefault(a => a.LogicalName == attr.name);
-                if (meta?.AttributeOf != null)
-                    attr.name = meta.AttributeOf;
+                var meta = metadata[Entity.name].Attributes.SingleOrDefault(a => a.LogicalName == attr.name && a.AttributeOf == null);
+                if (meta == null && (attr.name.EndsWith("name") || attr.name.EndsWith("type")))
+                {
+                    var logicalName = attr.name.Substring(0, attr.name.Length - 4);
+                    meta = metadata[Entity.name].Attributes.SingleOrDefault(a => a.LogicalName == logicalName && a.AttributeOf == null);
+
+                    if (meta != null)
+                        attr.name = logicalName;
+                }
 
                 if (Entity.Items != null)
                 {
@@ -405,9 +411,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             {
                 var linkEntity = Entity.FindLinkEntity(entityName);
 
-                var meta = metadata[linkEntity.name].Attributes.SingleOrDefault(a => a.LogicalName == attr.name);
-                if (meta?.AttributeOf != null)
-                    attr.name = meta.AttributeOf;
+                var meta = metadata[linkEntity.name].Attributes.SingleOrDefault(a => a.LogicalName == attr.name && a.AttributeOf == null);
+                if (meta == null && (attr.name.EndsWith("name") || attr.name.EndsWith("type")))
+                {
+                    var logicalName = attr.name.Substring(0, attr.name.Length - 4);
+                    meta = metadata[linkEntity.name].Attributes.SingleOrDefault(a => a.LogicalName == logicalName && a.AttributeOf == null);
+
+                    if (meta != null)
+                        attr.name = logicalName;
+                }
 
                 if (linkEntity.Items != null)
                 {
@@ -468,7 +480,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return false;
         }
 
-        private void AddAttributes(NodeSchema schema, IAttributeMetadataCache metadata, string entityName, string alias, object[] items)
+        private void AddSchemaAttributes(NodeSchema schema, IAttributeMetadataCache metadata, string entityName, string alias, object[] items)
         {
             if (items == null && !ReturnFullSchema)
                 return;
@@ -479,18 +491,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             {
                 foreach (var attrMetadata in meta.Attributes)
                 {
-                    var attrType = attrMetadata.GetAttributeSqlType();
+                    if (attrMetadata.IsValidForRead == false)
+                        continue;
+
+                    if (attrMetadata.AttributeOf != null)
+                        continue;
+
                     var fullName = $"{alias}.{attrMetadata.LogicalName}";
-
-                    schema.Schema[fullName] = attrType;
-
-                    if (!schema.Aliases.TryGetValue(attrMetadata.LogicalName, out var simpleColumnNameAliases))
-                    {
-                        simpleColumnNameAliases = new List<string>();
-                        schema.Aliases[attrMetadata.LogicalName] = simpleColumnNameAliases;
-                    }
-
-                    simpleColumnNameAliases.Add(fullName);
+                    var attrType = attrMetadata.GetAttributeSqlType();
+                    AddSchemaAttribute(schema, fullName, attrMetadata.LogicalName, attrType, attrMetadata);
                 }
             }
 
@@ -527,54 +536,24 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         attrAlias = attribute.name;
                     }
 
-                    schema.Schema[fullName] = attrType;
-
-                    if (!schema.Aliases.TryGetValue(attrAlias, out var simpleColumnNameAliases))
-                    {
-                        simpleColumnNameAliases = new List<string>();
-                        schema.Aliases[attrAlias] = simpleColumnNameAliases;
-                    }
-
-                    if (!simpleColumnNameAliases.Contains(fullName))
-                        simpleColumnNameAliases.Add(fullName);
-
-                    foreach (var virtualAttrMetadata in meta.Attributes.Where(a => a.AttributeOf == attrMetadata.LogicalName))
-                    {
-                        var virtualAttrType = virtualAttrMetadata.GetAttributeSqlType();
-                        var virtualAttrAlias = attrAlias + virtualAttrMetadata.LogicalName.Substring(attrMetadata.LogicalName.Length);
-                        var virtualAttrFullName = fullName + virtualAttrMetadata.LogicalName.Substring(attrMetadata.LogicalName.Length);
-
-                        schema.Schema[virtualAttrFullName] = virtualAttrType;
-
-                        if (!schema.Aliases.TryGetValue(virtualAttrAlias, out var simpleVirtualColumnNameAliases))
-                        {
-                            simpleVirtualColumnNameAliases = new List<string>();
-                            schema.Aliases[virtualAttrAlias] = simpleVirtualColumnNameAliases;
-                        }
-
-                        if (!simpleVirtualColumnNameAliases.Contains(virtualAttrFullName))
-                            simpleVirtualColumnNameAliases.Add(virtualAttrFullName);
-                    }
+                    AddSchemaAttribute(schema, fullName, attrAlias, attrType, attrMetadata);
                 }
 
                 if (items.OfType<allattributes>().Any())
                 {
                     foreach (var attrMetadata in meta.Attributes)
                     {
+                        if (attrMetadata.IsValidForRead == false)
+                            continue;
+
+                        if (attrMetadata.AttributeOf != null)
+                            continue;
+
                         var attrType = attrMetadata.GetAttributeSqlType();
                         var attrName = attrMetadata.LogicalName;
                         var fullName = $"{alias}.{attrName}";
 
-                        schema.Schema[fullName] = attrType;
-
-                        if (!schema.Aliases.TryGetValue(attrName, out var simpleColumnNameAliases))
-                        {
-                            simpleColumnNameAliases = new List<string>();
-                            schema.Aliases[attrName] = simpleColumnNameAliases;
-                        }
-
-                        if (!simpleColumnNameAliases.Contains(fullName))
-                            simpleColumnNameAliases.Add(fullName);
+                        AddSchemaAttribute(schema, fullName, attrName, attrType, attrMetadata);
                     }
                 }
 
@@ -596,9 +575,41 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         }
                     }
 
-                    AddAttributes(schema, metadata, linkEntity.name, linkEntity.alias, linkEntity.Items);
+                    AddSchemaAttributes(schema, metadata, linkEntity.name, linkEntity.alias, linkEntity.Items);
                 }
             }
+        }
+
+        private void AddSchemaAttribute(NodeSchema schema, string fullName, string simpleName, Type type, AttributeMetadata attrMetadata)
+        {
+            // Add the logical attribute
+            AddSchemaAttribute(schema, fullName, simpleName, type);
+
+            // Add standard virtual attributes
+            if (attrMetadata is EnumAttributeMetadata || attrMetadata is BooleanAttributeMetadata)
+                AddSchemaAttribute(schema, fullName + "name", attrMetadata.LogicalName + "name", typeof(SqlString));
+
+            if (attrMetadata is LookupAttributeMetadata lookup)
+            {
+                AddSchemaAttribute(schema, fullName + "name", attrMetadata.LogicalName + "name", typeof(SqlString));
+
+                if (lookup.Targets?.Length > 1)
+                    AddSchemaAttribute(schema, fullName + "type", attrMetadata.LogicalName + "type", typeof(SqlString));
+            }
+        }
+
+        private void AddSchemaAttribute(NodeSchema schema, string fullName, string simpleName, Type type)
+        {
+            schema.Schema[fullName] = type;
+
+            if (!schema.Aliases.TryGetValue(simpleName, out var simpleColumnNameAliases))
+            {
+                simpleColumnNameAliases = new List<string>();
+                schema.Aliases[simpleName] = simpleColumnNameAliases;
+            }
+
+            if (!simpleColumnNameAliases.Contains(fullName))
+                simpleColumnNameAliases.Add(fullName);
         }
 
         public override IDataExecutionPlanNode FoldQuery(IAttributeMetadataCache metadata, IQueryExecutionOptions options, IDictionary<string, Type> parameterTypes)
@@ -631,9 +642,16 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     }
                     else
                     {
-                        var attrMeta = metadata[Entity.name].Attributes.SingleOrDefault(a => a.LogicalName == ((FetchAttributeType)attr).name);
-                        if (attrMeta?.AttributeOf != null)
-                            ((FetchAttributeType)attr).name = attrMeta.AttributeOf;
+                        var attrName = ((FetchAttributeType)attr).name;
+                        var attrMeta = metadata[Entity.name].Attributes.SingleOrDefault(a => a.LogicalName == attrName && a.AttributeOf == null);
+
+                        if (attrMeta == null && (attrName.EndsWith("name") || attrName.EndsWith("type")))
+                            attrMeta = metadata[Entity.name].Attributes.SingleOrDefault(a => a.LogicalName == attrName.Substring(0, attrName.Length - 4));
+
+                        if (attrMeta == null)
+                            continue;
+
+                        ((FetchAttributeType)attr).name = attrMeta.LogicalName;
 
                         if (Entity.Items == null || (!Entity.Items.OfType<allattributes>().Any() && !Entity.Items.OfType<FetchAttributeType>().Any(a => (a.alias ?? a.name) == ((FetchAttributeType)attr).name)))
                             Entity.AddItem(attr);
@@ -651,9 +669,16 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         }
                         else
                         {
-                            var attrMeta = metadata[linkEntity.name].Attributes.SingleOrDefault(a => a.LogicalName == ((FetchAttributeType)attr).name);
-                            if (attrMeta?.AttributeOf != null)
-                                ((FetchAttributeType)attr).name = attrMeta.AttributeOf;
+                            var attrName = ((FetchAttributeType)attr).name;
+                            var attrMeta = metadata[linkEntity.name].Attributes.SingleOrDefault(a => a.LogicalName == attrName && a.AttributeOf == null);
+
+                            if (attrMeta == null && (attrName.EndsWith("name") || attrName.EndsWith("type")))
+                                attrMeta = metadata[Entity.name].Attributes.SingleOrDefault(a => a.LogicalName == attrName.Substring(0, attrName.Length - 4));
+
+                            if (attrMeta == null)
+                                continue;
+
+                            ((FetchAttributeType)attr).name = attrMeta.LogicalName;
 
                             if (linkEntity.Items == null || (!linkEntity.Items.OfType<allattributes>().Any() && !linkEntity.Items.OfType<FetchAttributeType>().Any(a => (a.alias ?? a.name) == ((FetchAttributeType)attr).name)))
                                 linkEntity.AddItem(attr);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
@@ -822,7 +822,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             filter.Conditions[0].PropertyName = prop.Name;
 
             // Convert the value to the expected type
-            filter.Conditions[0].Value = SqlTypeConverter.ChangeType(SqlTypeConverter.ChangeType(filter.Conditions[0].Value, MetadataQueryNode.GetPropertyType(targetValueType)), targetValueType);
+            if (filter.Conditions[0].Value != null)
+                filter.Conditions[0].Value = SqlTypeConverter.ChangeType(SqlTypeConverter.ChangeType(filter.Conditions[0].Value, MetadataQueryNode.GetPropertyType(targetValueType)), targetValueType);
 
             if (isEntityFilter)
             {

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FoldableJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FoldableJoinNode.cs
@@ -251,6 +251,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public override void AddRequiredColumns(IAttributeMetadataCache metadata, IDictionary<string, Type> parameterTypes, IList<string> requiredColumns)
         {
+            if (AdditionalJoinCriteria != null)
+            {
+                foreach (var col in AdditionalJoinCriteria.GetColumns())
+                {
+                    if (!requiredColumns.Contains(col, StringComparer.OrdinalIgnoreCase))
+                        requiredColumns.Add(col);
+                }
+            }
+
             // Work out which columns need to be pushed down to which source
             var leftSchema = LeftSource.GetSchema(metadata, parameterTypes);
             var rightSchema = RightSource.GetSchema(metadata, parameterTypes);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
@@ -105,7 +105,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                 aggregate.Value.Expression = sourceExpression.Compile(schema, parameterTypes);
 
-                aggregate.Value.ReturnType = aggregate.Value.SqlExpression.GetType(schema, parameterTypes);
+                aggregate.Value.ReturnType = aggregate.Value.SqlExpression.GetType(schema, null, parameterTypes);
 
                 if (aggregate.Value.AggregateType == AggregateType.Average)
                 {
@@ -225,7 +225,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         break;
 
                     default:
-                        aggregateType = aggregate.Value.SqlExpression.GetType(sourceSchema, parameterTypes);
+                        aggregateType = aggregate.Value.SqlExpression.GetType(sourceSchema, null, parameterTypes);
                         break;
                 }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
@@ -13,6 +13,7 @@ using MarkMpn.Sql4Cds.Engine.QueryExtensions;
 using MarkMpn.Sql4Cds.Engine.Visitors;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Metadata;
 
 namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 {
@@ -458,6 +459,20 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         default:
                             throw new ArgumentOutOfRangeException();
                     }
+
+                    // min, max, sum and avg are not supported for optionset attributes
+                    var parts = colName.Split('.');
+                    string entityName;
+
+                    if (parts[0] == fetchXml.Alias)
+                        entityName = fetchXml.Entity.name;
+                    else
+                        entityName = fetchXml.Entity.FindLinkEntity(parts[0]).name;
+
+                    var attr = metadata[entityName].Attributes.Single(a => a.LogicalName == parts[1]);
+
+                    if (attr is EnumAttributeMetadata && (aggregateType == FetchXml.AggregateType.avg || aggregateType == FetchXml.AggregateType.max || aggregateType == FetchXml.AggregateType.min || aggregateType == FetchXml.AggregateType.sum))
+                        return this;
 
                     var attribute = fetchXml.AddAttribute(colName, a => a.aggregate == aggregateType && a.alias == agg.Key && a.distinct == distinct, metadata, out _);
                     attribute.aggregate = aggregateType;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SqlTypeConverter.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SqlTypeConverter.cs
@@ -592,8 +592,27 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (value is OptionSetValueCollection osvc)
                 return new SqlString(String.Join(",", osvc.Select(v => v.Value)), CultureInfo.CurrentCulture.LCID, SqlCompareOptions.IgnoreCase | SqlCompareOptions.IgnoreNonSpace);
 
+            if (value is EntityCollection coll)
+                return new SqlString(String.Join(",", coll.Entities.Select(e => FormatEntityCollectionEntry(e))), CultureInfo.CurrentCulture.LCID, SqlCompareOptions.IgnoreCase | SqlCompareOptions.IgnoreNonSpace);
+
             // Convert any other complex types (e.g. from metadata queries) to strings
             return new SqlString(value.ToString(), CultureInfo.CurrentCulture.LCID, SqlCompareOptions.IgnoreCase | SqlCompareOptions.IgnoreNonSpace);
+        }
+
+        private static string FormatEntityCollectionEntry(Entity e)
+        {
+            if (e.LogicalName == "activityparty")
+            {
+                // Show the details of the party
+                var partyId = e.GetAttributeValue<EntityReference>("partyid");
+
+                if (partyId != null)
+                    return $"{partyId.LogicalName}:{partyId.Id}";
+
+                return e.GetAttributeValue<string>("addressused");
+            }
+
+            return e.Id.ToString();
         }
 
         /// <summary>

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SqlTypeConverter.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SqlTypeConverter.cs
@@ -190,6 +190,30 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 );
             }
 
+            if ((expr.Type == typeof(SqlBoolean) || expr.Type == typeof(SqlByte) || expr.Type == typeof(SqlInt16) || expr.Type == typeof(SqlInt32) || expr.Type == typeof(SqlInt64) || expr.Type == typeof(SqlDecimal) || expr.Type == typeof(SqlSingle) || expr.Type == typeof(SqlDouble)) && to == typeof(SqlDateTime))
+            {
+                expr = Expression.Condition(
+                    NullCheck(expr),
+                    Expression.Constant(SqlDateTime.Null),
+                    Expression.Convert(
+                        Expression.Call(
+                            Expression.New(
+                                typeof(DateTime).GetConstructor(new[] { typeof(int), typeof(int), typeof(int) }),
+                                Expression.Constant(1900),
+                                Expression.Constant(1),
+                                Expression.Constant(1)
+                            ),
+                            typeof(DateTime).GetMethod(nameof(DateTime.MinValue.AddDays)),
+                            Expression.Convert(
+                                Expression.Convert(expr, typeof(SqlDouble)),
+                                typeof(double)
+                            )
+                        ),
+                        typeof(SqlDateTime)
+                    )
+                );
+            }
+
             if (expr.Type != to)
             {
                 if (expr.Type == typeof(object) && expr is ConstantExpression constant && constant.Value == null && typeof(INullable).IsAssignableFrom(to))

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -423,7 +423,17 @@ namespace MarkMpn.Sql4Cds.Engine
             var targetAlias = deleteTarget.TargetAliasName ?? deleteTarget.TargetEntityName;
             var targetLogicalName = deleteTarget.TargetEntityName;
 
-            var targetMetadata = Metadata[targetLogicalName];
+            EntityMetadata targetMetadata;
+
+            try
+            {
+                targetMetadata = Metadata[targetLogicalName];
+            }
+            catch (FaultException ex)
+            {
+                throw new NotSupportedQueryFragmentException(ex.Message, deleteTarget.Target);
+            }
+
             queryExpression.SelectElements.Add(new SelectScalarExpression
             {
                 Expression = new ColumnReferenceExpression
@@ -518,7 +528,17 @@ namespace MarkMpn.Sql4Cds.Engine
             var targetAlias = updateTarget.TargetAliasName ?? updateTarget.TargetEntityName;
             var targetLogicalName = updateTarget.TargetEntityName;
 
-            var targetMetadata = Metadata[targetLogicalName];
+            EntityMetadata targetMetadata;
+
+            try
+            {
+                targetMetadata = Metadata[targetLogicalName];
+            }
+            catch (FaultException ex)
+            {
+                throw new NotSupportedQueryFragmentException(ex.Message, updateTarget.Target);
+            }
+
             queryExpression.SelectElements.Add(new SelectScalarExpression
             {
                 Expression = new ColumnReferenceExpression

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -655,7 +655,7 @@ namespace MarkMpn.Sql4Cds.Engine
 
                     var sourceColName = select.ColumnSet.Single(col => col.OutputColumn == targetAttribute.LogicalName).SourceColumn;
                     var sourceCol = sourceColName.ToColumnReference();
-                    var sourceType = sourceCol.GetType(schema, null);
+                    var sourceType = sourceCol.GetType(schema, null, null);
                     var targetType = targetAttribute.GetAttributeSqlType();
 
                     if (!SqlTypeConverter.CanChangeTypeImplicit(sourceType, targetType))
@@ -788,7 +788,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 node = distinct;
             }
 
-            node = ConvertOrderByClause(node, hints, binary.OrderByClause, concat.ColumnSet.Select(col => new ColumnReferenceExpression { MultiPartIdentifier = new MultiPartIdentifier { Identifiers = { new Identifier { Value = col.OutputColumn } } } }).ToArray(), binary, parameterTypes, outerSchema, outerReferences);
+            node = ConvertOrderByClause(node, hints, binary.OrderByClause, concat.ColumnSet.Select(col => new ColumnReferenceExpression { MultiPartIdentifier = new MultiPartIdentifier { Identifiers = { new Identifier { Value = col.OutputColumn } } } }).ToArray(), binary, parameterTypes, outerSchema, outerReferences, null);
             node = ConvertOffsetClause(node, binary.OffsetClause, parameterTypes);
 
             var select = new SelectNode { Source = node };
@@ -809,10 +809,12 @@ namespace MarkMpn.Sql4Cds.Engine
             node = ConvertWhereClause(node, hints, querySpec.WhereClause, outerSchema, outerReferences, parameterTypes, querySpec);
 
             // Add aggregates from GROUP BY/SELECT/HAVING/ORDER BY
+            var preGroupByNode = node;
             node = ConvertGroupByAggregates(node, querySpec, parameterTypes, outerSchema, outerReferences);
+            var nonAggregateSchema = preGroupByNode == node ? null : preGroupByNode.GetSchema(Metadata, parameterTypes);
 
             // Add filters from HAVING
-            node = ConvertHavingClause(node, hints, querySpec.HavingClause, parameterTypes, outerSchema, outerReferences, querySpec);
+            node = ConvertHavingClause(node, hints, querySpec.HavingClause, parameterTypes, outerSchema, outerReferences, querySpec, nonAggregateSchema);
 
             // Add sorts from ORDER BY
             var selectFields = new List<ScalarExpression>();
@@ -839,7 +841,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 }
             }
 
-            node = ConvertOrderByClause(node, hints, querySpec.OrderByClause, selectFields.ToArray(), querySpec, parameterTypes, outerSchema, outerReferences);
+            node = ConvertOrderByClause(node, hints, querySpec.OrderByClause, selectFields.ToArray(), querySpec, parameterTypes, outerSchema, outerReferences, nonAggregateSchema);
 
             // Add DISTINCT
             var distinct = querySpec.UniqueRowFilter == UniqueRowFilter.Distinct ? new DistinctNode { Source = node } : null;
@@ -853,7 +855,7 @@ namespace MarkMpn.Sql4Cds.Engine
             node = ConvertOffsetClause(node, querySpec.OffsetClause, parameterTypes);
 
             // Add SELECT
-            var selectNode = ConvertSelectClause(querySpec.SelectElements, hints, node, distinct, querySpec, parameterTypes, outerSchema, outerReferences);
+            var selectNode = ConvertSelectClause(querySpec.SelectElements, hints, node, distinct, querySpec, parameterTypes, outerSchema, outerReferences, nonAggregateSchema);
 
             return selectNode;
         }
@@ -873,7 +875,7 @@ namespace MarkMpn.Sql4Cds.Engine
             foreach (var inSubquery in visitor.InSubqueries)
             {
                 // Validate the LHS expression
-                inSubquery.Expression.GetType(schema, parameterTypes);
+                inSubquery.Expression.GetType(schema, null, parameterTypes);
 
                 // Each query of the format "col1 IN (SELECT col2 FROM source)" becomes a left outer join:
                 // LEFT JOIN source ON col1 = col2
@@ -1135,7 +1137,7 @@ namespace MarkMpn.Sql4Cds.Engine
             return source;
         }
 
-        private IDataExecutionPlanNode ConvertHavingClause(IDataExecutionPlanNode source, IList<OptimizerHint> hints, HavingClause havingClause, IDictionary<string, Type> parameterTypes, NodeSchema outerSchema, IDictionary<string, string> outerReferences, TSqlFragment query)
+        private IDataExecutionPlanNode ConvertHavingClause(IDataExecutionPlanNode source, IList<OptimizerHint> hints, HavingClause havingClause, IDictionary<string, Type> parameterTypes, NodeSchema outerSchema, IDictionary<string, string> outerReferences, TSqlFragment query, NodeSchema nonAggregateSchema)
         {
             if (havingClause == null)
                 return source;
@@ -1146,7 +1148,7 @@ namespace MarkMpn.Sql4Cds.Engine
             ConvertScalarSubqueries(havingClause.SearchCondition, hints, ref source, computeScalar, parameterTypes, query);
 
             // Validate the final expression
-            havingClause.SearchCondition.GetType(source.GetSchema(Metadata, parameterTypes), parameterTypes);
+            havingClause.SearchCondition.GetType(source.GetSchema(Metadata, parameterTypes), nonAggregateSchema, parameterTypes);
 
             return new FilterNode
             {
@@ -1387,8 +1389,8 @@ namespace MarkMpn.Sql4Cds.Engine
             if (offsetClause == null)
                 return source;
 
-            var offsetType = offsetClause.OffsetExpression.GetType(null, parameterTypes);
-            var fetchType = offsetClause.FetchExpression.GetType(null, parameterTypes);
+            var offsetType = offsetClause.OffsetExpression.GetType(null, null, parameterTypes);
+            var fetchType = offsetClause.FetchExpression.GetType(null, null, parameterTypes);
 
             if (!SqlTypeConverter.CanChangeTypeImplicit(offsetType, typeof(SqlInt32)))
                 throw new NotSupportedQueryFragmentException("Unexpected OFFSET type", offsetClause.OffsetExpression);
@@ -1414,7 +1416,7 @@ namespace MarkMpn.Sql4Cds.Engine
             if (topRowFilter.Percent)
                 source = new TableSpoolNode { Source = source };
 
-            var topType = topRowFilter.Expression.GetType(null, parameterTypes);
+            var topType = topRowFilter.Expression.GetType(null, null, parameterTypes);
             var targetType = topRowFilter.Percent ? typeof(SqlSingle) : typeof(SqlInt32);
 
             if (!SqlTypeConverter.CanChangeTypeImplicit(topType, targetType))
@@ -1429,7 +1431,7 @@ namespace MarkMpn.Sql4Cds.Engine
             };
         }
 
-        private IDataExecutionPlanNode ConvertOrderByClause(IDataExecutionPlanNode source, IList<OptimizerHint> hints, OrderByClause orderByClause, ScalarExpression[] selectList, TSqlFragment query, IDictionary<string, Type> parameterTypes, NodeSchema outerSchema, Dictionary<string, string> outerReferences)
+        private IDataExecutionPlanNode ConvertOrderByClause(IDataExecutionPlanNode source, IList<OptimizerHint> hints, OrderByClause orderByClause, ScalarExpression[] selectList, TSqlFragment query, IDictionary<string, Type> parameterTypes, NodeSchema outerSchema, Dictionary<string, string> outerReferences, NodeSchema nonAggregateSchema)
         {
             if (orderByClause == null)
                 return source;
@@ -1483,13 +1485,13 @@ namespace MarkMpn.Sql4Cds.Engine
                     !(orderBy.Expression is VariableReference) &&
                     !(orderBy.Expression is Literal))
                 {
-                    var calculated = ComputeScalarExpression(orderBy.Expression, hints, query, computeScalar, parameterTypes, ref source);
+                    var calculated = ComputeScalarExpression(orderBy.Expression, hints, query, computeScalar, nonAggregateSchema, parameterTypes, ref source);
                     sort.Source = source;
                     schema = source.GetSchema(Metadata, parameterTypes);
                 }
 
                 // Validate the expression
-                orderBy.Expression.GetType(schema, parameterTypes);
+                orderBy.Expression.GetType(schema, nonAggregateSchema, parameterTypes);
 
                 sort.Sorts.Add(orderBy);
             }
@@ -1514,7 +1516,7 @@ namespace MarkMpn.Sql4Cds.Engine
             ConvertScalarSubqueries(whereClause.SearchCondition, hints, ref source, computeScalar, parameterTypes, query);
 
             // Validate the final expression
-            whereClause.SearchCondition.GetType(source.GetSchema(Metadata, parameterTypes), parameterTypes);
+            whereClause.SearchCondition.GetType(source.GetSchema(Metadata, parameterTypes), null, parameterTypes);
 
             return new FilterNode
             {
@@ -1567,7 +1569,7 @@ namespace MarkMpn.Sql4Cds.Engine
             return query;
         }
 
-        private SelectNode ConvertSelectClause(IList<SelectElement> selectElements, IList<OptimizerHint> hints, IDataExecutionPlanNode node, DistinctNode distinct, TSqlFragment query, IDictionary<string, Type> parameterTypes, NodeSchema outerSchema, IDictionary<string,string> outerReferences)
+        private SelectNode ConvertSelectClause(IList<SelectElement> selectElements, IList<OptimizerHint> hints, IDataExecutionPlanNode node, DistinctNode distinct, TSqlFragment query, IDictionary<string, Type> parameterTypes, NodeSchema outerSchema, IDictionary<string,string> outerReferences, NodeSchema nonAggregateSchema)
         {
             var schema = node.GetSchema(Metadata, parameterTypes);
 
@@ -1593,13 +1595,8 @@ namespace MarkMpn.Sql4Cds.Engine
 
                         if (!schema.ContainsColumn(colName, out colName))
                         {
-                            if (!schema.Aliases.TryGetValue(col.GetColumnName(), out var normalized))
-                                throw new NotSupportedQueryFragmentException("Unknown column", col);
-
-                            throw new NotSupportedQueryFragmentException("Ambiguous column reference", col)
-                            {
-                                Suggestion = $"Did you mean:\r\n{String.Join("\r\n", normalized.Select(c => $"* {c}"))}"
-                            };
+                            // Column name isn't valid. Use the expression extensions to throw a consistent error message
+                            col.GetType(schema, nonAggregateSchema, parameterTypes);
                         }
 
                         var alias = scalar.ColumnName?.Value ?? col.MultiPartIdentifier.Identifiers.Last().Value;
@@ -1613,7 +1610,7 @@ namespace MarkMpn.Sql4Cds.Engine
                     else
                     {
                         var scalarSource = distinct?.Source ?? node;
-                        var alias = ComputeScalarExpression(scalar.Expression, hints, query, computeScalar, parameterTypes, ref scalarSource);
+                        var alias = ComputeScalarExpression(scalar.Expression, hints, query, computeScalar, nonAggregateSchema, parameterTypes, ref scalarSource);
 
                         if (distinct != null)
                             distinct.Source = scalarSource;
@@ -1669,7 +1666,7 @@ namespace MarkMpn.Sql4Cds.Engine
             return select;
         }
 
-        private string ComputeScalarExpression(ScalarExpression expression, IList<OptimizerHint> hints, TSqlFragment query, ComputeScalarNode computeScalar, IDictionary<string, Type> parameterTypes, ref IDataExecutionPlanNode node)
+        private string ComputeScalarExpression(ScalarExpression expression, IList<OptimizerHint> hints, TSqlFragment query, ComputeScalarNode computeScalar, NodeSchema nonAggregateSchema, IDictionary<string, Type> parameterTypes, ref IDataExecutionPlanNode node)
         {
             var computedColumn = ConvertScalarSubqueries(expression, hints, ref node, computeScalar, parameterTypes, query);
 
@@ -1677,8 +1674,8 @@ namespace MarkMpn.Sql4Cds.Engine
                 expression = computedColumn;
 
             // Check the type of this expression now so any errors can be reported
-            var computeScalarSchema = computeScalar.GetSchema(Metadata, parameterTypes);
-            expression.GetType(computeScalarSchema, parameterTypes);
+            var computeScalarSchema = computeScalar.Source.GetSchema(Metadata, parameterTypes);
+            expression.GetType(computeScalarSchema, nonAggregateSchema, parameterTypes);
 
             var alias = $"Expr{++_colNameCounter}";
             computeScalar.Columns[alias] = expression;
@@ -2248,7 +2245,7 @@ namespace MarkMpn.Sql4Cds.Engine
                                 lhs = lhsComputeScalar;
                             }
 
-                            var lhsColumn = ComputeScalarExpression(joinConditionVisitor.LhsExpression, hints, query, lhsComputeScalar, parameterTypes, ref lhs);
+                            var lhsColumn = ComputeScalarExpression(joinConditionVisitor.LhsExpression, hints, query, lhsComputeScalar, null, parameterTypes, ref lhs);
                             joinConditionVisitor.LhsKey = new ColumnReferenceExpression { MultiPartIdentifier = new MultiPartIdentifier { Identifiers = { new Identifier { Value = lhsColumn } } } };
                         }
 
@@ -2260,7 +2257,7 @@ namespace MarkMpn.Sql4Cds.Engine
                                 rhs = rhsComputeScalar;
                             }
 
-                            var rhsColumn = ComputeScalarExpression(joinConditionVisitor.RhsExpression, hints, query, rhsComputeScalar, parameterTypes, ref lhs);
+                            var rhsColumn = ComputeScalarExpression(joinConditionVisitor.RhsExpression, hints, query, rhsComputeScalar, null, parameterTypes, ref lhs);
                             joinConditionVisitor.RhsKey = new ColumnReferenceExpression { MultiPartIdentifier = new MultiPartIdentifier { Identifiers = { new Identifier { Value = rhsColumn } } } };
                         }
                     }
@@ -2335,7 +2332,7 @@ namespace MarkMpn.Sql4Cds.Engine
 
                 // Validate the join condition
                 var joinSchema = joinNode.GetSchema(Metadata, parameterTypes);
-                join.SearchCondition.GetType(joinSchema, parameterTypes);
+                join.SearchCondition.GetType(joinSchema, null, parameterTypes);
 
                 return joinNode;
             }
@@ -2426,13 +2423,13 @@ namespace MarkMpn.Sql4Cds.Engine
                 throw new NotSupportedQueryFragmentException($"Expected {columnNames.Count} columns, got {firstMismatchRow.ColumnValues.Count}", firstMismatchRow);
 
             // Work out the column types
-            var types = inlineDerivedTable.RowValues[0].ColumnValues.Select(val => val.GetType(null, null)).ToList();
+            var types = inlineDerivedTable.RowValues[0].ColumnValues.Select(val => val.GetType(null, null, null)).ToList();
 
             foreach (var row in inlineDerivedTable.RowValues.Skip(1))
             {
                 for (var colIndex = 0; colIndex < types.Count; colIndex++)
                 {
-                    if (!SqlTypeConverter.CanMakeConsistentTypes(types[colIndex], row.ColumnValues[colIndex].GetType(null, null), out var colType))
+                    if (!SqlTypeConverter.CanMakeConsistentTypes(types[colIndex], row.ColumnValues[colIndex].GetType(null, null, null), out var colType))
                         throw new NotSupportedQueryFragmentException("No available implicit type conversion", row.ColumnValues[colIndex]);
 
                     types[colIndex] = colType;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -333,7 +333,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 if (targetLookupAttribute == null)
                     continue;
 
-                if (targetLookupAttribute.Targets.Length > 1 && !attributeNames.Contains(targetAttrName + "type"))
+                if (targetLookupAttribute.Targets.Length > 1 && !attributeNames.Contains(targetAttrName + "type") && targetLookupAttribute.AttributeType != AttributeTypeCode.PartyList)
                 {
                     throw new NotSupportedQueryFragmentException("Inserting values into a polymorphic lookup field requires setting the associated type column as well", col)
                     {
@@ -692,7 +692,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 if (targetLookupAttribute == null)
                     continue;
 
-                if (targetLookupAttribute.Targets.Length > 1 && !update.ColumnMappings.ContainsKey(targetAttrName + "type"))
+                if (targetLookupAttribute.Targets.Length > 1 && !update.ColumnMappings.ContainsKey(targetAttrName + "type") && targetLookupAttribute.AttributeType != AttributeTypeCode.PartyList)
                 {
                     // Check we're not just setting the lookup column to null - no need to set the corresponding type then
                     if (assignment.NewValue is NullLiteral)

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -13,7 +13,8 @@
     <summary>Convert SQL queries to FetchXml and execute them against CDS</summary>
     <releaseNotes>Simplified accessing ___name and ___type virtual attributes
 Fixed accessing partylist attributes
-Fixed converting numeric values to datetime
+Fixed updating/inserting partylist and multi-select optionset values
+Fixed converting numeric values to datetime and datetime values to date
 Fixed folding DATEPART calculations into FetchXML
 Fixed folding IS NULL conditions to metadata queries
 Fixed aggregate queries on optionset or entity name attributes

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -16,6 +16,7 @@ Fixed accessing partylist attributes
 Fixed converting numeric values to datetime
 Fixed folding DATEPART calculations into FetchXML
 Fixed folding IS NULL conditions to metadata queries
+Fixed aggregate queries on optionset or entity name attributes
 Improved error reporting
 Allow use of "exists" link entity type for online instances
     </releaseNotes>

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -11,11 +11,13 @@
     <iconUrl>https://markcarrington.dev/sql4cds-icon/</iconUrl>
     <description>Convert SQL queries to FetchXml and execute them against CDS</description>
     <summary>Convert SQL queries to FetchXml and execute them against CDS</summary>
-    <releaseNotes>Complete replacement of the SQL conversion engine to support many more query types.
-
-Queries involving UNION, subqueries, more complex joins, data type conversions and more can now be executed without requiring the TDS Endpoint to be available.
-
-The Sql2FetchXml and Query classes are still available but are now deprecated. Please update your code to use the new ExecutionPlanBuilder class instead.
+    <releaseNotes>Simplified accessing ___name and ___type virtual attributes
+Fixed accessing partylist attributes
+Fixed converting numeric values to datetime
+Fixed folding DATEPART calculations into FetchXML
+Fixed folding IS NULL conditions to metadata queries
+Improved error reporting
+Allow use of "exists" link entity type for online instances
     </releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds.Engine/MetadataExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/MetadataExtensions.cs
@@ -45,6 +45,9 @@ namespace MarkMpn.Sql4Cds.Engine
             if (attrMetadata is BigIntAttributeMetadata || typeCode == AttributeTypeCode.BigInt)
                 return typeof(long?);
 
+            if (typeCode == AttributeTypeCode.PartyList)
+                return typeof(EntityCollection);
+
             if (attrMetadata is LookupAttributeMetadata || typeCode == AttributeTypeCode.Lookup || typeCode == AttributeTypeCode.Customer || typeCode == AttributeTypeCode.Owner)
                 return typeof(Guid?);
 
@@ -108,6 +111,9 @@ namespace MarkMpn.Sql4Cds.Engine
 
             if (attrMetadata is BigIntAttributeMetadata || typeCode == AttributeTypeCode.BigInt)
                 return typeof(SqlInt64);
+
+            if (typeCode == AttributeTypeCode.PartyList)
+                return typeof(SqlString);
 
             if (attrMetadata is LookupAttributeMetadata || typeCode == AttributeTypeCode.Lookup || typeCode == AttributeTypeCode.Customer || typeCode == AttributeTypeCode.Owner)
                 return typeof(SqlGuid);

--- a/MarkMpn.Sql4Cds.Engine/Visitors/UpdateTargetVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/UpdateTargetVisitor.cs
@@ -19,9 +19,11 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
             _search = search;
         }
 
-        public string TargetEntityName { get; set; }
+        public string TargetEntityName { get; private set; }
 
-        public string TargetAliasName { get; set; }
+        public string TargetAliasName { get; private set; }
+
+        public NamedTableReference Target { get; private set; }
 
         public bool Ambiguous => _ambiguous;
 
@@ -35,6 +37,7 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
 
                 TargetEntityName = node.SchemaObject.BaseIdentifier.Value;
                 TargetAliasName = node.Alias.Value;
+                Target = node;
                 _foundAlias = true;
             }
 
@@ -45,6 +48,7 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
 
                 TargetEntityName = _search;
                 TargetAliasName = node.Alias?.Value ?? _search;
+                Target = node;
             }
         }
     }

--- a/MarkMpn.Sql4Cds.Tests/AutocompleteTests.cs
+++ b/MarkMpn.Sql4Cds.Tests/AutocompleteTests.cs
@@ -28,6 +28,7 @@ namespace MarkMpn.Sql4Cds.Tests
             var n = metadata["new_customentity"];
 
             typeof(AttributeMetadata).GetProperty(nameof(AttributeMetadata.IsValidForUpdate)).SetValue(a.Attributes.Single(attr => attr.LogicalName == "primarycontactidname"), false);
+            typeof(AttributeMetadata).GetProperty(nameof(AttributeMetadata.AttributeOf)).SetValue(a.Attributes.Single(attr => attr.LogicalName == "primarycontactidname"), "primarycontactid");
             typeof(AttributeMetadata).GetProperty(nameof(AttributeMetadata.IsValidForUpdate)).SetValue(c.Attributes.Single(attr => attr.LogicalName == "fullname"), false);
 
             _autocomplete = new Autocomplete(new[] { a, c, n }, metadata);
@@ -98,7 +99,7 @@ namespace MarkMpn.Sql4Cds.Tests
             var sql = "SELECT * FROM account a left outer join contact c on a.accountid = c.p";
             var suggestions = _autocomplete.GetSuggestions(sql, sql.Length - 1).Select(s => s.Text).ToList();
 
-            CollectionAssert.AreEqual(new[] { "parentcustomerid" }, suggestions);
+            CollectionAssert.AreEqual(new[] { "parentcustomerid", "parentcustomeridname" }, suggestions);
         }
 
         [TestMethod]
@@ -107,7 +108,7 @@ namespace MarkMpn.Sql4Cds.Tests
             var sql = "SELECT * FROM account a left outer join contact c on a.accountid = c.parentcustomerid where ";
             var suggestions = _autocomplete.GetSuggestions(sql, sql.Length - 1).Select(s => s.Text).Where(s => !s.Contains("(")).ToList();
 
-            CollectionAssert.AreEqual(new[] { "a", "accountid", "c", "contactid", "employees", "firstname", "fullname", "lastname", "name", "parentcustomerid", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
+            CollectionAssert.AreEqual(new[] { "a", "accountid", "c", "contactid", "employees", "firstname", "fullname", "lastname", "name", "parentcustomerid", "parentcustomeridname", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
         }
 
         [TestMethod]
@@ -136,7 +137,7 @@ namespace MarkMpn.Sql4Cds.Tests
             var sql = sql1 + "\r\n" + sql2;
             var suggestions = _autocomplete.GetSuggestions(sql, sql1.Length + 2 + sql2.IndexOf(" ") + 1).Select(s => s.Text).Where(s => !s.Contains("(")).ToList();
 
-            CollectionAssert.AreEqual(new[] { "account", "accountid", "contact", "contactid", "employees", "firstname", "fullname", "lastname", "name", "parentcustomerid", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
+            CollectionAssert.AreEqual(new[] { "account", "accountid", "contact", "contactid", "employees", "firstname", "fullname", "lastname", "name", "parentcustomerid", "parentcustomeridname", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
         }
 
         [TestMethod]
@@ -199,7 +200,7 @@ namespace MarkMpn.Sql4Cds.Tests
             var sql = "INSERT INTO account (";
             var suggestions = _autocomplete.GetSuggestions(sql, sql.Length - 1).Select(s => s.Text).Where(s => !s.Contains("(")).ToList();
 
-            CollectionAssert.AreEqual(new[] { "accountid", "createdon", "employees", "name", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
+            CollectionAssert.AreEqual(new[] { "accountid", "createdon", "employees", "name", "primarycontactid", "turnover" }, suggestions);
         }
 
         //[TestMethod]

--- a/MarkMpn.Sql4Cds.sln
+++ b/MarkMpn.Sql4Cds.sln
@@ -33,7 +33,6 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2CFFF3C0-5A6F-493B-86D7-4CC42B322393}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2CFFF3C0-5A6F-493B-86D7-4CC42B322393}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2CFFF3C0-5A6F-493B-86D7-4CC42B322393}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{2CFFF3C0-5A6F-493B-86D7-4CC42B322393}.Debug|x86.Build.0 = Debug|Any CPU
 		{2CFFF3C0-5A6F-493B-86D7-4CC42B322393}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/MarkMpn.Sql4Cds/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds/Autocomplete.cs
@@ -433,7 +433,7 @@ namespace MarkMpn.Sql4Cds
                     }
                     else if (prevWord.Equals("update", StringComparison.OrdinalIgnoreCase) ||
                         prevWord.Equals("insert", StringComparison.OrdinalIgnoreCase) ||
-                        prevPrevWord.Equals("insert", StringComparison.OrdinalIgnoreCase) && prevWord.Equals("into", StringComparison.OrdinalIgnoreCase))
+                        prevPrevWord != null && prevPrevWord.Equals("insert", StringComparison.OrdinalIgnoreCase) && prevWord.Equals("into", StringComparison.OrdinalIgnoreCase))
                     {
                         return FilterList(_entities.Select(e => new EntityAutocompleteItem(e, _metadata, currentLength)), currentWord).OrderBy(x => x);
                     }

--- a/MarkMpn.Sql4Cds/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds/Autocomplete.cs
@@ -730,7 +730,7 @@ namespace MarkMpn.Sql4Cds
                 if (!writeable && (attribute is EnumAttributeMetadata || attribute is BooleanAttributeMetadata || attribute is LookupAttributeMetadata))
                     yield return new AttributeAutocompleteItem(attribute, metadata, replaceLength, "name");
 
-                if (attribute is LookupAttributeMetadata lookup && lookup.Targets?.Length > 1)
+                if (attribute is LookupAttributeMetadata lookup && lookup.Targets?.Length > 1 && lookup.AttributeType != AttributeTypeCode.PartyList)
                     yield return new AttributeAutocompleteItem(attribute, metadata, replaceLength, "type");
             }
 

--- a/MarkMpn.Sql4Cds/ExecutionPlanView.cs
+++ b/MarkMpn.Sql4Cds/ExecutionPlanView.cs
@@ -110,7 +110,7 @@ namespace MarkMpn.Sql4Cds
 
                 var rows = child is IDataExecutionPlanNode dataChild ? Executed ? dataChild.RowsOut : dataChild.EstimateRowsOut(Metadata, null, TableSizeCache) : 1;
                 var width = rows == 0 ? 1 : (int)Math.Log10(rows);
-                _lines.Add(new Line { Source = child, Start = new Point(iconRect.X, iconRect.Y + iconRect.Height / 2), End = new Point(parentIconRect.Right, parentIconRect.Top + (i + 1) * lineYSpacing), Width = width });
+                _lines.Add(new Line { Source = child, Start = new Point(iconRect.Left, parentIconRect.Top == iconRect.Top ? (parentIconRect.Top + (i + 1) * lineYSpacing) : (iconRect.Top + iconRect.Height / 2)), End = new Point(parentIconRect.Right, parentIconRect.Top + (i + 1) * lineYSpacing), Width = width });
 
                 LayoutChildren(child);
                 i++;

--- a/MarkMpn.Sql4Cds/FunctionMetadata.cs
+++ b/MarkMpn.Sql4Cds/FunctionMetadata.cs
@@ -43,9 +43,6 @@ namespace MarkMpn.Sql4Cds
             [Description("Adds a number value to a date value")]
             public abstract DateTime dateadd(string datepart, int number, DateTime date);
 
-            [Description("Creates a lookup value to be used for polymorphic lookup fields in INSERT or UPDATE queries")]
-            public abstract EntityReference createlookup(string entitytype, string id);
-
             [Description("Replaces one string value with another")]
             public abstract string replace(string input, string find, string replace);
 

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -27,6 +27,7 @@ Fixed accessing partylist attributes
 Fixed converting numeric values to datetime
 Fixed folding DATEPART calculations into FetchXML
 Fixed folding IS NULL conditions to metadata queries
+Fixed aggregate queries on optionset or entity name attributes
 Improved error reporting
 Allow use of "exists" link entity type for online instances</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -22,11 +22,13 @@ plugins or integrations by writing familiar SQL and converting it.
 
 Using the preview TDS Endpoint, SELECT queries can also be run that aren't convertible to FetchXML.</description>
     <summary>Convert SQL queries to FetchXML and execute them against CDS</summary>
-    <releaseNotes>Complete replacement of the SQL conversion engine to support many more query types.
-
-Queries involving UNION, subqueries, more complex joins, data type conversions and more can now be executed without requiring the TDS Endpoint to be available.
-
-Execution Plan view allows you to see all the operations that SQL 4 CDS will do to execute your query. Double-click on a FetchXML node to open the query in FetchXML Builder.</releaseNotes>
+    <releaseNotes>Simplified accessing ___name and ___type virtual attributes
+Fixed accessing partylist attributes
+Fixed converting numeric values to datetime
+Fixed folding DATEPART calculations into FetchXML
+Fixed folding IS NULL conditions to metadata queries
+Improved error reporting
+Allow use of "exists" link entity type for online instances</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -24,7 +24,8 @@ Using the preview TDS Endpoint, SELECT queries can also be run that aren't conve
     <summary>Convert SQL queries to FetchXML and execute them against CDS</summary>
     <releaseNotes>Simplified accessing ___name and ___type virtual attributes
 Fixed accessing partylist attributes
-Fixed converting numeric values to datetime
+Fixed updating/inserting partylist and multi-select optionset values
+Fixed converting numeric values to datetime and datetime values to date
 Fixed folding DATEPART calculations into FetchXML
 Fixed folding IS NULL conditions to metadata queries
 Fixed aggregate queries on optionset or entity name attributes

--- a/MarkMpn.Sql4Cds/ObjectExplorer.cs
+++ b/MarkMpn.Sql4Cds/ObjectExplorer.cs
@@ -172,14 +172,35 @@ namespace MarkMpn.Sql4Cds
                 metadata = _metadata[GetService(parent)][logicalName];
 
             return metadata.Attributes
-                .OrderBy(a => a.LogicalName)
-                .Select(a =>
+                .Where(a => a.AttributeOf == null)
+                .SelectMany(a =>
                 {
                     var node = new TreeNode(a.LogicalName);
                     node.Tag = a;
                     SetIcon(node, GetIconType(a));
-                    return node;
+
+                    var nodes = new List<TreeNode>();
+                    nodes.Add(node);
+
+                    if (a is EnumAttributeMetadata || a is BooleanAttributeMetadata || a is LookupAttributeMetadata)
+                    {
+                        var nameNode = new TreeNode(a.LogicalName + "name");
+                        nameNode.Tag = a;
+                        SetIcon(nameNode, "Text");
+                        nodes.Add(nameNode);
+                    }
+
+                    if (a is LookupAttributeMetadata lookup && lookup.Targets.Length > 1)
+                    {
+                        var typeNode = new TreeNode(a.LogicalName + "type");
+                        typeNode.Tag = a;
+                        SetIcon(typeNode, "Text");
+                        nodes.Add(typeNode);
+                    }
+
+                    return nodes;
                 })
+                .OrderBy(n => n.Text)
                 .ToArray();
         }
 

--- a/MarkMpn.Sql4Cds/ObjectExplorer.cs
+++ b/MarkMpn.Sql4Cds/ObjectExplorer.cs
@@ -190,7 +190,7 @@ namespace MarkMpn.Sql4Cds
                         nodes.Add(nameNode);
                     }
 
-                    if (a is LookupAttributeMetadata lookup && lookup.Targets.Length > 1)
+                    if (a is LookupAttributeMetadata lookup && lookup.Targets.Length > 1 && lookup.AttributeType != AttributeTypeCode.PartyList)
                     {
                         var typeNode = new TreeNode(a.LogicalName + "type");
                         typeNode.Tag = a;

--- a/MarkMpn.Sql4Cds/QueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds/QueryExecutionOptions.cs
@@ -35,7 +35,11 @@ namespace MarkMpn.Sql4Cds
             };
 
             if (new Version(con.OrganizationVersion) >= new Version("9.1.0.17461"))
-                _joinOperators.Add(JoinOperator.Any); // First documented in SDK Version 9.0.2.25: Updated for 9.1.0.17461 CDS release
+            {
+                // First documented in SDK Version 9.0.2.25: Updated for 9.1.0.17461 CDS release
+                _joinOperators.Add(JoinOperator.Any);
+                _joinOperators.Add(JoinOperator.Exists);
+            }
         }
 
         public bool Cancelled => _worker.CancellationPending;

--- a/MarkMpn.Sql4Cds/QueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds/QueryExecutionOptions.cs
@@ -140,8 +140,8 @@ namespace MarkMpn.Sql4Cds
         {
             _retrievedPages++;
 
-            if (_retrievedPages > Settings.Instance.MaxRetrievesPerQuery)
-                throw new QueryExecutionException("Hit maximum retrieval limit. Try limiting the data to retrieve with WHERE clauses or eliminating subqueries");
+            if (Settings.Instance.MaxRetrievesPerQuery != 0 && _retrievedPages > Settings.Instance.MaxRetrievesPerQuery)
+                throw new QueryExecutionException($"Hit maximum retrieval limit. This limit is in place to protect against excessive API requests. Try restricting the data to retrieve with WHERE clauses or eliminating subqueries.\r\nYour limit of {Settings.Instance.MaxRetrievesPerQuery:N0} retrievals per query can be modified in Settings.");
         }
     }
 }

--- a/MarkMpn.Sql4Cds/SettingsForm.Designer.cs
+++ b/MarkMpn.Sql4Cds/SettingsForm.Designer.cs
@@ -52,18 +52,21 @@
             this.label9 = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.label12 = new System.Windows.Forms.Label();
+            this.localTimesComboBox = new System.Windows.Forms.ComboBox();
+            this.label11 = new System.Windows.Forms.Label();
             this.maxDopUpDown = new System.Windows.Forms.NumericUpDown();
             this.label13 = new System.Windows.Forms.Label();
             this.retrieveTotalRecordCountCheckbox = new System.Windows.Forms.CheckBox();
             this.tsqlEndpointCheckBox = new System.Windows.Forms.CheckBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.autoSizeColumnsCheckBox = new System.Windows.Forms.CheckBox();
-            this.localTimesComboBox = new System.Windows.Forms.ComboBox();
-            this.label11 = new System.Windows.Forms.Label();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.quotedIdentifiersCheckbox = new System.Windows.Forms.CheckBox();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.showTooltipsCheckbox = new System.Windows.Forms.CheckBox();
+            this.label10 = new System.Windows.Forms.Label();
+            this.retriveLimitUpDown = new System.Windows.Forms.NumericUpDown();
+            this.label14 = new System.Windows.Forms.Label();
             this.topPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
             this.panel2.SuspendLayout();
@@ -76,6 +79,7 @@
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
             this.groupBox4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.retriveLimitUpDown)).BeginInit();
             this.SuspendLayout();
             // 
             // topPanel
@@ -119,11 +123,11 @@
             this.panel2.Controls.Add(this.cancelButton);
             this.panel2.Controls.Add(this.okButton);
             this.panel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel2.Location = new System.Drawing.Point(0, 517);
+            this.panel2.Location = new System.Drawing.Point(0, 547);
             this.panel2.Margin = new System.Windows.Forms.Padding(2);
             this.panel2.Name = "panel2";
             this.panel2.Size = new System.Drawing.Size(400, 45);
-            this.panel2.TabIndex = 0;
+            this.panel2.TabIndex = 4;
             // 
             // cancelButton
             // 
@@ -151,7 +155,7 @@
             this.label2.Location = new System.Drawing.Point(10, 20);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(73, 13);
-            this.label2.TabIndex = 1;
+            this.label2.TabIndex = 0;
             this.label2.Text = "Limit results to";
             // 
             // selectLimitUpDown
@@ -164,7 +168,7 @@
             0});
             this.selectLimitUpDown.Name = "selectLimitUpDown";
             this.selectLimitUpDown.Size = new System.Drawing.Size(102, 20);
-            this.selectLimitUpDown.TabIndex = 2;
+            this.selectLimitUpDown.TabIndex = 1;
             // 
             // label3
             // 
@@ -172,21 +176,21 @@
             this.label3.Location = new System.Drawing.Point(196, 20);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(116, 13);
-            this.label3.TabIndex = 3;
+            this.label3.TabIndex = 2;
             this.label3.Text = "records (0 for unlimited)";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(280, 46);
+            this.label4.Location = new System.Drawing.Point(280, 72);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(42, 13);
-            this.label4.TabIndex = 6;
+            this.label4.TabIndex = 8;
             this.label4.Text = "records";
             // 
             // updateWarnThresholdUpDown
             // 
-            this.updateWarnThresholdUpDown.Location = new System.Drawing.Point(172, 44);
+            this.updateWarnThresholdUpDown.Location = new System.Drawing.Point(172, 70);
             this.updateWarnThresholdUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
@@ -194,29 +198,29 @@
             0});
             this.updateWarnThresholdUpDown.Name = "updateWarnThresholdUpDown";
             this.updateWarnThresholdUpDown.Size = new System.Drawing.Size(102, 20);
-            this.updateWarnThresholdUpDown.TabIndex = 5;
+            this.updateWarnThresholdUpDown.TabIndex = 7;
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(10, 46);
+            this.label5.Location = new System.Drawing.Point(10, 72);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(156, 13);
-            this.label5.TabIndex = 4;
+            this.label5.TabIndex = 6;
             this.label5.Text = "Warn when updating more than";
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(280, 95);
+            this.label6.Location = new System.Drawing.Point(280, 121);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(42, 13);
-            this.label6.TabIndex = 9;
+            this.label6.TabIndex = 12;
             this.label6.Text = "records";
             // 
             // deleteWarnThresholdUpDown
             // 
-            this.deleteWarnThresholdUpDown.Location = new System.Drawing.Point(172, 93);
+            this.deleteWarnThresholdUpDown.Location = new System.Drawing.Point(172, 119);
             this.deleteWarnThresholdUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
@@ -224,59 +228,59 @@
             0});
             this.deleteWarnThresholdUpDown.Name = "deleteWarnThresholdUpDown";
             this.deleteWarnThresholdUpDown.Size = new System.Drawing.Size(102, 20);
-            this.deleteWarnThresholdUpDown.TabIndex = 8;
+            this.deleteWarnThresholdUpDown.TabIndex = 11;
             // 
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(10, 95);
+            this.label7.Location = new System.Drawing.Point(10, 121);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(152, 13);
-            this.label7.TabIndex = 7;
+            this.label7.TabIndex = 10;
             this.label7.Text = "Warn when deleting more than";
             // 
             // blockUpdateWithoutWhereCheckbox
             // 
             this.blockUpdateWithoutWhereCheckbox.AutoSize = true;
-            this.blockUpdateWithoutWhereCheckbox.Location = new System.Drawing.Point(12, 70);
+            this.blockUpdateWithoutWhereCheckbox.Location = new System.Drawing.Point(12, 96);
             this.blockUpdateWithoutWhereCheckbox.Name = "blockUpdateWithoutWhereCheckbox";
             this.blockUpdateWithoutWhereCheckbox.Size = new System.Drawing.Size(191, 17);
-            this.blockUpdateWithoutWhereCheckbox.TabIndex = 10;
+            this.blockUpdateWithoutWhereCheckbox.TabIndex = 9;
             this.blockUpdateWithoutWhereCheckbox.Text = "Prevent UPDATE without WHERE";
             this.blockUpdateWithoutWhereCheckbox.UseVisualStyleBackColor = true;
             // 
             // blockDeleteWithoutWhereCheckbox
             // 
             this.blockDeleteWithoutWhereCheckbox.AutoSize = true;
-            this.blockDeleteWithoutWhereCheckbox.Location = new System.Drawing.Point(12, 119);
+            this.blockDeleteWithoutWhereCheckbox.Location = new System.Drawing.Point(12, 145);
             this.blockDeleteWithoutWhereCheckbox.Name = "blockDeleteWithoutWhereCheckbox";
             this.blockDeleteWithoutWhereCheckbox.Size = new System.Drawing.Size(189, 17);
-            this.blockDeleteWithoutWhereCheckbox.TabIndex = 11;
+            this.blockDeleteWithoutWhereCheckbox.TabIndex = 13;
             this.blockDeleteWithoutWhereCheckbox.Text = "Prevent DELETE without WHERE";
             this.blockDeleteWithoutWhereCheckbox.UseVisualStyleBackColor = true;
             // 
             // bulkDeleteCheckbox
             // 
             this.bulkDeleteCheckbox.AutoSize = true;
-            this.bulkDeleteCheckbox.Location = new System.Drawing.Point(13, 194);
+            this.bulkDeleteCheckbox.Location = new System.Drawing.Point(13, 220);
             this.bulkDeleteCheckbox.Name = "bulkDeleteCheckbox";
             this.bulkDeleteCheckbox.Size = new System.Drawing.Size(152, 17);
-            this.bulkDeleteCheckbox.TabIndex = 12;
+            this.bulkDeleteCheckbox.TabIndex = 20;
             this.bulkDeleteCheckbox.Text = "Use bulk delete operations";
             this.bulkDeleteCheckbox.UseVisualStyleBackColor = true;
             // 
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(335, 144);
+            this.label8.Location = new System.Drawing.Point(335, 170);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(42, 13);
-            this.label8.TabIndex = 15;
+            this.label8.TabIndex = 16;
             this.label8.Text = "records";
             // 
             // batchSizeUpDown
             // 
-            this.batchSizeUpDown.Location = new System.Drawing.Point(227, 142);
+            this.batchSizeUpDown.Location = new System.Drawing.Point(227, 168);
             this.batchSizeUpDown.Maximum = new decimal(new int[] {
             1000,
             0,
@@ -289,7 +293,7 @@
             0});
             this.batchSizeUpDown.Name = "batchSizeUpDown";
             this.batchSizeUpDown.Size = new System.Drawing.Size(102, 20);
-            this.batchSizeUpDown.TabIndex = 14;
+            this.batchSizeUpDown.TabIndex = 15;
             this.batchSizeUpDown.Value = new decimal(new int[] {
             1,
             0,
@@ -299,14 +303,17 @@
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(10, 144);
+            this.label9.Location = new System.Drawing.Point(10, 170);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(211, 13);
-            this.label9.TabIndex = 13;
+            this.label9.TabIndex = 14;
             this.label9.Text = "Insert/Update/Delete records in batches of";
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.label10);
+            this.groupBox1.Controls.Add(this.retriveLimitUpDown);
+            this.groupBox1.Controls.Add(this.label14);
             this.groupBox1.Controls.Add(this.label12);
             this.groupBox1.Controls.Add(this.localTimesComboBox);
             this.groupBox1.Controls.Add(this.label11);
@@ -333,23 +340,46 @@
             this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox1.Size = new System.Drawing.Size(382, 290);
-            this.groupBox1.TabIndex = 16;
+            this.groupBox1.Size = new System.Drawing.Size(382, 320);
+            this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Query Execution";
             // 
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(177, 170);
+            this.label12.Location = new System.Drawing.Point(177, 196);
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(155, 13);
-            this.label12.TabIndex = 20;
+            this.label12.TabIndex = 19;
             this.label12.Text = "worker threads for DML queries";
+            // 
+            // localTimesComboBox
+            // 
+            this.localTimesComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.localTimesComboBox.FormattingEnabled = true;
+            this.localTimesComboBox.Items.AddRange(new object[] {
+            "UTC times",
+            "Local times"});
+            this.localTimesComboBox.Location = new System.Drawing.Point(142, 288);
+            this.localTimesComboBox.Margin = new System.Windows.Forms.Padding(2);
+            this.localTimesComboBox.Name = "localTimesComboBox";
+            this.localTimesComboBox.Size = new System.Drawing.Size(203, 21);
+            this.localTimesComboBox.TabIndex = 24;
+            // 
+            // label11
+            // 
+            this.label11.AutoSize = true;
+            this.label11.Location = new System.Drawing.Point(10, 291);
+            this.label11.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(128, 13);
+            this.label11.TabIndex = 23;
+            this.label11.Text = "Treat date/time values as";
             // 
             // maxDopUpDown
             // 
-            this.maxDopUpDown.Location = new System.Drawing.Point(69, 168);
+            this.maxDopUpDown.Location = new System.Drawing.Point(69, 194);
             this.maxDopUpDown.Minimum = new decimal(new int[] {
             1,
             0,
@@ -357,7 +387,7 @@
             0});
             this.maxDopUpDown.Name = "maxDopUpDown";
             this.maxDopUpDown.Size = new System.Drawing.Size(102, 20);
-            this.maxDopUpDown.TabIndex = 19;
+            this.maxDopUpDown.TabIndex = 18;
             this.maxDopUpDown.Value = new decimal(new int[] {
             10,
             0,
@@ -367,41 +397,41 @@
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(10, 170);
+            this.label13.Location = new System.Drawing.Point(10, 196);
             this.label13.Name = "label13";
             this.label13.Size = new System.Drawing.Size(53, 13);
-            this.label13.TabIndex = 18;
+            this.label13.TabIndex = 17;
             this.label13.Text = "Use up to";
             // 
             // retrieveTotalRecordCountCheckbox
             // 
             this.retrieveTotalRecordCountCheckbox.AutoSize = true;
-            this.retrieveTotalRecordCountCheckbox.Location = new System.Drawing.Point(13, 240);
+            this.retrieveTotalRecordCountCheckbox.Location = new System.Drawing.Point(13, 266);
             this.retrieveTotalRecordCountCheckbox.Name = "retrieveTotalRecordCountCheckbox";
             this.retrieveTotalRecordCountCheckbox.Size = new System.Drawing.Size(286, 17);
-            this.retrieveTotalRecordCountCheckbox.TabIndex = 17;
+            this.retrieveTotalRecordCountCheckbox.TabIndex = 22;
             this.retrieveTotalRecordCountCheckbox.Text = "Use RetrieveTotalRecordCount request where possible";
             this.retrieveTotalRecordCountCheckbox.UseVisualStyleBackColor = true;
             // 
             // tsqlEndpointCheckBox
             // 
             this.tsqlEndpointCheckBox.AutoSize = true;
-            this.tsqlEndpointCheckBox.Location = new System.Drawing.Point(13, 217);
+            this.tsqlEndpointCheckBox.Location = new System.Drawing.Point(13, 243);
             this.tsqlEndpointCheckBox.Name = "tsqlEndpointCheckBox";
             this.tsqlEndpointCheckBox.Size = new System.Drawing.Size(235, 17);
-            this.tsqlEndpointCheckBox.TabIndex = 16;
+            this.tsqlEndpointCheckBox.TabIndex = 21;
             this.tsqlEndpointCheckBox.Text = "Use TDS Endpoint where possible (Preview)";
             this.tsqlEndpointCheckBox.UseVisualStyleBackColor = true;
             // 
             // groupBox2
             // 
             this.groupBox2.Controls.Add(this.autoSizeColumnsCheckBox);
-            this.groupBox2.Location = new System.Drawing.Point(11, 419);
+            this.groupBox2.Location = new System.Drawing.Point(11, 449);
             this.groupBox2.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Padding = new System.Windows.Forms.Padding(2);
             this.groupBox2.Size = new System.Drawing.Size(382, 43);
-            this.groupBox2.TabIndex = 17;
+            this.groupBox2.TabIndex = 2;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Results";
             // 
@@ -411,32 +441,9 @@
             this.autoSizeColumnsCheckBox.Location = new System.Drawing.Point(12, 18);
             this.autoSizeColumnsCheckBox.Name = "autoSizeColumnsCheckBox";
             this.autoSizeColumnsCheckBox.Size = new System.Drawing.Size(158, 17);
-            this.autoSizeColumnsCheckBox.TabIndex = 18;
+            this.autoSizeColumnsCheckBox.TabIndex = 0;
             this.autoSizeColumnsCheckBox.Text = "Auto-size columns to fit data";
             this.autoSizeColumnsCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // localTimesComboBox
-            // 
-            this.localTimesComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.localTimesComboBox.FormattingEnabled = true;
-            this.localTimesComboBox.Items.AddRange(new object[] {
-            "UTC times",
-            "Local times"});
-            this.localTimesComboBox.Location = new System.Drawing.Point(142, 262);
-            this.localTimesComboBox.Margin = new System.Windows.Forms.Padding(2);
-            this.localTimesComboBox.Name = "localTimesComboBox";
-            this.localTimesComboBox.Size = new System.Drawing.Size(203, 21);
-            this.localTimesComboBox.TabIndex = 3;
-            // 
-            // label11
-            // 
-            this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(10, 265);
-            this.label11.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(128, 13);
-            this.label11.TabIndex = 2;
-            this.label11.Text = "Treat date/time values as";
             // 
             // groupBox3
             // 
@@ -444,7 +451,7 @@
             this.groupBox3.Location = new System.Drawing.Point(11, 65);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Size = new System.Drawing.Size(382, 55);
-            this.groupBox3.TabIndex = 18;
+            this.groupBox3.TabIndex = 0;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "SQL Language";
             // 
@@ -461,10 +468,10 @@
             // groupBox4
             // 
             this.groupBox4.Controls.Add(this.showTooltipsCheckbox);
-            this.groupBox4.Location = new System.Drawing.Point(11, 467);
+            this.groupBox4.Location = new System.Drawing.Point(11, 497);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Size = new System.Drawing.Size(382, 43);
-            this.groupBox4.TabIndex = 19;
+            this.groupBox4.TabIndex = 3;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Intellisense";
             // 
@@ -478,13 +485,43 @@
             this.showTooltipsCheckbox.Text = "Show tooltips";
             this.showTooltipsCheckbox.UseVisualStyleBackColor = true;
             // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Location = new System.Drawing.Point(10, 46);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(131, 13);
+            this.label10.TabIndex = 3;
+            this.label10.Text = "Stop query execution after";
+            // 
+            // retriveLimitUpDown
+            // 
+            this.retriveLimitUpDown.Location = new System.Drawing.Point(147, 44);
+            this.retriveLimitUpDown.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.retriveLimitUpDown.Name = "retriveLimitUpDown";
+            this.retriveLimitUpDown.Size = new System.Drawing.Size(102, 20);
+            this.retriveLimitUpDown.TabIndex = 4;
+            // 
+            // label14
+            // 
+            this.label14.AutoSize = true;
+            this.label14.Location = new System.Drawing.Point(255, 46);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(123, 13);
+            this.label14.TabIndex = 5;
+            this.label14.Text = "retrievals (0 for unlimited)";
+            // 
             // SettingsForm
             // 
             this.AcceptButton = this.okButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancelButton;
-            this.ClientSize = new System.Drawing.Size(400, 562);
+            this.ClientSize = new System.Drawing.Size(400, 592);
             this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox2);
@@ -517,6 +554,7 @@
             this.groupBox3.PerformLayout();
             this.groupBox4.ResumeLayout(false);
             this.groupBox4.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.retriveLimitUpDown)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -558,5 +596,8 @@
         private System.Windows.Forms.NumericUpDown maxDopUpDown;
         private System.Windows.Forms.Label label13;
         private System.Windows.Forms.CheckBox autoSizeColumnsCheckBox;
+        private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.NumericUpDown retriveLimitUpDown;
+        private System.Windows.Forms.Label label14;
     }
 }

--- a/MarkMpn.Sql4Cds/SettingsForm.cs
+++ b/MarkMpn.Sql4Cds/SettingsForm.cs
@@ -20,6 +20,7 @@ namespace MarkMpn.Sql4Cds
 
             quotedIdentifiersCheckbox.Checked = settings.QuotedIdentifiers;
             selectLimitUpDown.Value = settings.SelectLimit;
+            retriveLimitUpDown.Value = settings.MaxRetrievesPerQuery;
             updateWarnThresholdUpDown.Value = settings.UpdateWarnThreshold;
             blockUpdateWithoutWhereCheckbox.Checked = settings.BlockUpdateWithoutWhere;
             deleteWarnThresholdUpDown.Value = settings.DeleteWarnThreshold;
@@ -44,6 +45,7 @@ namespace MarkMpn.Sql4Cds
             {
                 _settings.QuotedIdentifiers = quotedIdentifiersCheckbox.Checked;
                 _settings.SelectLimit = (int) selectLimitUpDown.Value;
+                _settings.MaxRetrievesPerQuery = (int) retriveLimitUpDown.Value;
                 _settings.UpdateWarnThreshold = (int) updateWarnThresholdUpDown.Value;
                 _settings.BlockUpdateWithoutWhere = blockUpdateWithoutWhereCheckbox.Checked;
                 _settings.DeleteWarnThreshold = (int) deleteWarnThresholdUpDown.Value;

--- a/MarkMpn.Sql4Cds/SqlQueryControl.cs
+++ b/MarkMpn.Sql4Cds/SqlQueryControl.cs
@@ -848,6 +848,8 @@ namespace MarkMpn.Sql4Cds
             }
 
             BusyChanged?.Invoke(this, EventArgs.Empty);
+
+            _editor.Focus();
         }
 
         private void AddMessage(int index, int length, string message, bool error)

--- a/MarkMpn.Sql4Cds/SqlQueryControl.cs
+++ b/MarkMpn.Sql4Cds/SqlQueryControl.cs
@@ -925,7 +925,6 @@ namespace MarkMpn.Sql4Cds
 
             backgroundWorker.ReportProgress(0, "Executing query...");
 
-            //var converter = new Sql2FetchXml(Metadata, Settings.Instance.QuotedIdentifiers);
             var options = new QueryExecutionOptions(_con, Service, backgroundWorker, this);
             var converter = new ExecutionPlanBuilder(Metadata, _tableSize, options);
 

--- a/MarkMpn.Sql4Cds/SqlQueryControl.cs
+++ b/MarkMpn.Sql4Cds/SqlQueryControl.cs
@@ -800,6 +800,15 @@ namespace MarkMpn.Sql4Cds
                     error = queryException.InnerException;
                 }
 
+                if (error is QueryExecutionException queryExecution)
+                {
+                    messageSuffix = "\r\nSee the Execution Plan tab for details of where this error occurred";
+                    ShowResult(plan, new ExecuteParams { Execute = true, IncludeFetchXml = true, Sql = plan.Sql }, null, null, queryExecution);
+
+                    if (queryExecution.InnerException != null)
+                        error = queryExecution.InnerException;
+                }
+
                 if (error is NotSupportedQueryFragmentException err && err.Fragment != null)
                 {
                     _editor.IndicatorFillRange(_params.Offset + err.Fragment.StartOffset, err.Fragment.FragmentLength);
@@ -821,14 +830,6 @@ namespace MarkMpn.Sql4Cds
                         AddMessage(index, length, msg, false);
 
                     error = partialSuccess.InnerException;
-                }
-                else if (error is QueryExecutionException queryExecution)
-                {
-                    messageSuffix = "\r\nSee the Execution Plan tab for details of where this error occurred";
-                    ShowResult(plan, new ExecuteParams { Execute = true, IncludeFetchXml = true, Sql = plan.Sql }, null, null, queryExecution);
-
-                    if (queryExecution.InnerException != null)
-                        error = queryExecution.InnerException;
                 }
 
                 _ai.TrackException(error, new Dictionary<string, string> { ["Sql"] = _params.Sql, ["Source"] = "XrmToolBox" });

--- a/MarkMpn.Sql4Cds/SqlQueryControl.cs
+++ b/MarkMpn.Sql4Cds/SqlQueryControl.cs
@@ -800,7 +800,7 @@ namespace MarkMpn.Sql4Cds
                     error = queryException.InnerException;
                 }
 
-                if (error is NotSupportedQueryFragmentException err)
+                if (error is NotSupportedQueryFragmentException err && err.Fragment != null)
                 {
                     _editor.IndicatorFillRange(_params.Offset + err.Fragment.StartOffset, err.Fragment.FragmentLength);
                     index = _params.Offset + err.Fragment.StartOffset;

--- a/MarkMpn.Sql4Cds/SqlQueryControl.cs
+++ b/MarkMpn.Sql4Cds/SqlQueryControl.cs
@@ -826,6 +826,9 @@ namespace MarkMpn.Sql4Cds
                 {
                     messageSuffix = "\r\nSee the Execution Plan tab for details of where this error occurred";
                     ShowResult(plan, new ExecuteParams { Execute = true, IncludeFetchXml = true, Sql = plan.Sql }, null, null, queryExecution);
+
+                    if (queryExecution.InnerException != null)
+                        error = queryExecution.InnerException;
                 }
 
                 _ai.TrackException(error, new Dictionary<string, string> { ["Sql"] = _params.Sql, ["Source"] = "XrmToolBox" });


### PR DESCRIPTION
* Allow use of `exists` link entity type for online instances
* Change handling of virtual attributes. Virtual attributes exposed in metadata do not always follow the expected naming convention, so these are now ignored and a fixed `___name` virtual attribute is exposed for all picklist, bool and lookup fields, and a `___type` attribute is exposed for polymorphic lookup attributes.
* Fixes data type conversions between datetime and numeric data types.
* Fixes retrieving partylist attributes.
* Improved error reporting
* Fixed type of datetime groupings in FetchXML schema
* Ensure all required columns are included in data sources for additional join criteria
* Fixed folding of `IS NULL` filters to metadata queries