### PR TITLE
Bug fixes & optimizations

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
@@ -830,5 +830,23 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                 Assert.AreEqual(1, outputParam2.Value);
             }
         }
+
+        [TestMethod]
+        public void CorrelatedNotExistsTypeConversion()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSource))
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandText = "SELECT * FROM (VALUES ('1'), ('2')) a (s) WHERE NOT EXISTS (SELECT TOP 1 1 FROM (VALUES (1)) b (i) WHERE a.s = b.i)";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    Assert.IsTrue(reader.Read());
+                    Assert.AreEqual("2", reader.GetString(0));
+
+                    Assert.IsFalse(reader.Read());
+                }
+            }
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -745,6 +745,86 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         }
 
         [TestMethod]
+        public void GroupByDatePartUsingYearMonthDayFunctions()
+        {
+            var metadata = new AttributeMetadataCache(_service);
+            var planBuilder = new ExecutionPlanBuilder(metadata, new StubTableSizeCache(), new StubMessageCache(), this);
+
+            var query = @"
+                SELECT
+                    YEAR(createdon),
+                    MONTH(createdon),
+                    DAY(createdon),
+                    count(*)
+                FROM
+                    account
+                GROUP BY
+                    YEAR(createdOn),
+                    MONTH(createdOn),
+                    DAY(createdOn)";
+
+            var plans = planBuilder.Build(query, null, out _);
+
+            Assert.AreEqual(1, plans.Length);
+
+            var select = AssertNode<SelectNode>(plans[0]);
+            Assert.AreEqual("createdon_year", select.ColumnSet[0].SourceColumn);
+            Assert.AreEqual("createdon_month", select.ColumnSet[1].SourceColumn);
+            Assert.AreEqual("createdon_day", select.ColumnSet[2].SourceColumn);
+            Assert.AreEqual("count", select.ColumnSet[3].SourceColumn);
+            var tryCatch1 = AssertNode<TryCatchNode>(select.Source);
+            var tryCatch2 = AssertNode<TryCatchNode>(tryCatch1.TrySource);
+            var aggregateFetch = AssertNode<FetchXmlScan>(tryCatch2.TrySource);
+            AssertFetchXml(aggregateFetch, @"
+                <fetch aggregate='true'>
+                    <entity name='account'>
+                        <attribute name='createdon' groupby='true' alias='createdon_year' dategrouping='year' />
+                        <attribute name='createdon' groupby='true' alias='createdon_month' dategrouping='month' />
+                        <attribute name='createdon' groupby='true' alias='createdon_day' dategrouping='day' />
+                        <attribute name='accountid' aggregate='count' alias='count' />
+                        <order alias='createdon_year' />
+                        <order alias='createdon_month' />
+                        <order alias='createdon_day' />
+                    </entity>
+                </fetch>");
+            var partitionAggregate = AssertNode<PartitionedAggregateNode>(tryCatch2.CatchSource);
+            Assert.AreEqual("createdon_year", partitionAggregate.GroupBy[0].ToSql());
+            Assert.AreEqual("createdon_month", partitionAggregate.GroupBy[1].ToSql());
+            Assert.AreEqual("createdon_day", partitionAggregate.GroupBy[2].ToSql());
+            Assert.AreEqual("count", partitionAggregate.Aggregates.Single().Key);
+            var partitionFetch = AssertNode<FetchXmlScan>(partitionAggregate.Source);
+            AssertFetchXml(partitionFetch, @"
+                <fetch aggregate='true'>
+                    <entity name='account'>
+                        <attribute name='createdon' groupby='true' alias='createdon_year' dategrouping='year' />
+                        <attribute name='createdon' groupby='true' alias='createdon_month' dategrouping='month' />
+                        <attribute name='createdon' groupby='true' alias='createdon_day' dategrouping='day' />
+                        <attribute name='accountid' aggregate='count' alias='count' />
+                        <order alias='createdon_year' />
+                        <order alias='createdon_month' />
+                        <order alias='createdon_day' />
+                    </entity>
+                </fetch>");
+            var aggregate = AssertNode<HashMatchAggregateNode>(tryCatch1.CatchSource);
+            Assert.AreEqual("createdon_year", aggregate.GroupBy[0].ToSql());
+            Assert.AreEqual("createdon_month", aggregate.GroupBy[1].ToSql());
+            Assert.AreEqual("createdon_day", aggregate.GroupBy[2].ToSql());
+            Assert.AreEqual("count", aggregate.Aggregates.Single().Key);
+            var computeScalar = AssertNode<ComputeScalarNode>(aggregate.Source);
+            Assert.AreEqual(3, computeScalar.Columns.Count);
+            Assert.AreEqual("YEAR(createdOn)", computeScalar.Columns["createdon_year"].ToSql());
+            Assert.AreEqual("MONTH(createdOn)", computeScalar.Columns["createdon_month"].ToSql());
+            Assert.AreEqual("DAY(createdOn)", computeScalar.Columns["createdon_day"].ToSql());
+            var scalarFetch = AssertNode<FetchXmlScan>(computeScalar.Source);
+            AssertFetchXml(scalarFetch, @"
+                <fetch>
+                    <entity name='account'>
+                        <attribute name='createdon' />
+                    </entity>
+                </fetch>");
+        }
+
+        [TestMethod]
         public void PartialOrdering()
         {
             var metadata = new AttributeMetadataCache(_service);
@@ -3310,13 +3390,13 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
 
             var select = AssertNode<SelectNode>(plans[0]);
             var grouping = AssertNode<HashMatchAggregateNode>(select.Source);
-            Assert.AreEqual("Expr1", grouping.GroupBy[0].ToSql());
-            Assert.AreEqual("Expr2", grouping.GroupBy[1].ToSql());
-            Assert.AreEqual("Expr3", grouping.GroupBy[2].ToSql());
+            Assert.AreEqual("createdon_day", grouping.GroupBy[0].ToSql());
+            Assert.AreEqual("createdon_month", grouping.GroupBy[1].ToSql());
+            Assert.AreEqual("createdon_year", grouping.GroupBy[2].ToSql());
             var calc = AssertNode<ComputeScalarNode>(grouping.Source);
-            Assert.AreEqual("DAY(a.createdon)", calc.Columns["Expr1"].ToSql());
-            Assert.AreEqual("MONTH(a.createdon)", calc.Columns["Expr2"].ToSql());
-            Assert.AreEqual("YEAR(a.createdon)", calc.Columns["Expr3"].ToSql());
+            Assert.AreEqual("DAY(a.createdon)", calc.Columns["createdon_day"].ToSql());
+            Assert.AreEqual("MONTH(a.createdon)", calc.Columns["createdon_month"].ToSql());
+            Assert.AreEqual("YEAR(a.createdon)", calc.Columns["createdon_year"].ToSql());
             var filter = AssertNode<FilterNode>(calc.Source);
             Assert.AreEqual("YEAR(a.createdon) = 2021 AND MONTH(a.createdon) = 11", filter.Filter.ToSql().Replace("\r\n", " "));
             var fetch = AssertNode<FetchXmlScan>(filter.Source);

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -210,13 +210,17 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
 
             var select = AssertNode<SelectNode>(plans[0]);
             var fetch = AssertNode<FetchXmlScan>(select.Source);
+            Assert.IsTrue(fetch.UsingCustomPaging);
             AssertFetchXml(fetch, @"
                 <fetch>
                     <entity name='account'>
                         <attribute name='accountid' />
                         <attribute name='name' />
                         <link-entity name='contact' alias='contact' from='fullname' to='name' link-type='inner'>
+                            <attribute name='contactid' />
+                            <order attribute='contactid' />
                         </link-entity>
+                        <order attribute='accountid' />
                     </entity>
                 </fetch>");
         }
@@ -4046,25 +4050,56 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                     </entity>
                 </fetch>");
             var fetch2 = AssertNode<FetchXmlScan>(join.RightSource);
+            Assert.IsTrue(fetch2.UsingCustomPaging);
             AssertFetchXml(fetch2, @"
                 <fetch>
                     <entity name='contact'>
+                        <attribute name='contactid' />
                         <link-entity name='account' alias='a' from='accountid' to='parentcustomerid' link-type='inner'>
                             <attribute name='name' />
                             <attribute name='accountid' />
-                            <link-entity name='contact' alias='c2' from='parentcustomerid' to='accountid' link-type='inner' />
-                            <link-entity name='contact' alias='c3' from='parentcustomerid' to='accountid' link-type='inner' />
-                            <link-entity name='contact' alias='c4' from='parentcustomerid' to='accountid' link-type='inner' />
-                            <link-entity name='contact' alias='c5' from='parentcustomerid' to='accountid' link-type='inner' />
-                            <link-entity name='contact' alias='c6' from='parentcustomerid' to='accountid' link-type='inner' />
-                            <link-entity name='contact' alias='c7' from='parentcustomerid' to='accountid' link-type='inner' />
-                            <link-entity name='contact' alias='c8' from='parentcustomerid' to='accountid' link-type='inner' />
-                            <link-entity name='contact' alias='c9' from='parentcustomerid' to='accountid' link-type='inner' />
-                            <link-entity name='contact' alias='c10' from='parentcustomerid' to='accountid' link-type='inner' />
+                            <link-entity name='contact' alias='c2' from='parentcustomerid' to='accountid' link-type='inner'>
+                                <attribute name='contactid' />
+                                <order attribute='contactid' />
+                            </link-entity>
+                            <link-entity name='contact' alias='c3' from='parentcustomerid' to='accountid' link-type='inner'>
+                                <attribute name='contactid' />
+                                <order attribute='contactid' />
+                            </link-entity>
+                            <link-entity name='contact' alias='c4' from='parentcustomerid' to='accountid' link-type='inner'>
+                                <attribute name='contactid' />
+                                <order attribute='contactid' />
+                            </link-entity>
+                            <link-entity name='contact' alias='c5' from='parentcustomerid' to='accountid' link-type='inner'>
+                                <attribute name='contactid' />
+                                <order attribute='contactid' />
+                            </link-entity>
+                            <link-entity name='contact' alias='c6' from='parentcustomerid' to='accountid' link-type='inner'>
+                                <attribute name='contactid' />
+                                <order attribute='contactid' />
+                            </link-entity>
+                            <link-entity name='contact' alias='c7' from='parentcustomerid' to='accountid' link-type='inner'>
+                                <attribute name='contactid' />
+                                <order attribute='contactid' />
+                            </link-entity>
+                            <link-entity name='contact' alias='c8' from='parentcustomerid' to='accountid' link-type='inner'>
+                                <attribute name='contactid' />
+                                <order attribute='contactid' />
+                            </link-entity>
+                            <link-entity name='contact' alias='c9' from='parentcustomerid' to='accountid' link-type='inner'>
+                                <attribute name='contactid' />
+                                <order attribute='contactid' />
+                            </link-entity>
+                            <link-entity name='contact' alias='c10' from='parentcustomerid' to='accountid' link-type='inner'>
+                                <attribute name='contactid' />
+                                <order attribute='contactid' />
+                            </link-entity>
                             <filter>
                                 <condition attribute='primarycontactidname' operator='eq' value='Test' />
                             </filter>
+                            <order attribute='accountid' />
                         </link-entity>
+                        <order attribute='contactid' />
                     </entity>
                 </fetch>");
         }

--- a/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
@@ -1765,10 +1765,13 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                 <fetch>
                     <entity name='contact'>
                         <attribute name='createdon' />
+                        <attribute name='contactid' />
                         <link-entity name='contact' to='parentcustomerid' from='parentcustomerid' alias='c2' link-type='inner'>
                             <attribute name='contactid' />
                             <attribute name='createdon' />
+                            <order attribute='contactid' />
                         </link-entity>
+                        <order attribute='contactid' />
                     </entity>
                 </fetch>");
 
@@ -2373,12 +2376,17 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                 <fetch>
                     <entity name='account'>
                         <attribute name='employees' />
+                        <attribute name='accountid' />
                         <link-entity name='contact' from='contactid' to='primarycontactid' alias='contact' link-type='inner'>
                             <attribute name='fullname' />
+                            <attribute name='contactid' />
                             <link-entity name='new_customentity' from='new_parentid' to='parentcustomerid' alias='new_customentity' link-type='inner'>
+                                <attribute name='new_customentityid' />
+                                <order attribute='new_customentityid' />
                             </link-entity>
+                            <order attribute='contactid' />
                         </link-entity>
-                        <order attribute='employees' />
+                        <order attribute='accountid' />
                     </entity>
                 </fetch>");
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/Aggregate.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/Aggregate.cs
@@ -205,19 +205,19 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             var sum = _sum.GetValue(s.SumState);
 
             if (sum is SqlInt32 i32)
-                return i32 / count;
+                return count == 0 ? SqlInt32.Null : i32 / count;
 
             if (sum is SqlInt64 i64)
-                return i64 / count;
+                return count == 0 ? SqlInt64.Null : i64 / count;
 
             if (sum is SqlDecimal dec)
-                return dec / count;
+                return count == 0 ? SqlDecimal.Null : dec / count;
 
             if (sum is SqlMoney money)
-                return money / count;
+                return count == 0 ? SqlMoney.Null : money / count;
 
             if (sum is SqlDouble dbl)
-                return dbl / count;
+                return count == 0 ? SqlDouble.Null : dbl / count;
 
             throw new InvalidOperationException();
         }
@@ -354,7 +354,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 throw new InvalidOperationException("MAX is not valid for values of type " + value.GetType().Name);
 
             var s = (State)state;
-            if (s.Value == null || s.Value.CompareTo(cmp) < 0)
+            if (((INullable)s.Value).IsNull || s.Value.CompareTo(cmp) < 0)
                 s.Value = cmp;
         }
 
@@ -411,7 +411,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             var s = (State)state;
 
-            if (s.Value == null || s.Value.CompareTo(cmp) > 0)
+            if (((INullable)s.Value).IsNull || s.Value.CompareTo(cmp) > 0)
                 s.Value = cmp;
         }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -174,6 +174,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             foreach (var linkEntity in Entity.GetLinkEntities())
             {
+                if (linkEntity.linktype == "exists" || linkEntity.linktype == "in")
+                    continue;
+
                 if (linkEntity.from != dataSource.Metadata[linkEntity.name].PrimaryIdAttribute)
                     return true;
             }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -95,6 +95,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         private bool _lastFullSchema;
         private bool _resetPage;
         private string _startingPage;
+        private List<string> _pagingFields;
+        private List<SqlEntityReference> _lastPageValues;
 
         public FetchXmlScan()
         {
@@ -157,6 +159,28 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         [Browsable(false)]
         public bool ReturnFullSchema { get; set; }
 
+        [Category("FetchXML Scan")]
+        [Description("Indicates that custom paging will be used to ensure all results are retrieved, instead of the standard FetchXML paging")]
+        [DisplayName("Using Custom Paging")]
+        public bool UsingCustomPaging => _pagingFields != null;
+
+        public bool RequiresCustomPaging(IDictionary<string, DataSource> dataSources)
+        {
+            if (FetchXml.distinct)
+                return false;
+
+            if (!dataSources.TryGetValue(DataSource, out var dataSource))
+                throw new NotSupportedQueryFragmentException("Missing datasource " + DataSource);
+
+            foreach (var linkEntity in Entity.GetLinkEntities())
+            {
+                if (linkEntity.from != dataSource.Metadata[linkEntity.name].PrimaryIdAttribute)
+                    return true;
+            }
+
+            return false;
+        }
+
         protected override IEnumerable<Entity> ExecuteInternal(IDictionary<string, DataSource> dataSources, IQueryExecutionOptions options, IDictionary<string, DataTypeReference> parameterTypes, IDictionary<string, object> parameterValues)
         {
             PagesRetrieved = 0;
@@ -182,16 +206,23 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (!options.ContinueRetrieve(0))
                 yield break;
 
-            // Ensure we reset the page number & cookie for subsequent executions
-            if (_resetPage)
+            if (_pagingFields == null)
             {
-                FetchXml.page = _startingPage;
-                FetchXml.pagingcookie = null;
+                // Ensure we reset the page number & cookie for subsequent executions
+                if (_resetPage)
+                {
+                    FetchXml.page = _startingPage;
+                    FetchXml.pagingcookie = null;
+                }
+                else
+                {
+                    _startingPage = FetchXml.page;
+                    _resetPage = true;
+                }
             }
             else
             {
-                _startingPage = FetchXml.page;
-                _resetPage = true;
+                _lastPageValues = new List<SqlEntityReference>();
             }
 
             var res = dataSource.Connection.RetrieveMultiple(new FetchExpression(Serialize(FetchXml)));
@@ -221,12 +252,23 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 if (!(Parent is PartitionedAggregateNode))
                     options.Progress(0, $"Retrieved {count:N0} {GetDisplayName(count, meta)}...");
 
-                if (FetchXml.page == null)
-                    FetchXml.page = "2";
-                else
-                    FetchXml.page = (Int32.Parse(FetchXml.page, CultureInfo.InvariantCulture) + 1).ToString();
+                filter pagingFilter = null;
 
-                FetchXml.pagingcookie = res.PagingCookie;
+                if (_pagingFields == null)
+                {
+                    if (FetchXml.page == null)
+                        FetchXml.page = "2";
+                    else
+                        FetchXml.page = (Int32.Parse(FetchXml.page, CultureInfo.InvariantCulture) + 1).ToString();
+
+                    FetchXml.pagingcookie = res.PagingCookie;
+                }
+                else
+                {
+                    pagingFilter = new filter { type = filterType.or };
+                    AddPagingFilters(pagingFilter);
+                    Entity.AddItem(pagingFilter);
+                }
 
                 var nextPage = dataSource.Connection.RetrieveMultiple(new FetchExpression(Serialize(FetchXml)));
                 PagesRetrieved++;
@@ -239,6 +281,27 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                 count += nextPage.Entities.Count;
                 res = nextPage;
+
+                if (pagingFilter != null)
+                    Entity.Items = Entity.Items.Except(new[] { pagingFilter }).ToArray();
+            }
+        }
+
+        private void AddPagingFilters(filter filter)
+        {
+            for (var i = 0; i < _pagingFields.Count; i++)
+            {
+                if (_lastPageValues[i].IsNull)
+                    continue;
+
+                var subFilter = new filter();
+
+                for (var j = 0; j < i; j++)
+                    subFilter.AddItem(new condition { entityname = j == 0 ? null : _pagingFields[j].Split('.')[0], attribute = _pagingFields[j].Split('.')[1], @operator = _lastPageValues[j].IsNull ? @operator.@null : @operator.eq, value = _lastPageValues[j].IsNull ? null : _lastPageValues[j].Id.ToString() });
+
+                subFilter.AddItem(new condition { entityname = i == 0 ? null : _pagingFields[i].Split('.')[0], attribute = _pagingFields[i].Split('.')[1], @operator = @operator.gt, value = _lastPageValues[i].Id.ToString() });
+
+                filter.AddItem(subFilter);
             }
         }
 
@@ -425,6 +488,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     sqlValue = new SqlEntityReference(DataSource, logicalName, guid);
 
                 entity[col.Key] = sqlValue;
+            }
+
+            if (_pagingFields != null)
+            {
+                _lastPageValues.Clear();
+
+                foreach (var pagingField in _pagingFields)
+                    _lastPageValues.Add((SqlEntityReference)entity[pagingField]);
             }
         }
 
