### PR TITLE
Query hints

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/OptionsWrapper.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/OptionsWrapper.cs
@@ -23,7 +23,6 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             UseBulkDelete = options.UseBulkDelete;
             BatchSize = options.BatchSize;
             UseTDSEndpoint = options.UseTDSEndpoint;
-            UseRetrieveTotalRecordCount = options.UseRetrieveTotalRecordCount;
             MaxDegreeOfParallelism = options.MaxDegreeOfParallelism;
             ColumnComparisonAvailable = options.ColumnComparisonAvailable;
             UseLocalTimeZone = options.UseLocalTimeZone;
@@ -64,19 +63,16 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
 
         public bool QuotedIdentifiers { get; set; }
 
-        public bool ConfirmDelete(int count, EntityMetadata meta)
+        public void ConfirmDelete(ConfirmDmlStatementEventArgs e)
         {
-            return _options.ConfirmDelete(count, meta);
         }
 
-        public bool ConfirmInsert(int count, EntityMetadata meta)
+        public void ConfirmInsert(ConfirmDmlStatementEventArgs e)
         {
-            return _options.ConfirmInsert(count, meta);
         }
 
-        public bool ConfirmUpdate(int count, EntityMetadata meta)
+        public void ConfirmUpdate(ConfirmDmlStatementEventArgs e)
         {
-            return _options.ConfirmUpdate(count, meta);
         }
 
         public bool ContinueRetrieve(int count)

--- a/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
@@ -38,8 +38,6 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
 
         bool IQueryExecutionOptions.UseTDSEndpoint => false;
 
-        bool IQueryExecutionOptions.UseRetrieveTotalRecordCount => true;
-
         int IQueryExecutionOptions.MaxDegreeOfParallelism => 10;
 
         bool IQueryExecutionOptions.ColumnComparisonAvailable => true;
@@ -1843,7 +1841,7 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         [TestMethod]
         public void Count1ConvertedToCountStar()
         {
-            var query = "SELECT COUNT(1) FROM contact";
+            var query = "SELECT COUNT(1) FROM contact OPTION(USE HINT('RETRIEVE_TOTAL_RECORD_COUNT'))";
 
             var metadata = new AttributeMetadataCache(_service);
             var planBuilder = new ExecutionPlanBuilder(metadata, new StubTableSizeCache(), this);
@@ -2667,19 +2665,16 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             return true;
         }
 
-        bool IQueryExecutionOptions.ConfirmInsert(int count, EntityMetadata meta)
+        void IQueryExecutionOptions.ConfirmInsert(ConfirmDmlStatementEventArgs e)
         {
-            return true;
         }
 
-        bool IQueryExecutionOptions.ConfirmUpdate(int count, EntityMetadata meta)
+        void IQueryExecutionOptions.ConfirmUpdate(ConfirmDmlStatementEventArgs e)
         {
-            return true;
         }
 
-        bool IQueryExecutionOptions.ConfirmDelete(int count, EntityMetadata meta)
+        void IQueryExecutionOptions.ConfirmDelete(ConfirmDmlStatementEventArgs e)
         {
-            return true;
         }
 
         private class RetrieveMetadataChangesHandler : IFakeMessageExecutor

--- a/MarkMpn.Sql4Cds.Engine.Tests/StubOptions.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/StubOptions.cs
@@ -23,8 +23,6 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
 
         bool IQueryExecutionOptions.UseTDSEndpoint => false;
 
-        bool IQueryExecutionOptions.UseRetrieveTotalRecordCount => true;
-
         int IQueryExecutionOptions.MaxDegreeOfParallelism => 10;
 
         bool IQueryExecutionOptions.ColumnComparisonAvailable => true;
@@ -35,19 +33,16 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
 
         bool IQueryExecutionOptions.BypassCustomPlugins => false;
 
-        bool IQueryExecutionOptions.ConfirmInsert(int count, EntityMetadata meta)
+        void IQueryExecutionOptions.ConfirmInsert(ConfirmDmlStatementEventArgs e)
         {
-            return true;
         }
 
-        bool IQueryExecutionOptions.ConfirmDelete(int count, EntityMetadata meta)
+        void IQueryExecutionOptions.ConfirmDelete(ConfirmDmlStatementEventArgs e)
         {
-            return true;
         }
 
