### PR TITLE
Query optimizer improvements

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/ExpressionTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExpressionTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlTypes;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MarkMpn.Sql4Cds.Engine.ExecutionPlan;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xrm.Sdk;
+
+namespace MarkMpn.Sql4Cds.Engine.Tests
+{
+    [TestClass]
+    public class ExpressionTests
+    {
+        [TestMethod]
+        public void SimpleCaseExpression()
+        {
+            var expr = new SimpleCaseExpression
+            {
+                InputExpression = Col("name"),
+                WhenClauses =
+                {
+                    new SimpleWhenClause
+                    {
+                        WhenExpression = Str("one"),
+                        ThenExpression = Int(1)
+                    },
+                    new SimpleWhenClause
+                    {
+                        WhenExpression = Str("two"),
+                        ThenExpression = Int(2)
+                    }
+                },
+                ElseExpression = Int(3)
+            };
+            var schema = new NodeSchema(new Dictionary<string, DataTypeReference>
+            {
+                ["name"] = DataTypeHelpers.NVarChar(100)
+            }, new Dictionary<string, IReadOnlyList<string>>(), null, Array.Empty<string>(), Array.Empty<string>());
+            var parameterTypes = new Dictionary<string, DataTypeReference>();
+            var func = expr.Compile(schema, parameterTypes);
+
+            var options = new StubOptions();
+            var parameterValues = new Dictionary<string, object>();
+
+            var record = new Entity
+            {
+                ["name"] = SqlTypeConverter.UseDefaultCollation("One")
+            };
+
+            var value = func(record, parameterValues, options);
+            Assert.AreEqual((SqlInt32)1, value);
+
+            record["name"] = SqlTypeConverter.UseDefaultCollation("Two");
+            value = func(record, parameterValues, options);
+            Assert.AreEqual((SqlInt32)2, value);
+
+            record["name"] = SqlTypeConverter.UseDefaultCollation("Five");
+            value = func(record, parameterValues, options);
+            Assert.AreEqual((SqlInt32)3, value);
+        }
+
+        private ColumnReferenceExpression Col(string name)
+        {
+            return new ColumnReferenceExpression
+            {
+                MultiPartIdentifier = new MultiPartIdentifier
+                {
+                    Identifiers =
+                    {
+                        new Identifier
+                        {
+                            Value = name
+                        }
+                    }
+                }
+            };
+        }
+
+        private StringLiteral Str(string value)
+        {
+            return new StringLiteral { Value = value };
+        }
+
+        private IntegerLiteral Int(int value)
+        {
+            return new IntegerLiteral { Value = value.ToString(CultureInfo.InvariantCulture) };
+        }
+    }
+}

--- a/MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj
+++ b/MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj
@@ -153,6 +153,7 @@
   <ItemGroup>
     <Compile Include="ExecutionPlanNodeTests.cs" />
     <Compile Include="ExecutionPlanTests.cs" />
+    <Compile Include="ExpressionTests.cs" />
     <Compile Include="FakeXrmEasyTestsBase.cs" />
     <Compile Include="Metadata\New_CustomEntity.cs" />
     <Compile Include="Metadata\Contact.cs" />

--- a/MarkMpn.Sql4Cds.Engine.Tests/PropertyEqualityComparer.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/PropertyEqualityComparer.cs
@@ -42,6 +42,9 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                 if (prop.DeclaringType == typeof(FetchLinkEntityType) && prop.Name == nameof(FetchLinkEntityType.SemiJoin))
                     continue;
 
+                if (prop.DeclaringType == typeof(FetchLinkEntityType) && prop.Name == nameof(FetchLinkEntityType.RequireTablePrefix))
+                    continue;
+
                 var propRoute = route + "." + prop.Name;
 
                 var valueX = prop.GetValue(x);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/Aggregate.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/Aggregate.cs
@@ -154,6 +154,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
     {
         class State
         {
+            public State(object sumState, object countState)
+            {
+                SumState = sumState;
+                CountState = countState;
+            }
+
             public object SumState { get; set; }
             public object CountState { get; set; }
         }
@@ -220,7 +226,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public override object Reset()
         {
-            return new State();
+            return new State(_sum.Reset(), _count.Reset());
         }
     }
 