@@ -1273,8 +1344,54 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 Entity.AddItem(new FetchAttributeType { name = metadata.PrimaryIdAttribute });
             }
 
+            if (RequiresCustomPaging(dataSources))
+            {
+                RemoveSorts();
+
+                _pagingFields = new List<string>();
+                _lastPageValues = new List<SqlEntityReference>();
+
+                // Ensure the primary key of each entity is included
+                AddPrimaryIdAttribute(Entity, dataSource);
+
+                foreach (var linkEntity in Entity.GetLinkEntities())
+                    AddPrimaryIdAttribute(linkEntity, dataSource);
+            }
+
             NormalizeAttributes(dataSources);
             SetDefaultPageSize(dataSources, parameterTypes);
+        }
+
+        private void AddPrimaryIdAttribute(FetchEntityType entity, DataSource dataSource)
+        {
+            entity.Items = AddPrimaryIdAttribute(entity.Items, Alias, dataSource.Metadata[entity.name]);
+        }
+
+        private void AddPrimaryIdAttribute(FetchLinkEntityType linkEntity, DataSource dataSource)
+        {
+            linkEntity.Items = AddPrimaryIdAttribute(linkEntity.Items, linkEntity.alias, dataSource.Metadata[linkEntity.name]);
+        }
+
+        private object[] AddPrimaryIdAttribute(object[] items, string alias, EntityMetadata metadata)
+        {
+            _pagingFields.Add(alias + "." + metadata.PrimaryIdAttribute);
+
+            if (items == null || items.Length == 0)
+            {
+                return new object[]
+                {
+                    new FetchAttributeType { name = metadata.PrimaryIdAttribute },
+                    new FetchOrderType { attribute = metadata.PrimaryIdAttribute }
+                };
+            }
+
+            if (!items.OfType<allattributes>().Any() && !items.OfType<FetchAttributeType>().Any(a => a.name == metadata.PrimaryIdAttribute))
+                items = items.Concat(new object[] { new FetchAttributeType { name = metadata.PrimaryIdAttribute } }).ToArray();
+
+            if (!items.OfType<FetchOrderType>().Any(a => a.attribute == metadata.PrimaryIdAttribute))
+                items = items.Concat(new object[] { new FetchOrderType { attribute = metadata.PrimaryIdAttribute } }).ToArray();
+
+            return items;
         }
 
         private bool HasAttribute(object[] items)