-        bool IQueryExecutionOptions.ConfirmUpdate(int count, EntityMetadata meta)
+        void IQueryExecutionOptions.ConfirmUpdate(ConfirmDmlStatementEventArgs e)
         {
-            return true;
         }
 
         bool IQueryExecutionOptions.ContinueRetrieve(int count)

--- a/MarkMpn.Sql4Cds.Engine/Ado/CancellationTokenOptionsWrapper.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/CancellationTokenOptionsWrapper.cs
@@ -31,8 +31,6 @@ namespace MarkMpn.Sql4Cds.Engine
 
         public bool UseTDSEndpoint => _options.UseTDSEndpoint;
 
-        public bool UseRetrieveTotalRecordCount => _options.UseRetrieveTotalRecordCount;
-
         public int MaxDegreeOfParallelism => _options.MaxDegreeOfParallelism;
 
         public bool ColumnComparisonAvailable => _options.ColumnComparisonAvailable;
@@ -49,19 +47,19 @@ namespace MarkMpn.Sql4Cds.Engine
 
         public bool QuotedIdentifiers => _options.QuotedIdentifiers;
 
-        public bool ConfirmDelete(int count, EntityMetadata meta)
+        public void ConfirmDelete(ConfirmDmlStatementEventArgs e)
         {
-            return _options.ConfirmDelete(count, meta);
+            _options.ConfirmDelete(e);
         }
 
-        public bool ConfirmInsert(int count, EntityMetadata meta)
+        public void ConfirmInsert(ConfirmDmlStatementEventArgs e)
         {
-            return _options.ConfirmInsert(count, meta);
+            _options.ConfirmInsert(e);
         }
 
-        public bool ConfirmUpdate(int count, EntityMetadata meta)
+        public void ConfirmUpdate(ConfirmDmlStatementEventArgs e)
         {
-            return _options.ConfirmUpdate(count, meta);
+            _options.ConfirmUpdate(e);
         }
 
         public bool ContinueRetrieve(int count)

--- a/MarkMpn.Sql4Cds.Engine/Ado/ChangeDatabaseOptionsWrapper.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/ChangeDatabaseOptionsWrapper.cs
@@ -23,7 +23,6 @@ namespace MarkMpn.Sql4Cds.Engine
             BlockDeleteWithoutWhere = options.BlockDeleteWithoutWhere;
             UseBulkDelete = options.UseBulkDelete;
             BatchSize = options.BatchSize;
-            UseRetrieveTotalRecordCount = options.UseRetrieveTotalRecordCount;
             MaxDegreeOfParallelism = options.MaxDegreeOfParallelism;
             ColumnComparisonAvailable = options.ColumnComparisonAvailable;
             UseLocalTimeZone = options.UseLocalTimeZone;
@@ -43,8 +42,6 @@ namespace MarkMpn.Sql4Cds.Engine
 
         public bool UseTDSEndpoint { get; set; }
 
-        public bool UseRetrieveTotalRecordCount { get; set; }
-
         public int MaxDegreeOfParallelism { get; set; }
 
         public bool ColumnComparisonAvailable { get; }
@@ -61,49 +58,31 @@ namespace MarkMpn.Sql4Cds.Engine
 
         public bool QuotedIdentifiers { get; set; }
 
-        public bool ConfirmDelete(int count, EntityMetadata meta)
+        public void ConfirmDelete(ConfirmDmlStatementEventArgs e)
         {
-            var cancelled = !_options.ConfirmDelete(count, meta);
+            if (!e.Cancel)
+                _options.ConfirmDelete(e);
 
-            if (!cancelled)
-            {
-                var args = new ConfirmDmlStatementEventArgs(count, meta);
-                _connection.OnPreDelete(args);
-
-                cancelled = args.Cancel;
-            }
-
-            return !cancelled;
+            if (!e.Cancel)
+                _connection.OnPreDelete(e);
         }
 
-        public bool ConfirmInsert(int count, EntityMetadata meta)
+        public void ConfirmInsert(ConfirmDmlStatementEventArgs e)
         {
-            var cancelled = !_options.ConfirmInsert(count, meta);
+            if (!e.Cancel)
+                _options.ConfirmInsert(e);
 
-            if (!cancelled)
-            {
-                var args = new ConfirmDmlStatementEventArgs(count, meta);
-                _connection.OnPreInsert(args);
-
-                cancelled = args.Cancel;
-            }
-
-            return !cancelled;
+            if (!e.Cancel)
+                _connection.OnPreInsert(e);
         }
 