@@ -231,7 +237,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
     {
         class State
         {
-            public SqlInt32 Value { get; set; }
+            public SqlInt32 Value { get; set; } = 0;
         }
 
         /// <summary>
@@ -264,7 +270,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public override object Reset()
         {
-            return new State { Value = 0 };
+            return new State();
         }
     }
 
@@ -275,7 +281,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
     {
         class State
         {
-            public SqlInt32 Value { get; set; }
+            public SqlInt32 Value { get; set; } = 0;
         }
 
         /// <summary>
@@ -311,7 +317,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public override object Reset()
         {
-            return new State { Value = 0 };
+            return new State();
         }
     }
 
@@ -322,6 +328,11 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
     {
         class State
         {
+            public State(IComparable value)
+            {
+                Value = value;
+            }
+
             public IComparable Value { get; set; }
         }
 
@@ -362,7 +373,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public override object Reset()
         {
-            return new State();
+            return new State((IComparable)SqlTypeConverter.GetNullValue(Type.ToNetType(out _)));
         }
     }
 
@@ -373,6 +384,11 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
     {
         class State
         {
+            public State(IComparable value)
+            {
+                Value = value;
+            }
+
             public IComparable Value { get; set; }
         }
 
@@ -414,7 +430,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public override object Reset()
         {
-            return new State();
+            return new State((IComparable)SqlTypeConverter.GetNullValue(Type.ToNetType(out _)));
         }
     }
 
@@ -425,11 +441,11 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
     {
         class State
         {
-            public SqlInt32 Int32Value { get; set; }
-            public SqlInt64 Int64Value { get; set; }
-            public SqlDecimal DecimalValue { get; set; }
-            public SqlMoney MoneyValue { get; set; }
-            public SqlDouble FloatValue { get; set; }
+            public SqlInt32 Int32Value { get; set; } = 0;
+            public SqlInt64 Int64Value { get; set; } = 0;
+            public SqlDecimal DecimalValue { get; set; } = 0;
+            public SqlMoney MoneyValue { get; set; } = 0;
+            public SqlDouble FloatValue { get; set; } = 0;
         }
 
         private readonly SqlDataTypeOption _type;
@@ -521,14 +537,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public override object Reset()
         {
-            return new State
-            {
-                Int32Value = 0,
-                Int64Value = 0,
-                DecimalValue = 0,
-                MoneyValue = 0,
-                FloatValue = 0
-            };
+            return new State();
         }
     }
 
@@ -536,6 +545,11 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
     {
         class State
         {
+            public State(object value)
+            {
+                Value = value;
+            }
+
             public bool Done { get; set; }
 
             public object Value { get; set; }
@@ -575,7 +589,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public override object Reset()
         {
-            return new State();
+            return new State(SqlTypeConverter.GetNullValue(Type.ToNetType(out _)));
         }
     }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -1022,7 +1022,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     valueCopy = SqlTypeConverter.Convert(valueCopy, valueType, caseType);
 
                 if (!whenType.IsSameAs(caseType))
-                    whenValue = SqlTypeConverter.Convert(whenValue, whenType, type);
+                    whenValue = SqlTypeConverter.Convert(whenValue, whenType, caseType);
 
                 var comparison = Expression.Equal(valueCopy, whenValue);
                 var returnValue = thenClauses[i].Expression;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -3184,6 +3184,9 @@ namespace MarkMpn.Sql4Cds.Engine
                 }
                 else
                 {
+                    // Spool the inner table so the results can be reused by the nested loop
+                    rhs = new TableSpoolNode { Source = rhs, SpoolType = SpoolType.Eager };
+
                     joinNode = new NestedLoopNode
                     {
                         LeftSource = lhs,

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -2741,8 +2741,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 !innerSchema.ContainsColumn(innerKey, out innerKey))
                 return false;
 
-            if (outerSchema.PrimaryKey != outerKey &&
-                innerSchema.PrimaryKey != innerKey)
+            if (!semiJoin && innerSchema.PrimaryKey != innerKey)
                 return false;
 
             // Give the inner fetch a unique alias and update the name of the inner key

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanOptimizer.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanOptimizer.cs
@@ -51,7 +51,7 @@ namespace MarkMpn.Sql4Cds.Engine
 
             // Move any additional operators down to the FetchXml
             var nodes =
-                hints.OfType<UseHintList>().Any(list => list.Hints.Any(h => h.Value.Equals("DEBUG_BYPASS_OPTIMIZATION", StringComparison.OrdinalIgnoreCase)))
+                hints != null && hints.OfType<UseHintList>().Any(list => list.Hints.Any(h => h.Value.Equals("DEBUG_BYPASS_OPTIMIZATION", StringComparison.OrdinalIgnoreCase)))
                 ? new[] { node }
                 : node.FoldQuery(DataSources, Options, ParameterTypes, hints);
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanOptimizer.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanOptimizer.cs
@@ -50,7 +50,10 @@ namespace MarkMpn.Sql4Cds.Engine
             }
 
             // Move any additional operators down to the FetchXml