@@ -1568,6 +1685,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 _lastSchemaAlias = _lastSchemaAlias,
                 _lastSchemaFetchXml = _lastSchemaFetchXml,
                 _primaryKeyColumns = _primaryKeyColumns,
+                _pagingFields = _pagingFields,
             };
 
             // Custom properties are not serialized, so need to copy them manually

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
@@ -138,6 +138,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             foldedFilters |= FoldTableSpoolToIndexSpool(dataSources, options, parameterTypes, hints);
             foldedFilters |= FoldFiltersToDataSources(dataSources, options, parameterTypes);
 
+            if (FoldColumnComparisonsWithKnownValues(dataSources, parameterTypes))
+                foldedFilters |= FoldFiltersToDataSources(dataSources, options, parameterTypes);
+
             foreach (var addedLink in addedLinks)
             {
                 addedLink.Key.SemiJoin = true;
@@ -711,6 +714,139 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             }
 
             return foldedFilters;
+        }
+
+        private bool FoldColumnComparisonsWithKnownValues(IDictionary<string, DataSource> dataSources, IDictionary<string, DataTypeReference> parameterTypes)
+        {
+            var foldedFilters = false;
+
+            // Find all the data source nodes we could fold this into. Include direct data sources, those from either side of an inner join, or the main side of an outer join
+            foreach (var source in GetFoldableSources(Source))
+            {
+                if (source is FetchXmlScan fetchXml && !fetchXml.FetchXml.aggregate)
+                {
+                    if (!dataSources.TryGetValue(fetchXml.DataSource, out var dataSource))
+                        throw new NotSupportedQueryFragmentException("Missing datasource " + fetchXml.DataSource);
+
+                    var schema = source.GetSchema(dataSources, parameterTypes);
+
+                    var newFilter = FoldColumnComparisonsWithKnownValues(dataSources, parameterTypes, fetchXml, schema, Filter);
+
+                    if (newFilter != Filter)
+                    {
+                        Filter = newFilter;
+                        foldedFilters = true;
+                    }
+                }
+
+                //if (source is MetadataQueryNode meta)
+                //    foldedFilters |= FoldColumnComparisonsWithKnownValues(dataSources, options, parameterTypes, meta, Filter);
+            }
+
+            return foldedFilters;
+        }
+
+        private BooleanExpression FoldColumnComparisonsWithKnownValues(IDictionary<string, DataSource> dataSources, IDictionary<string, DataTypeReference> parameterTypes, FetchXmlScan fetchXml, INodeSchema schema, BooleanExpression filter)
+        {
+            if (filter is BooleanComparisonExpression cmp &&
+                cmp.FirstExpression is ColumnReferenceExpression col1 &&
+                cmp.SecondExpression is ColumnReferenceExpression col2)
+            {
+                if (HasKnownValue(dataSources, parameterTypes, fetchXml, col1, schema, out var value))
+                {
+                    return new BooleanComparisonExpression
+                    {
+                        FirstExpression = value,
+                        ComparisonType = cmp.ComparisonType,
+                        SecondExpression = col2
+                    };
+                }
+                else if (HasKnownValue(dataSources, parameterTypes, fetchXml, col2, schema, out value))
+                {
+                    return new BooleanComparisonExpression
+                    {
+                        FirstExpression = col1,
+                        ComparisonType = cmp.ComparisonType,
+                        SecondExpression = value
+                    };
+                }
+            }
+            else if (filter is BooleanBinaryExpression bin &&
+                bin.BinaryExpressionType == BooleanBinaryExpressionType.And)
+            {
+                var bin1 = FoldColumnComparisonsWithKnownValues(dataSources, parameterTypes, fetchXml, schema, bin.FirstExpression);
+                var bin2 = FoldColumnComparisonsWithKnownValues(dataSources, parameterTypes, fetchXml, schema, bin.SecondExpression);
+
+                if (bin1 != bin.FirstExpression || bin2 != bin.SecondExpression)
+                {
+                    return new BooleanBinaryExpression
+                    {
+                        FirstExpression = bin1,
+                        BinaryExpressionType = bin.BinaryExpressionType,
+                        SecondExpression = bin2
+                    };
+                }
+            }
+
+            return filter;
+        }
+
+        private bool HasKnownValue(IDictionary<string, DataSource> dataSources, IDictionary<string, DataTypeReference> parameterTypes, FetchXmlScan fetchXml, ColumnReferenceExpression col, INodeSchema schema, out Literal value)
+        {
+            value = null;
+
+            if (!schema.ContainsColumn(col.GetColumnName(), out var colName))
+                return false;
+
+            var parts = colName.Split('.');
+            object[] items;
+
+            if (parts[0] == fetchXml.Alias)
+                items = fetchXml.Entity.Items;
+            else
+                items = fetchXml.Entity.GetLinkEntities().SingleOrDefault(le => le.alias == parts[0])?.Items;
+
+            if (items != fetchXml.Entity.Items)
+            {
+                foreach (var filter in fetchXml.Entity.Items.OfType<filter>())
+                {
+                    if (HasKnownValue(parts[0], parts[1], filter, out value))
+                        return true;
+                }
+            }
+
+            if (items == null)
+                return false;
+
+            foreach (var filter in items.OfType<filter>())
+            {
+                if (HasKnownValue(null, parts[1], filter, out value))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private bool HasKnownValue(string table, string column, filter filter, out Literal value)
+        {
+            value = null;
+
+            if (filter.type == filterType.or)
+                return false;
+
+            if (filter.Items == null)
+                return false;
+
+            foreach (var condition in filter.Items.OfType<condition>())
+            {
+                if (condition.entityname == table && condition.attribute == column && condition.@operator == @operator.eq)
+                {
+                    value = new StringLiteral { Value = condition.value };
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private BooleanIsNullExpression FindNotNullFilter(BooleanExpression filter, string attribute, out bool and)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
@@ -619,7 +619,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         Expression = indexColumn.ToColumnReference(),
                         IsNot = true
                     }
-                }.FoldQuery(dataSources, options, parameterTypes, hints);
+                };
             }
 
             Source = new IndexSpoolNode
@@ -627,7 +627,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 Source = spoolSource,
                 KeyColumn = indexColumn,
                 SeekValue = seekVariable
-            };
+            }.FoldQuery(dataSources, options, parameterTypes, hints);
 
             Filter = filter;
             return true;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
