### PR TITLE
Performance improvements & fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -2731,15 +2731,7 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             AssertFetchXml(accountFetch, @"
                 <fetch>
                     <entity name='account'>
-                        <attribute name='accountid' />
-                        <attribute name='createdon' />
-                        <attribute name='employees' />
-                        <attribute name='name' />
-                        <attribute name='ownerid' />
-                        <attribute name='owneridname' />
-                        <attribute name='primarycontactid' />
-                        <attribute name='primarycontactidname' />
-                        <attribute name='turnover' />
+                        <all-attributes />
                         <order attribute='accountid' />
                     </entity>
                 </fetch>");
@@ -4499,6 +4491,29 @@ UPDATE account SET employees = @employees WHERE name = @name";
 
             AssertFetchXml(fetch, @"
                 <fetch xmlns:generator='MarkMpn.SQL4CDS' top='10'>
+                    <entity name='account'>
+                        <all-attributes />
+                    </entity>
+                </fetch>");
+        }
+
+        [TestMethod]
+        public void OrderByStar()
+        {
+            var metadata = new AttributeMetadataCache(_service);
+            var planBuilder = new ExecutionPlanBuilder(metadata, new StubTableSizeCache(), this);
+
+            var query = "SELECT * FROM account ORDER BY primarycontactid";
+
+            var plans = planBuilder.Build(query, null, out _);
+
+            Assert.AreEqual(1, plans.Length);
+            var select = AssertNode<SelectNode>(plans[0]);
+            var sort = AssertNode<SortNode>(select.Source);
+            var fetch = AssertNode<FetchXmlScan>(sort.Source);
+
+            AssertFetchXml(fetch, @"
+                <fetch xmlns:generator='MarkMpn.SQL4CDS'>
                     <entity name='account'>
                         <all-attributes />
                     </entity>

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
@@ -62,12 +62,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// <returns>A stream of <see cref="Entity"/> records</returns>
         public IEnumerable<Entity> Execute(IDictionary<string, DataSource> dataSources, IQueryExecutionOptions options, IDictionary<string, DataTypeReference> parameterTypes, IDictionary<string, object> parameterValues)
         {
+            if (options.CancellationToken.IsCancellationRequested)
+                yield break;
+
             // Track execution times roughly using Environment.TickCount. Stopwatch provides more accurate results
             // but gives a large performance penalty.
             IEnumerator<Entity> enumerator;
 
             using (_timer.Run())
-            { 
+            {
                 try
                 {
                     _executionCount++;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -880,8 +880,13 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         public override IDataExecutionPlanNodeInternal FoldQuery(IDictionary<string, DataSource> dataSources, IQueryExecutionOptions options, IDictionary<string, DataTypeReference> parameterTypes, IList<Microsoft.SqlServer.TransactSql.ScriptDom.OptimizerHint> hints)
         {
             NormalizeFilters();
-            ConvertQueryHints(hints);
-            ApplyPageSizeHint(hints);
+
+            if (hints != null)
+            {
+                ConvertQueryHints(hints);
+                ApplyPageSizeHint(hints);
+            }
+
             return this;
         }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MetadataQueryNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MetadataQueryNode.cs
@@ -348,6 +348,29 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     _manyToManyRelationshipCols[col] = prop;
                 }
             }
+
+            NormalizeProperties();
+        }
+
+        private void NormalizeProperties()
+        {
+            NormalizeProperties(Query, _entityProps.Values.Select(p => p.PropertyName));
+            NormalizeProperties(Query.AttributeQuery, _attributeProps.Values.Select(p => p.PropertyName));
+            NormalizeProperties(Query.RelationshipQuery, _oneToManyRelationshipProps.Values.Select(p => p.PropertyName).Union(_manyToManyRelationshipProps.Values.Select(p => p.PropertyName)));
+        }
+
+        private void NormalizeProperties(MetadataQueryExpression query, IEnumerable<string> allProperties)
+        {
+            if (query == null || query.Properties == null || query.Properties.AllProperties)
+                return;
+
+            var missingProperties = allProperties.Except(query.Properties.PropertyNames).Any();
+
+            if (!missingProperties)
+            {
+                query.Properties.PropertyNames.Clear();
+                query.Properties.AllProperties = true;
+            }
         }
 
         protected override int EstimateRowsOutInternal(IDictionary<string, DataSource> dataSources, IQueryExecutionOptions options, IDictionary<string, DataTypeReference> parameterTypes)

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -15,7 +15,9 @@
 Improved handling string length and decimal precision options
 Improved data type conversion handling for datetime/datetime2/date/time/datetimeoffset values
 Fixed use of REVERT
-Handle Dataverse bug with aggregates on address fields</releaseNotes>
+Handle Dataverse bug with aggregates on address fields
+Simplify long list of attributes to &lt;all-attributes /&gt;
+Auto-adapt page size based on number of columns</releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -27,7 +27,8 @@ Improved handling string length and decimal precision options
 Improved data type conversion handling for datetime/datetime2/date/time/datetimeoffset values
 Fixed use of REVERT
 Handle Dataverse bug with aggregates on address fields
-Open records in appropriate browser profile</releaseNotes>
+Open records in appropriate browser profile
+Prevent query tab being closed while it is still running</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -29,7 +29,9 @@ Fixed use of REVERT
 Handle Dataverse bug with aggregates on address fields
 Open records in appropriate browser profile
 Prevent query tab being closed while it is still running
-Improved metadata cache performance</releaseNotes>
+Improved metadata cache performance
+Simplify long list of attributes to &lt;all-attributes /&gt;
+Auto-adapt page size based on number of columns</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -28,7 +28,8 @@ Improved data type conversion handling for datetime/datetime2/date/time/datetime
 Fixed use of REVERT
 Handle Dataverse bug with aggregates on address fields
 Open records in appropriate browser profile
-Prevent query tab being closed while it is still running</releaseNotes>
+Prevent query tab being closed while it is still running
+Improved metadata cache performance</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/PluginControl.cs
+++ b/MarkMpn.Sql4Cds/PluginControl.cs
@@ -521,6 +521,20 @@ namespace MarkMpn.Sql4Cds
 
         public override void ClosingPlugin(PluginCloseInfo info)
         {
+            if (!info.Silent)
+            {
+                var busy = dockPanel.Documents
+                    .OfType<SqlQueryControl>()
+                    .Any(query => query.Busy);
+
+                if (busy)
+                {
+                    MessageBox.Show(this, "Query is still executing. Please wait for the query to finish before closing this tab.", "Query Running", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    info.Cancel = true;
+                    return;
+                }
+            }
+
             var unsavedDocuments = dockPanel.Documents
                 .OfType<SqlQueryControl>()
                 .Where(query => query.Modified)

--- a/MarkMpn.Sql4Cds/SqlQueryControl.cs
+++ b/MarkMpn.Sql4Cds/SqlQueryControl.cs
@@ -161,6 +161,13 @@ namespace MarkMpn.Sql4Cds
         {
             base.OnClosing(e);
 
+            if (Busy)
+            {
+                MessageBox.Show(this, "Query is still executing. Please wait for the query to finish before closing this tab.", "Query Running", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                e.Cancel = true;
+                return;
+            }
+
             if (_modified)
             {
                 using (var form = new ConfirmCloseForm(new[] { DisplayName }, true))


### PR DESCRIPTION
Prevent query tab being closed while it is still running - fixes #198 
Improved metadata cache performance
Simplify long lists of attributes to single `<all-attributes />` in FetchXML or `AllProperties` in metadata query
Refactored hints
Added custom `FETCHXML_PAGE_SIZE_n` hint to control FetchXML paging, and use smaller default page size when retrieving lots of attributes