-        public bool ConfirmUpdate(int count, EntityMetadata meta)
+        public void ConfirmUpdate(ConfirmDmlStatementEventArgs e)
         {
-            var cancelled = !_options.ConfirmUpdate(count, meta);
+            if (!e.Cancel)
+                _options.ConfirmUpdate(e);
 
-            if (!cancelled)
-            {
-                var args = new ConfirmDmlStatementEventArgs(count, meta);
-                _connection.OnPreUpdate(args);
-
-                cancelled = args.Cancel;
-            }
-
-            return !cancelled;
+            if (!e.Cancel)
+                _connection.OnPreUpdate(e);
         }
 
         public bool ContinueRetrieve(int count)

--- a/MarkMpn.Sql4Cds.Engine/Ado/ConfirmDmlStatementEventArgs.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/ConfirmDmlStatementEventArgs.cs
@@ -16,10 +16,12 @@ namespace MarkMpn.Sql4Cds.Engine
         /// </summary>
         /// <param name="count">The number of records that will be affected</param>
         /// <param name="metadata">The metadata of the entity that will be affected</param>
-        internal ConfirmDmlStatementEventArgs(int count, EntityMetadata metadata)
+        /// <param name="bypassCustomPluginExecution">Indicates if custom plugins will be bypassed by the operation</param>
+        internal ConfirmDmlStatementEventArgs(int count, EntityMetadata metadata, bool bypassCustomPluginExecution)
         {
             Count = count;
             Metadata = metadata;
+            BypassCustomPluginExecution = bypassCustomPluginExecution;
         }
 
         /// <summary>
@@ -31,5 +33,10 @@ namespace MarkMpn.Sql4Cds.Engine
         /// Returns the metadata of the entity that will be affected
         /// </summary>
         public EntityMetadata Metadata { get; }
+
+        /// <summary>
+        /// Indicates if custom plugins will be bypassed by the operation
+        /// </summary>
+        public bool BypassCustomPluginExecution { get; }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine/Ado/DefaultQueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/DefaultQueryExecutionOptions.cs
@@ -74,8 +74,6 @@ namespace MarkMpn.Sql4Cds.Engine
 
         public bool UseTDSEndpoint => true;
 
-        public bool UseRetrieveTotalRecordCount => false;
-
         public int MaxDegreeOfParallelism => 10;
 
         public bool ColumnComparisonAvailable { get; }
@@ -92,19 +90,16 @@ namespace MarkMpn.Sql4Cds.Engine
 
         public bool QuotedIdentifiers => true;
 
-        public bool ConfirmDelete(int count, EntityMetadata meta)
+        public void ConfirmDelete(ConfirmDmlStatementEventArgs e)
         {
-            return true;
         }
 
-        public bool ConfirmInsert(int count, EntityMetadata meta)
+        public void ConfirmInsert(ConfirmDmlStatementEventArgs e)
         {
-            return true;
         }
 
-        public bool ConfirmUpdate(int count, EntityMetadata meta)
+        public void ConfirmUpdate(ConfirmDmlStatementEventArgs e)
         {
-            return true;
         }
 
         public bool ContinueRetrieve(int count)

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
@@ -174,15 +174,6 @@ namespace MarkMpn.Sql4Cds.Engine
         }
 
         /// <summary>
-        /// Indicates if a <see cref="Microsoft.Crm.Sdk.Messages.RetrieveTotalRecordCountRequest"/> should be used for simple SELECT count(*) FROM table queries
-        /// </summary>
-        public bool UseRetrieveTotalRecordCount
-        {
-            get => _options.UseRetrieveTotalRecordCount;
-            set => _options.UseRetrieveTotalRecordCount = value;
-        }
-
-        /// <summary>
         /// The maximum number of worker threads to use to execute DML queries
         /// </summary>
         public int MaxDegreeOfParallelism

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/AssignVariablesNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/AssignVariablesNode.cs
@@ -25,6 +25,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public override TimeSpan Duration => _timer.Duration;
 