@@ -32,6 +32,13 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             InitializeAggregates(schema, parameterTypes);
             var aggregates = CreateAggregateFunctions(parameterValues, options, false);
 
+            if (IsScalarAggregate)
+            {
+                // Initialize the single group
+                var values = ResetAggregates(aggregates);
+                groups[new Entity()] = values;
+            }
+
             foreach (var entity in Source.Execute(dataSources, options, parameterTypes, parameterValues))
             {
                 if (!groups.TryGetValue(entity, out var values))

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SortNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SortNode.cs
@@ -246,7 +246,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 fetchXml = source as FetchXmlScan;
             }
 
-            if (fetchXml != null)
+            if (fetchXml != null && !fetchXml.RequiresCustomPaging(dataSources))
             {
                 if (!dataSources.TryGetValue(fetchXml.DataSource, out var dataSource))
                     throw new QueryExecutionException("Missing datasource " + fetchXml.DataSource);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -2029,7 +2029,7 @@ namespace MarkMpn.Sql4Cds.Engine
                             innerQuery.Source = computeScalar;
                         }
 
-                        computeScalar.Columns[innerSchema.PrimaryKey] = new IntegerLiteral { Value = "1" };
+                        computeScalar.Columns[innerSchemaPrimaryKey] = new IntegerLiteral { Value = "1" };
                     }
 
                     var definedValue = $"Expr{++_colNameCounter}";