-            var nodes = node.FoldQuery(DataSources, Options, ParameterTypes, hints);
+            var nodes =
+                hints.OfType<UseHintList>().Any(list => list.Hints.Any(h => h.Value.Equals("DEBUG_BYPASS_OPTIMIZATION", StringComparison.OrdinalIgnoreCase)))
+                ? new[] { node }
+                : node.FoldQuery(DataSources, Options, ParameterTypes, hints);
 
             foreach (var n in nodes)
             {

--- a/MarkMpn.Sql4Cds.Engine/FetchXml.cs
+++ b/MarkMpn.Sql4Cds.Engine/FetchXml.cs
@@ -591,6 +591,9 @@ namespace MarkMpn.Sql4Cds.Engine.FetchXml {
 
         [XmlIgnore]
         public bool SemiJoin { get; set; }
+
+        [XmlIgnore]
+        public bool RequireTablePrefix { get; set; }
     }
     
     /// <remarks/>

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -11,15 +11,14 @@
     <iconUrl>https://markcarrington.dev/sql4cds-icon/</iconUrl>
     <description>Convert SQL queries to FetchXml and execute them against Dataverse / D365</description>
     <summary>Convert SQL queries to FetchXml and execute them against Dataverse / D365</summary>
-    <releaseNotes>Fixed UPDATE queries where column to be updated is also in the WHERE clause
-Simplified the filters in the generated FetchXML to make them easier to read
-Improved automatic FetchXML page size calculations
-Validate query hints and remove SQL 4 CDS-specific hints from TDS Endpoint queries
-Allow parallel DML queries for Client Secret and Certificate authenticated connections
-Improved support for multi-table queries in intellisense and query folding
-Improved performance folding queries with many joins
-Automatically use bulk delete to delete audit records
-Fixed inserting records in many-to-many intersect tables</releaseNotes>
+    <releaseNotes>Fixed evaluation of expressions CASE value WHEN x THEN y ...
+Fixed converting queries with nested IN subqueries
+Prevent ambiguous column errors with IN or EXISTS subqueries
+Simplified FetchXML generated for IN subqueries
+Fixed scalar subqueries without additional filter criteria
+Use merge join instead of hash join for more join types
+Spool inner source of nested loop joins for improved performance
+Fixed null values for aggregates</releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>SQL CDS</tags>

--- a/MarkMpn.Sql4Cds.Engine/Visitors/InSubqueryVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/InSubqueryVisitor.cs
@@ -11,10 +11,8 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
     {
         public List<InPredicate> InSubqueries { get; } = new List<InPredicate>();
 
-        public override void Visit(InPredicate node)
+        public override void ExplicitVisit(InPredicate node)
         {
-            base.Visit(node);
-
             if (node.Subquery != null)
                 InSubqueries.Add(node);
         }

--- a/MarkMpn.Sql4Cds.Engine/Visitors/OptimizerHintValidatingVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/OptimizerHintValidatingVisitor.cs
@@ -45,6 +45,9 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
 
             // Custom hint to use cached record count for simple count(*) queries
             "RETRIEVE_TOTAL_RECORD_COUNT",
+
+            // Custom hint to get query plan without any optimization
+            "DEBUG_BYPASS_OPTIMIZATION",
         };
 
         private static readonly HashSet<string> _removableSql4CdsQueryHints = new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -22,15 +22,15 @@ plugins or integrations by writing familiar SQL and converting it.
 
 Using the preview TDS Endpoint, SELECT queries can also be run that aren't convertible to FetchXML.</description>
     <summary>Convert SQL queries to FetchXML and execute them against Dataverse / D365</summary>
-    <releaseNotes>Fixed UPDATE queries where column to be updated is also in the WHERE clause
-Simplified the filters in the generated FetchXML to make them easier to read
-Improved automatic FetchXML page size calculations
-Validate query hints and remove SQL 4 CDS-specific hints from TDS Endpoint queries
-Allow parallel DML queries for Client Secret and Certificate authenticated connections
-Improved support for multi-table queries in intellisense and query folding
-Improved performance folding queries with many joins
-Automatically use bulk delete to delete audit records
-Fixed inserting records in many-to-many intersect tables</releaseNotes>
+    <releaseNotes>Fixed evaluation of expressions CASE value WHEN x THEN y ...
+Fixed converting queries with nested IN subqueries
+Prevent ambiguous column errors with IN or EXISTS subqueries
+Simplified FetchXML generated for IN subqueries
+Fixed scalar subqueries without additional filter criteria
+Use merge join instead of hash join for more join types
+Spool inner source of nested loop joins for improved performance
+Fixed metadata cache error for CRM versions before 8
+Fixed null values for aggregates</releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>

--- a/MarkMpn.Sql4Cds/SharedMetadataCache.cs
+++ b/MarkMpn.Sql4Cds/SharedMetadataCache.cs
@@ -32,7 +32,7 @@ namespace MarkMpn.Sql4Cds
         {
             get
             {
-                if (!_metadataCacheSupported || _connection.MetadataCacheLoader == null || _connection.MetadataCacheLoader.Status != TaskStatus.RanToCompletion)
+                if (!CacheReady)
                     return _innerCache[name];
 
                 LoadCache();
@@ -48,7 +48,7 @@ namespace MarkMpn.Sql4Cds
         {
             get
             {
-                if (!_metadataCacheSupported || _connection.MetadataCacheLoader == null || _connection.MetadataCacheLoader.Status != TaskStatus.RanToCompletion)
+                if (!CacheReady)
                     return _innerCache[otc];
 
                 LoadCache();
@@ -62,7 +62,7 @@ namespace MarkMpn.Sql4Cds
 
         public bool TryGetMinimalData(string logicalName, out EntityMetadata metadata)
         {
-            if (!_metadataCacheSupported || _connection.MetadataCacheLoader == null || _connection.MetadataCacheLoader.Status != TaskStatus.RanToCompletion)
+            if (!CacheReady)
                 return _innerCache.TryGetMinimalData(logicalName, out metadata);
 
             LoadCache();
@@ -72,12 +72,32 @@ namespace MarkMpn.Sql4Cds
 
         public bool TryGetValue(string logicalName, out EntityMetadata metadata)
         {
-            if (!_metadataCacheSupported || _connection.MetadataCacheLoader == null || _connection.MetadataCacheLoader.Status != TaskStatus.RanToCompletion)
+            if (!CacheReady)
                 return _innerCache.TryGetValue(logicalName, out metadata);
 
             LoadCache();
 
             return _entitiesByName.TryGetValue(logicalName, out metadata);
+        }
+
+        private  bool CacheReady
+        {
+            get
+            {
+                if (!_metadataCacheSupported)
+                    return false;
+
+                if (_connection.MetadataCacheLoader == null)
+                    return false;
+
+                if (_connection.MetadataCacheLoader.Status != TaskStatus.RanToCompletion)
+                    return false;
+
+                if (_connection.MetadataCacheLoader.Result == null)
+                    return false;
+
+                return true;
+            }
         }
 
         private void LoadCache()


### PR DESCRIPTION
* Fixed evaluation of expressions `CASE value WHEN x THEN y ...`
* Fixed converting queries with nested `IN` subqueries
* Prevent ambiguous column errors with `IN` or `EXISTS` subqueries
* Simplified FetchXML generated for `IN` subqueries
* Fixed scalar subqueries without additional filter criteria
* Use merge join instead of hash join for more join types
* Spool inner source of nested loop joins for improved performance
* Fixed metadata cache error for CRM versions before 8
* Fixed null values for aggregates