### PR TITLE
Execution plan

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -2939,5 +2939,33 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             Assert.AreEqual(MetadataSource.Entity, metadataQuery.MetadataSource);
             CollectionAssert.AreEquivalent(new[] { "CollectionSchemaName", "EntitySetName", "Description" }, metadataQuery.Query.Properties.PropertyNames);
         }
+
+        [TestMethod]
+        public void MultipleAliases()
+        {
+            var metadata = new AttributeMetadataCache(_service);
+            var planBuilder = new ExecutionPlanBuilder(metadata, new StubTableSizeCache(), this);
+
+            var query = "SELECT name AS n1, name AS n2 FROM account WHERE name = 'test'";
+
+            var plans = planBuilder.Build(query);
+
+            Assert.AreEqual(1, plans.Length);
+
+            var select = AssertNode<SelectNode>(plans[0]);
+            Assert.AreEqual("account.n1", select.ColumnSet[0].SourceColumn);
+            Assert.AreEqual("account.n1", select.ColumnSet[1].SourceColumn);
+
+            var fetch = AssertNode<FetchXmlScan>(select.Source);
+            AssertFetchXml(fetch, @"
+                <fetch>
+                    <entity name='account'>
+                        <attribute name='name' alias='n1' />
+                        <filter>
+                            <condition attribute='name' operator='eq' value='test' />
+                        </filter>
+                    </entity>
+                </fetch>");
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -2913,5 +2913,31 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                     </entity>
                 </fetch>");
         }
+
+        [TestMethod]
+        public void MetadataExpressions()
+        {
+            var metadata = new AttributeMetadataCache(_service);
+            var planBuilder = new ExecutionPlanBuilder(metadata, new StubTableSizeCache(), this);
+
+            var query = "SELECT collectionschemaname + '.' + entitysetname FROM metadata.entity WHERE description LIKE '%test%'";
+
+            var plans = planBuilder.Build(query);
+
+            Assert.AreEqual(1, plans.Length);
+
+            var select = AssertNode<SelectNode>(plans[0]);
+            Assert.AreEqual("Expr1", select.ColumnSet[0].SourceColumn);
+
+            var computeScalar = AssertNode<ComputeScalarNode>(select.Source);
+            Assert.AreEqual("collectionschemaname + '.' + entitysetname", computeScalar.Columns["Expr1"].ToSql());
+
+            var filter = AssertNode<FilterNode>(computeScalar.Source);
+            Assert.AreEqual("description LIKE '%test%'", filter.Filter.ToSql());
+
+            var metadataQuery = AssertNode<MetadataQueryNode>(filter.Source);
+            Assert.AreEqual(MetadataSource.Entity, metadataQuery.MetadataSource);
+            CollectionAssert.AreEquivalent(new[] { "CollectionSchemaName", "EntitySetName", "Description" }, metadataQuery.Query.Properties.PropertyNames);
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
@@ -2104,6 +2104,62 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         }
 
         [TestMethod]
+        public void ContainsValues1()
+        {
+            var context = new XrmFakedContext();
+            context.InitializeMetadata(Assembly.GetExecutingAssembly());
+
+            var org = context.GetOrganizationService();
+            var metadata = new AttributeMetadataCache(org);
+            var sql2FetchXml = new Sql2FetchXml(metadata, true);
+
+            var query = "SELECT new_name FROM new_customentity WHERE CONTAINS(new_optionsetvaluecollection, '1')";
+
+            var queries = sql2FetchXml.Convert(query);
+
+            AssertFetchXml(queries, $@"
+                <fetch>
+                    <entity name='new_customentity'>
+                        <attribute name='new_name' />
+                        <filter>
+                            <condition attribute='new_optionsetvaluecollection' operator='contain-values'>
+                                <value>1</value>
+                            </condition>
+                        </filter>
+                    </entity>
+                </fetch>
+            ");
+        }
+
+        [TestMethod]
+        public void ContainsValuesFunction1()
+        {
+            var context = new XrmFakedContext();
+            context.InitializeMetadata(Assembly.GetExecutingAssembly());
+
+            var org = context.GetOrganizationService();
+            var metadata = new AttributeMetadataCache(org);
+            var sql2FetchXml = new Sql2FetchXml(metadata, true);
+
+            var query = "SELECT new_name FROM new_customentity WHERE new_optionsetvaluecollection = containvalues(1)";
+
+            var queries = sql2FetchXml.Convert(query);
+
+            AssertFetchXml(queries, $@"
+                <fetch>
+                    <entity name='new_customentity'>
+                        <attribute name='new_name' />
+                        <filter>
+                            <condition attribute='new_optionsetvaluecollection' operator='contain-values'>
+                                <value>1</value>
+                            </condition>
+                        </filter>
+                    </entity>
+                </fetch>
+            ");
+        }
+
+        [TestMethod]
         public void ContainsValues()
         {
             var context = new XrmFakedContext();
@@ -2114,6 +2170,35 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             var sql2FetchXml = new Sql2FetchXml(metadata, true);
 
             var query = "SELECT new_name FROM new_customentity WHERE CONTAINS(new_optionsetvaluecollection, '1 OR 2')";
+
+            var queries = sql2FetchXml.Convert(query);
+
+            AssertFetchXml(queries, $@"
+                <fetch>
+                    <entity name='new_customentity'>
+                        <attribute name='new_name' />
+                        <filter>
+                            <condition attribute='new_optionsetvaluecollection' operator='contain-values'>
+                                <value>1</value>
+                                <value>2</value>
+                            </condition>
+                        </filter>
+                    </entity>
+                </fetch>
+            ");
+        }
+
+        [TestMethod]
+        public void ContainsValuesFunction()
+        {
+            var context = new XrmFakedContext();
+            context.InitializeMetadata(Assembly.GetExecutingAssembly());
+
+            var org = context.GetOrganizationService();
+            var metadata = new AttributeMetadataCache(org);
+            var sql2FetchXml = new Sql2FetchXml(metadata, true);
+
+            var query = "SELECT new_name FROM new_customentity WHERE new_optionsetvaluecollection = containvalues(1, 2)";
 
             var queries = sql2FetchXml.Convert(query);
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
@@ -610,7 +610,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             var attrNames = new[] { attrName };
             var ft = filterType.and;
 
-            var usesItems = values != null && values.Length > 1 || op == @operator.@in || op == @operator.notin;
+            var usesItems = values != null && values.Length > 1 || op == @operator.@in || op == @operator.notin || op == @operator.containvalues || op == @operator.notcontainvalues;
 
             if (attribute is DateTimeAttributeMetadata && literals != null &&
                 (op == @operator.eq || op == @operator.ne || op == @operator.neq || op == @operator.gt || op == @operator.ge || op == @operator.lt || op == @operator.le))

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ComputeScalarNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ComputeScalarNode.cs
@@ -94,13 +94,18 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public override void AddRequiredColumns(IAttributeMetadataCache metadata, IDictionary<string, Type> parameterTypes, IList<string> requiredColumns)
         {
+            var schema = Source.GetSchema(metadata, parameterTypes);
+
             var calcSourceColumns = Columns.Values
-                   .SelectMany(expr => expr.GetColumns());
+                .SelectMany(expr => expr.GetColumns());
 
             foreach (var col in calcSourceColumns)
             {
-                if (!requiredColumns.Contains(col, StringComparer.OrdinalIgnoreCase))
-                    requiredColumns.Add(col);
+                if (!schema.ContainsColumn(col, out var normalized))
+                    continue;
+
+                if (!requiredColumns.Contains(normalized, StringComparer.OrdinalIgnoreCase))
+                    requiredColumns.Add(normalized);
             }
 
             Source.AddRequiredColumns(metadata, parameterTypes, requiredColumns);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -459,7 +459,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             {
                 var paramType = parameters[i].ParameterType;
 
-                if (i == parameters.Length - 1 && paramTypes.Length > parameters.Length && paramType.IsArray)
+                if (i == parameters.Length - 1 && paramTypes.Length >= parameters.Length && paramType.IsArray)
                     paramType = paramType.GetElementType();
 
                 if (!SqlTypeConverter.CanChangeTypeImplicit(paramTypes[i], paramType))

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -490,12 +490,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (items == null)
                 return false;
 
-            var hasSort = items.OfType<FetchOrderType>().Any(sort => sort.alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
+            var hasSort = items.OfType<FetchOrderType>().Any(sort => sort.alias != null && sort.alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
 
             if (hasSort)
                 return true;
 
-            var hasCondition = items.OfType<condition>().Any(condition => condition.alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
+            var hasCondition = items.OfType<condition>().Any(condition => condition.alias != null && condition.alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
 
             if (hasCondition)
                 return true;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SelectNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SelectNode.cs
@@ -184,7 +184,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                             if (!col.OutputColumn.Equals(parts.Last(), StringComparison.OrdinalIgnoreCase) && FetchXmlScan.IsValidAlias(col.OutputColumn))
                             {
-                                if (added || (!processedSourceColumns.Contains(col.SourceColumn) && !fetchXml.IsAliasReferenced(attr.alias)))
+                                if (added || (!processedSourceColumns.Contains(sourceCol) && !fetchXml.IsAliasReferenced(attr.alias)))
                                 {
                                     // Don't fold the alias if there's also a sort on the same attribute, as it breaks paging
                                     // https://markcarrington.dev/2019/12/10/inside-fetchxml-pt-4-order/#sorting_&_aliases
@@ -197,7 +197,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                                 col.SourceColumn = sourceCol.Split('.')[0] + "." + (attr.alias ?? attr.name);
                             }
 
-                            processedSourceColumns.Add(col.SourceColumn);
+                            processedSourceColumns.Add(sourceCol);
                         }
                     }
                 }

--- a/MarkMpn.Sql4Cds.Engine/FetchXmlConditionMethods.cs
+++ b/MarkMpn.Sql4Cds.Engine/FetchXmlConditionMethods.cs
@@ -213,10 +213,10 @@ namespace MarkMpn.Sql4Cds.Engine
         public static SqlBoolean EqOrAbove(SqlGuid field, SqlGuid value) => ThrowException();
 
         [Description("Matches a multi-select picklist value that contains any of the specified values")]
-        public static SqlBoolean ContainValues(OptionSetValueCollection field, SqlInt32[] value) => ThrowException();
+        public static SqlBoolean ContainValues(SqlString field, SqlInt32[] value) => ThrowException();
 
         [Description("Matches a multi-select picklist value that doesn't contains any of the specified values")]
-        public static SqlBoolean NotContainValues(OptionSetValueCollection field, SqlInt32[] value) => ThrowException();
+        public static SqlBoolean NotContainValues(SqlString field, SqlInt32[] value) => ThrowException();
 
         private static SqlBoolean ThrowException()
         {

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -16,6 +16,7 @@ Fixed "Aggregates are not supported" when using audit table
 Fixed paging issues with aggregates
 Fixed handling of "containvalues" filters on choices columns
 Fixed "unknown column" errors when using metadata columns in calculations without fully qualified names
+Fixed handling of multiple aliases for the same column
     </releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -14,6 +14,7 @@
     <releaseNotes>Fixed IN queries on metadata
 Fixed "Aggregates are not supported" when using audit table
 Fixed paging issues with aggregates
+Fixed handling of "containvalues" filters on choices columns
     </releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -15,6 +15,7 @@
 Fixed "Aggregates are not supported" when using audit table
 Fixed paging issues with aggregates
 Fixed handling of "containvalues" filters on choices columns
+Fixed "unknown column" errors when using metadata columns in calculations without fully qualified names
     </releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -27,7 +27,8 @@ Fixed IN queries on metadata
 Fixed "Aggregates are not supported" when using audit table
 Fixed adding connection to Object Explorer after using Change Connection toolbar button
 Improved performance of adding new connection by limiting properties shown in properties window
-Fixed paging issues with aggregates</releaseNotes>
+Fixed paging issues with aggregates
+Fixed handling of "containvalues" filters on choices columns</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -29,7 +29,9 @@ Fixed adding connection to Object Explorer after using Change Connection toolbar
 Improved performance of adding new connection by limiting properties shown in properties window
 Fixed paging issues with aggregates
 Fixed handling of "containvalues" filters on choices columns
-Fixed "unknown column" errors when using metadata columns in calculations without fully qualified names</releaseNotes>
+Fixed "unknown column" errors when using metadata columns in calculations without fully qualified names
+Fixed handling of multiple aliases for the same column
+    </releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -28,7 +28,8 @@ Fixed "Aggregates are not supported" when using audit table
 Fixed adding connection to Object Explorer after using Change Connection toolbar button
 Improved performance of adding new connection by limiting properties shown in properties window
 Fixed paging issues with aggregates
-Fixed handling of "containvalues" filters on choices columns</releaseNotes>
+Fixed handling of "containvalues" filters on choices columns
+Fixed "unknown column" errors when using metadata columns in calculations without fully qualified names</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/PluginControl.cs
+++ b/MarkMpn.Sql4Cds/PluginControl.cs
@@ -75,16 +75,14 @@ namespace MarkMpn.Sql4Cds
 
         private void AddConnection(ConnectionDetail con)
         {
-            var svc = con.ServiceClient;
-
             if (!_metadata.ContainsKey(con))
                 _metadata[con] = new SharedMetadataCache(con);
             
             if (!_tableSize.ContainsKey(con))
-                _tableSize[con] = new TableSizeCache(svc, _metadata[con]);
+                _tableSize[con] = new TableSizeCache(con.GetCrmServiceClient(true), _metadata[con]);
 
             // Start loading the entity list in the background
-            EntityCache.TryGetEntities(con.MetadataCacheLoader, svc, out _);
+            EntityCache.TryGetEntities(con.MetadataCacheLoader, con.GetCrmServiceClient(true), out _);
         }
 
         private void PluginControl_Load(object sender, EventArgs e)


### PR DESCRIPTION
More bug fixes:

* Remove locking while metadata cache is loading for smoother UX when adding connection
* Improved handling of `containvalues` function
* Fixed use of metadata columns in filters
* Fixed including the same column multiple times with different aliases