--- a/MarkMpn.Sql4Cds.Engine/MessageCache.cs
+++ b/MarkMpn.Sql4Cds.Engine/MessageCache.cs
@@ -166,9 +166,9 @@ namespace MarkMpn.Sql4Cds.Engine
             {
                 return Type.GetType(typeName);
             }
-            catch (Exception ex)
+            catch
             {
-                throw new ApplicationException("Error retrieving type " + typeName + ":" + ex.Message, ex);
+                return null;
             }
         }
 

--- a/MarkMpn.Sql4Cds.Engine/Visitors/RewriteVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/RewriteVisitor.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.SqlServer.TransactSql.ScriptDom;
+﻿using MarkMpn.Sql4Cds.Engine.ExecutionPlan;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -25,15 +27,21 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
         public RewriteVisitor(IDictionary<ScalarExpression,string> rewrites)
         {
             _mappings = rewrites
-                .GroupBy(kvp => kvp.Key.ToSql())
-                .ToDictionary(g => g.Key, g => (ScalarExpression) new ColumnReferenceExpression { MultiPartIdentifier = new MultiPartIdentifier { Identifiers = { new Identifier { Value = g.First().Value } } } });
+                .GroupBy(kvp => kvp.Key.ToSql(), StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    g => g.Key,
+                    g => (ScalarExpression) g.First().Value.ToColumnReference(),
+                    StringComparer.OrdinalIgnoreCase);
         }
 
         public RewriteVisitor(IDictionary<ScalarExpression,ScalarExpression> rewrites)
         {
             _mappings = rewrites
-                .GroupBy(kvp => kvp.Key.ToSql())
-                .ToDictionary(g => g.Key, g => g.First().Value);
+                .GroupBy(kvp => kvp.Key.ToSql(), StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.First().Value,
+                    StringComparer.OrdinalIgnoreCase);
         }
 
         protected override ScalarExpression ReplaceExpression(ScalarExpression expression, out string name)