+        [Browsable(false)]
+        public override int MaxDOP { get; set; }
+
+        [Browsable(false)]
+        public override bool BypassCustomPluginExecution { get; set; }
+
         public override string Execute(IDictionary<string, DataSource> dataSources, IQueryExecutionOptions options, IDictionary<string, DataTypeReference> parameterTypes, IDictionary<string, object> parameterValues, out int recordsAffected)
         {
             _executionCount++;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
@@ -91,6 +91,19 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         public virtual string DataSource { get; set; }
 
         /// <summary>
+        /// The maximum degree of paralellism to apply to this operation
+        /// </summary>
+        [Description("The maximum number of operations that will be performed in parallel")]
+        public abstract int MaxDOP { get; set; }
+
+        /// <summary>
+        /// Indicates if custom plugins should be skipped
+        /// </summary>
+        [DisplayName("Bypass Plugin Execution")]
+        [Description("Indicates if custom plugins should be skipped")]
+        public abstract bool BypassCustomPluginExecution { get; set; }
+
+        /// <summary>
         /// Changes system settings to optimise for parallel connections
         /// </summary>
         /// <returns>An object to dispose of to reset the settings to their original values</returns>
@@ -370,7 +383,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             var inProgressCount = 0;
             var count = 0;
 
-            var maxDop = options.MaxDegreeOfParallelism;
+            var maxDop = MaxDOP;
 
 #if NETCOREAPP
             var svc = org as ServiceClient;
@@ -422,7 +435,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                             var request = requestGenerator(entity);
 
-                            if (options.BypassCustomPlugins)
+                            if (BypassCustomPluginExecution)
                                 request.Parameters["BypassCustomPluginExecution"] = true;
 
                             if (options.BatchSize == 1)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteAsNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteAsNode.cs
@@ -31,6 +31,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         [DisplayName("UserId Source")]
         public string UserIdSource { get; set; }
 
+        [Browsable(false)]
+        public override int MaxDOP { get; set; }
+
+        [Browsable(false)]
+        public override bool BypassCustomPluginExecution { get; set; }
+
         public override void AddRequiredColumns(IDictionary<string, DataSource> dataSources, IDictionary<string, DataTypeReference> parameterTypes, IList<string> requiredColumns)
         {
             if (!requiredColumns.Contains(UserIdSource))

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
@@ -67,7 +67,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             Source.Parent = this;
 
             // Special case for using RetrieveTotalRecordCount instead of FetchXML
-            if (options.UseRetrieveTotalRecordCount &&
+            var retrieveTotalRecordCount = hints
+                .OfType<UseHintList>()
+                .Where(useHint => useHint.Hints.Any(hint => hint.Value.Equals("RETRIEVE_TOTAL_RECORD_COUNT", StringComparison.OrdinalIgnoreCase)))
+                .Any();
+
+            if (retrieveTotalRecordCount &&
                 Source is FetchXmlScan fetch &&
                 (fetch.Entity.Items == null || fetch.Entity.Items.Length == 0) &&
                 GroupBy.Count == 0 &&

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/TableSpoolNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/TableSpoolNode.cs
@@ -135,6 +135,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         public override IDataExecutionPlanNodeInternal FoldQuery(IDictionary<string, DataSource> dataSources, IQueryExecutionOptions options, IDictionary<string, DataTypeReference> parameterTypes, IList<OptimizerHint> hints)
         {
             Source = Source.FoldQuery(dataSources, options, parameterTypes, hints);
+
+            if (hints.Any(hint => hint.HintKind == OptimizerHintKind.NoPerformanceSpool))
+                return Source;
+
             Source.Parent = this;
             return this;
         }

--- a/MarkMpn.Sql4Cds.Engine/IQueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds.Engine/IQueryExecutionOptions.cs
@@ -48,26 +48,20 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <summary>
         /// Checks if an INSERT query should be executed
         /// </summary>
-        /// <param name="count">The number of records that the INSERT will apply to</param>
-        /// <param name="meta">The metadata of the entity type that will be affected</param>
-        /// <returns><c>true</c> if the entities should be inserted, or <c>false</c> otherwise</returns>
-        bool ConfirmInsert(int count, EntityMetadata meta);
+        /// <param name="e">The details of the insertion operation</param>
+        void ConfirmInsert(ConfirmDmlStatementEventArgs e);
 
         /// <summary>
         /// Checks if an UPDATE query should be executed
         /// </summary>
-        /// <param name="count">The number of records that the UPDATE will apply to</param>
-        /// <param name="meta">The metadata of the entity type that will be affected</param>
-        /// <returns><c>true</c> if the entities should be updated, or <c>false</c> otherwise</returns>
-        bool ConfirmUpdate(int count, EntityMetadata meta);
+        /// <param name="e">The details of the insertion operation</param>
+        void ConfirmUpdate(ConfirmDmlStatementEventArgs e);
 
         /// <summary>
         /// Checks if a DELETE query should be executed
         /// </summary>
-        /// <param name="count">The number of records that the DELETE will apply to</param>
-        /// <param name="meta">The metadata of the entity type that will be affected</param>
-        /// <returns><c>true</c> if the entities should be deleted, or <c>false</c> otherwise</returns>
-        bool ConfirmDelete(int count, EntityMetadata meta);
+        /// <param name="e">The details of the insertion operation</param>
+        void ConfirmDelete(ConfirmDmlStatementEventArgs e);
 
         /// <summary>
         /// The number of records that should be inserted, updated or deleted in a single batch
@@ -78,11 +72,6 @@ namespace MarkMpn.Sql4Cds.Engine
         /// Indicates if the TDS Endpoint should be used for query execution where possible
         /// </summary>
         bool UseTDSEndpoint { get; }
-
-        /// <summary>
-        /// Indicates if a <see cref="Microsoft.Crm.Sdk.Messages.RetrieveTotalRecordCountRequest"/> should be used for simple SELECT count(*) FROM table queries
-        /// </summary>
-        bool UseRetrieveTotalRecordCount { get; }
 
         /// <summary>
         /// The maximum number of worker threads to use to execute DML queries

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -11,10 +11,7 @@
     <iconUrl>https://markcarrington.dev/sql4cds-icon/</iconUrl>
     <description>Convert SQL queries to FetchXml and execute them against Dataverse / D365</description>
     <summary>Convert SQL queries to FetchXml and execute them against Dataverse / D365</summary>
-    <releaseNotes>Fixed dependencies
-Handle CrmServiceClient instances with null ConnectedOrgUniqueName
-Fixed running partitioned aggregate queries
-    </releaseNotes>
+    <releaseNotes>Use query hints to control bypassing plugins, parallelism, count(*) optimization &amp; more</releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>SQL CDS</tags>

--- a/MarkMpn.Sql4Cds.SSMS/QueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds.SSMS/QueryExecutionOptions.cs
@@ -32,7 +32,6 @@ namespace MarkMpn.Sql4Cds.SSMS
             con.UseBulkDelete = false;
             con.BatchSize = _options.BatchSize;
             con.UseTDSEndpoint = _useTds;
-            con.UseRetrieveTotalRecordCount = false;
             con.MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism;
             con.UseLocalTimeZone = false;
             con.BypassCustomPlugins = _options.BypassCustomPlugins;

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -22,7 +22,7 @@ plugins or integrations by writing familiar SQL and converting it.
 
 Using the preview TDS Endpoint, SELECT queries can also be run that aren't convertible to FetchXML.</description>
     <summary>Convert SQL queries to FetchXML and execute them against Dataverse / D365</summary>
-    <releaseNotes>Fixed running partitioned aggregate queries</releaseNotes>
+    <releaseNotes>Use query hints to control bypassing plugins, parallelism, count(*) optimization &amp; more</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/QueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds/QueryExecutionOptions.cs
@@ -34,7 +34,6 @@ namespace MarkMpn.Sql4Cds
             con.UseBulkDelete = Settings.Instance.UseBulkDelete;
             con.BatchSize = Settings.Instance.BatchSize;
             con.UseTDSEndpoint = Settings.Instance.UseTSQLEndpoint && (execute || !Settings.Instance.ShowFetchXMLInEstimatedExecutionPlans);
-            con.UseRetrieveTotalRecordCount = Settings.Instance.UseRetrieveTotalRecordCount;
             con.MaxDegreeOfParallelism = Settings.Instance.MaxDegreeOfPaallelism;
             con.UseLocalTimeZone = Settings.Instance.ShowLocalTimes;
             con.BypassCustomPlugins = Settings.Instance.BypassCustomPlugins;
@@ -51,15 +50,15 @@ namespace MarkMpn.Sql4Cds
 
         private void ConfirmInsert(object sender, ConfirmDmlStatementEventArgs e)
         {
-            e.Cancel |= !ConfirmInsert((Sql4CdsConnection)sender, e.Count, e.Metadata);
+            e.Cancel |= !ConfirmInsert((Sql4CdsConnection)sender, e);
         }
 
-        private bool ConfirmInsert(Sql4CdsConnection con, int count, EntityMetadata meta)
+        private bool ConfirmInsert(Sql4CdsConnection con, ConfirmDmlStatementEventArgs e)
         {
-            if (count > Settings.Instance.InsertWarnThreshold || con.BypassCustomPlugins)
+            if (e.Count > Settings.Instance.InsertWarnThreshold || e.BypassCustomPluginExecution)
             {
-                var msg = $"Insert will affect {count:N0} {GetDisplayName(count, meta)}.";
-                if (con.BypassCustomPlugins)
+                var msg = $"Insert will affect {e.Count:N0} {GetDisplayName(e.Count, e.Metadata)}.";
+                if (e.BypassCustomPluginExecution)
                     msg += "\r\n\r\nThis operation will bypass any custom plugins.";
 
                 var result = MessageBox.Show(_host, msg + "\r\n\r\nDo you want to proceed?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);
@@ -73,15 +72,15 @@ namespace MarkMpn.Sql4Cds
 
         private void ConfirmUpdate(object sender, ConfirmDmlStatementEventArgs e)
         {
-            e.Cancel |= !ConfirmUpdate((Sql4CdsConnection)sender, e.Count, e.Metadata);
+            e.Cancel |= !ConfirmUpdate((Sql4CdsConnection)sender, e);
         }
 
-        private bool ConfirmUpdate(Sql4CdsConnection con, int count, EntityMetadata meta)
+        private bool ConfirmUpdate(Sql4CdsConnection con, ConfirmDmlStatementEventArgs e)
         {
-            if (count > Settings.Instance.UpdateWarnThreshold || con.BypassCustomPlugins)
+            if (e.Count > Settings.Instance.UpdateWarnThreshold || e.BypassCustomPluginExecution)
             {
-                var msg = $"Update will affect {count:N0} {GetDisplayName(count, meta)}.";
-                if (con.BypassCustomPlugins)
+                var msg = $"Update will affect {e.Count:N0} {GetDisplayName(e.Count, e.Metadata)}.";
+                if (e.BypassCustomPluginExecution)
                     msg += "\r\n\r\nThis operation will bypass any custom plugins.";
 
                 var result = MessageBox.Show(_host, msg + "\r\n\r\nDo you want to proceed?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);
@@ -95,15 +94,15 @@ namespace MarkMpn.Sql4Cds
 
         private void ConfirmDelete(object sender, ConfirmDmlStatementEventArgs e)
         {
-            e.Cancel |= !ConfirmDelete((Sql4CdsConnection)sender, e.Count, e.Metadata);
+            e.Cancel |= !ConfirmDelete((Sql4CdsConnection)sender, e);
         }
 
-        private bool ConfirmDelete(Sql4CdsConnection con, int count, EntityMetadata meta)
+        private bool ConfirmDelete(Sql4CdsConnection con, ConfirmDmlStatementEventArgs e)
         {
-            if (count > Settings.Instance.DeleteWarnThreshold || con.BypassCustomPlugins)
+            if (e.Count > Settings.Instance.DeleteWarnThreshold || e.BypassCustomPluginExecution)
             {
-                var msg = $"Delete will affect {count:N0} {GetDisplayName(count, meta)}.";
-                if (con.BypassCustomPlugins)
+                var msg = $"Delete will affect {e.Count:N0} {GetDisplayName(e.Count, e.Metadata)}.";
+                if (e.BypassCustomPluginExecution)
                     msg += "\r\n\r\nThis operation will bypass any custom plugins.";
 
                 var result = MessageBox.Show(_host, msg + "\r\n\r\nDo you want to proceed?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);

--- a/MarkMpn.Sql4Cds/Settings.cs
+++ b/MarkMpn.Sql4Cds/Settings.cs
@@ -38,8 +38,6 @@ namespace MarkMpn.Sql4Cds
 
         public bool UseTSQLEndpoint { get; set; }
 
-        public bool UseRetrieveTotalRecordCount { get; set; }
-
         public bool ShowIntellisenseTooltips { get; set; } = true;
 
         public int MaxDegreeOfPaallelism { get; set; } = 10;

--- a/MarkMpn.Sql4Cds/SettingsForm.Designer.cs
+++ b/MarkMpn.Sql4Cds/SettingsForm.Designer.cs
@@ -59,15 +59,14 @@
             this.label11 = new System.Windows.Forms.Label();
             this.maxDopUpDown = new System.Windows.Forms.NumericUpDown();
             this.label13 = new System.Windows.Forms.Label();
-            this.retrieveTotalRecordCountCheckbox = new System.Windows.Forms.CheckBox();
             this.tsqlEndpointCheckBox = new System.Windows.Forms.CheckBox();
             this.autoSizeColumnsCheckBox = new System.Windows.Forms.CheckBox();
             this.quotedIdentifiersCheckbox = new System.Windows.Forms.CheckBox();
             this.showTooltipsCheckbox = new System.Windows.Forms.CheckBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.showFetchXMLInEstimatedExecutionPlansCheckBox = new System.Windows.Forms.CheckBox();
             this.pictureBox6 = new System.Windows.Forms.PictureBox();
-            this.pictureBox5 = new System.Windows.Forms.PictureBox();
             this.pictureBox4 = new System.Windows.Forms.PictureBox();
             this.pictureBox2 = new System.Windows.Forms.PictureBox();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
@@ -86,7 +85,6 @@
             this.nativeSqlRadioButton = new System.Windows.Forms.RadioButton();
             this.simpleSqlRadioButton = new System.Windows.Forms.RadioButton();
             this.label17 = new System.Windows.Forms.Label();
-            this.showFetchXMLInEstimatedExecutionPlansCheckBox = new System.Windows.Forms.CheckBox();
             this.topPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
             this.panel2.SuspendLayout();
@@ -99,7 +97,6 @@
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox6)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox5)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
@@ -396,7 +393,7 @@
             this.localTimesComboBox.Items.AddRange(new object[] {
             "UTC times",
             "Local times"});
-            this.localTimesComboBox.Location = new System.Drawing.Point(137, 190);
+            this.localTimesComboBox.Location = new System.Drawing.Point(137, 167);
             this.localTimesComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.localTimesComboBox.Name = "localTimesComboBox";
             this.localTimesComboBox.Size = new System.Drawing.Size(203, 21);
@@ -405,7 +402,7 @@
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(5, 193);
+            this.label11.Location = new System.Drawing.Point(5, 170);
             this.label11.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(128, 13);
@@ -437,16 +434,6 @@
             this.label13.Size = new System.Drawing.Size(53, 13);
             this.label13.TabIndex = 4;
             this.label13.Text = "Use up to";
-            // 
-            // retrieveTotalRecordCountCheckbox
-            // 
-            this.retrieveTotalRecordCountCheckbox.AutoSize = true;
-            this.retrieveTotalRecordCountCheckbox.Location = new System.Drawing.Point(9, 168);
-            this.retrieveTotalRecordCountCheckbox.Name = "retrieveTotalRecordCountCheckbox";
-            this.retrieveTotalRecordCountCheckbox.Size = new System.Drawing.Size(286, 17);
-            this.retrieveTotalRecordCountCheckbox.TabIndex = 11;
-            this.retrieveTotalRecordCountCheckbox.Text = "Use RetrieveTotalRecordCount request where possible";
-            this.retrieveTotalRecordCountCheckbox.UseVisualStyleBackColor = true;
             // 
             // tsqlEndpointCheckBox
             // 
@@ -507,7 +494,6 @@
             // 
             this.tabPage1.Controls.Add(this.showFetchXMLInEstimatedExecutionPlansCheckBox);
             this.tabPage1.Controls.Add(this.pictureBox6);
-            this.tabPage1.Controls.Add(this.pictureBox5);
             this.tabPage1.Controls.Add(this.pictureBox4);
             this.tabPage1.Controls.Add(this.pictureBox2);
             this.tabPage1.Controls.Add(this.pictureBox1);
@@ -524,7 +510,6 @@
             this.tabPage1.Controls.Add(this.label8);
             this.tabPage1.Controls.Add(this.label13);
             this.tabPage1.Controls.Add(this.tsqlEndpointCheckBox);
-            this.tabPage1.Controls.Add(this.retrieveTotalRecordCountCheckbox);
             this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
@@ -545,19 +530,6 @@
             this.pictureBox6.Tag = "https://docs.microsoft.com/powerapps/developer/data-platform/api-limits#how-to-ma" +
     "ximize-throughput";
             this.pictureBox6.Click += new System.EventHandler(this.helpIcon_Click);
-            // 
-            // pictureBox5
-            // 
-            this.pictureBox5.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.pictureBox5.Image = global::MarkMpn.Sql4Cds.Properties.Resources.StatusHelp_16x;
-            this.pictureBox5.Location = new System.Drawing.Point(301, 168);
-            this.pictureBox5.Name = "pictureBox5";
-            this.pictureBox5.Size = new System.Drawing.Size(16, 16);
-            this.pictureBox5.TabIndex = 30;
-            this.pictureBox5.TabStop = false;
-            this.pictureBox5.Tag = "https://docs.microsoft.com/powerapps/developer/data-platform/use-fetchxml-aggrega" +
-    "tion#limitations";
-            this.pictureBox5.Click += new System.EventHandler(this.helpIcon_Click);
             // 
             // pictureBox4
             // 
@@ -826,7 +798,6 @@
             this.tabPage1.ResumeLayout(false);
             this.tabPage1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox6)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox5)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
@@ -870,7 +841,6 @@
         private System.Windows.Forms.Label label11;
         private System.Windows.Forms.CheckBox quotedIdentifiersCheckbox;
         private System.Windows.Forms.CheckBox tsqlEndpointCheckBox;
-        private System.Windows.Forms.CheckBox retrieveTotalRecordCountCheckbox;
         private System.Windows.Forms.CheckBox showTooltipsCheckbox;
         private System.Windows.Forms.Label label12;
         private System.Windows.Forms.NumericUpDown maxDopUpDown;
@@ -890,7 +860,6 @@
         private System.Windows.Forms.PictureBox pictureBox1;
         private System.Windows.Forms.PictureBox pictureBox3;
         private System.Windows.Forms.PictureBox pictureBox6;
-        private System.Windows.Forms.PictureBox pictureBox5;
         private System.Windows.Forms.PictureBox pictureBox4;
         private System.Windows.Forms.Label label15;
         private System.Windows.Forms.NumericUpDown insertWarnThresholdUpDown;

--- a/MarkMpn.Sql4Cds/SettingsForm.cs
+++ b/MarkMpn.Sql4Cds/SettingsForm.cs
@@ -33,7 +33,6 @@ namespace MarkMpn.Sql4Cds
             localTimesComboBox.SelectedIndex = settings.ShowLocalTimes ? 1 : 0;
             tsqlEndpointCheckBox.Checked = settings.UseTSQLEndpoint;
             showFetchXMLInEstimatedExecutionPlansCheckBox.Checked = settings.ShowFetchXMLInEstimatedExecutionPlans;
-            retrieveTotalRecordCountCheckbox.Checked = settings.UseRetrieveTotalRecordCount;
             showTooltipsCheckbox.Checked = settings.ShowIntellisenseTooltips;
             maxDopUpDown.Value = settings.MaxDegreeOfPaallelism;
             autoSizeColumnsCheckBox.Checked = settings.AutoSizeColumns;
@@ -105,7 +104,6 @@ namespace MarkMpn.Sql4Cds
                 _settings.ShowLocalTimes = localTimesComboBox.SelectedIndex == 1;
                 _settings.UseTSQLEndpoint = tsqlEndpointCheckBox.Checked;
                 _settings.ShowFetchXMLInEstimatedExecutionPlans = showFetchXMLInEstimatedExecutionPlansCheckBox.Checked;
-                _settings.UseRetrieveTotalRecordCount = retrieveTotalRecordCountCheckbox.Checked;
                 _settings.ShowIntellisenseTooltips = showTooltipsCheckbox.Checked;
                 _settings.MaxDegreeOfPaallelism = (int) maxDopUpDown.Value;
                 _settings.AutoSizeColumns = autoSizeColumnsCheckBox.Checked;


### PR DESCRIPTION
Use query hints to control:

* bypassing plugins - add `OPTION (USE HINT ('BYPASS_CUSTOM_PLUGIN_EXECUTION'))` to bypass plugins for one query only
* parallelism - add `OPTION (MAXDOP 10)` to override the default number of threads for a DML query
* `count(*)` optimization - `count(*)` queries will now always use a full aggregate query unless `OPTION (USE HINT ('RETRIEVE_TOTAL_RECORD_COUNT'))` is specified, in which case it will use the RetrieveTotalRecordCount request where possible
* caching of data using table spool execution plan steps - this can be disabled with `OPTION (NO_PERFORMANCE_SPOOL)`