--- a/MarkMpn.Sql4Cds.SSMS/Sql2FetchXmlCommand.cs
+++ b/MarkMpn.Sql4Cds.SSMS/Sql2FetchXmlCommand.cs
@@ -122,7 +122,7 @@ namespace MarkMpn.Sql4Cds.SSMS
 
                             if (nodes.Any(node => !(node is IFetchXmlExecutionPlanNode)))
                             {
-                                editPoint.Insert("\r\n‼ WARNING ‼\r\n");
+                                editPoint.Insert("\r\n\r\n‼ WARNING ‼\r\n");
                                 editPoint.Insert("This query requires additional processing. This FetchXML gives the required data, but needs additional processing to format it in the same way as returned by the TDS Endpoint or SQL 4 CDS.\r\n\r\n");
                                 editPoint.Insert("See the estimated execution plan to see what extra processing is performed by SQL 4 CDS");
                             }

--- a/MarkMpn.Sql4Cds/FetchXmlControl.cs
+++ b/MarkMpn.Sql4Cds/FetchXmlControl.cs
@@ -106,16 +106,23 @@ namespace MarkMpn.Sql4Cds
                 // Reformat XML to use single quotes for attributes so it can be copied into C# string literals easily
                 if (!String.IsNullOrEmpty(value))
                 {
-                    var doc = new XmlDocument();
-                    doc.LoadXml(value);
-                    using (var writer = new StringWriter())
-                    using (var xmlWriter = new XmlFragmentWriter(writer))
+                    try
                     {
-                        xmlWriter.QuoteChar = '\'';
-                        xmlWriter.Formatting = Formatting.Indented;
+                        var doc = new XmlDocument();
+                        doc.LoadXml(value);
+                        using (var writer = new StringWriter())
+                        using (var xmlWriter = new XmlFragmentWriter(writer))
+                        {
+                            xmlWriter.QuoteChar = '\'';
+                            xmlWriter.Formatting = Formatting.Indented;
 
-                        doc.Save(xmlWriter);
-                        value = writer.ToString();
+                            doc.Save(xmlWriter);
+                            value = writer.ToString();
+                        }
+                    }
+                    catch (XmlException)
+                    {
+                        // Use the origina value
                     }
                 }
 

--- a/MarkMpn.Sql4Cds/PluginControl.cs
+++ b/MarkMpn.Sql4Cds/PluginControl.cs
@@ -646,9 +646,9 @@ in
                         if (fetchXmlNodes.Count == 0)
                             continue;
 
-                        if (nodes.Count < fetchXmlNodes.Count)
+                        if (nodes.Count > fetchXmlNodes.Count)
                         {
-                            sb.Append("\r\n‼ WARNING ‼\r\n");
+                            sb.Append("\r\n\r\n‼ WARNING ‼\r\n");
                             sb.Append("This query requires additional processing. This FetchXML gives the required data, but needs additional processing to format it in the same way as returned by the TDS Endpoint or SQL 4 CDS.\r\n\r\n");
                             sb.Append("See the estimated execution plan to see what extra processing is performed by SQL 4 CDS");
                         }


### PR DESCRIPTION
* Fixed `IN`, `NOT IN` and custom joins not working correctly when using an implicit type conversion on a comparison optimized with an index seek
* Fixed `MIN` aggregates returning incorrect null values
* Fixed queries using tables that aren't supported by RetrieveTotalRecordCount method
* Fixed showing FetchXML conversion for queries that require multiple FetchXML nodes
* Apply custom paging for queries where standard FetchXML paging fails
* Improved filter folding
* Optimize joins on `col1 = col2` where there is also a filter on `col1 = <value>`
* Optimize groupings on `YEAR()`, `MONTH()` and `DAY()` functions
* Fixed executing queries with date groupings