### PR TITLE
Fixes

### DIFF
--- a/AzureDataStudioExtension/CHANGELOG.md
+++ b/AzureDataStudioExtension/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Change Log
 
+## [v7.5.0](https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.5.0) - 2023-09-03
+
+Added `sql_variant` type support, including `SQL_VARIANT_PROPERTY` function
+Added `IS [NOT] DISTINCT FROM` predicate support
+Added `@@SERVERNAME` and `@@VERSION` global variables
+Added `SERVERPROPERTY` function support
+Added `USE_LEGACY_UPDATE_MESSAGES` query hint to use legacy update messages `Assign`, `SetState`, `SetParentBusinessUnit` and `SetBusinessEquipment`
+
+Subquery fixes:
+- Only include requested columns from `CROSS APPLY` and query-defined tables
+- Performance improvements for uncorrelated scalar subqueries
+- Only retrieve minimal rows for scalar subqueries
+- Fixed use of nested `IN` and `EXISTS` subqueries
+
+Fixed use of table-valued function with alias
+Fixed `JSON_VALUE` function with embedded null literals
+Fixed bulk DML operations that require non-standard requests
+Do not use merge joins for data types with different sort ordering
+Fixed filtering and sorting on non-lowercase attributes
+Fixed executing messages with OptionSetValue parameters
+Improved error reporting on batch DML statements
+
+Added autocomplete for collation names and variable names
+
 ## [v7.4.0](https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.4.0) - 2023-08-05
 
 Added support for long-term retention data

--- a/MarkMpn.Sql4Cds.Controls/MarkMpn.Sql4Cds.Controls.csproj
+++ b/MarkMpn.Sql4Cds.Controls/MarkMpn.Sql4Cds.Controls.csproj
@@ -171,4 +171,7 @@
     <EmbeddedResource Include="Images\XmlWriterNode.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy $(TargetDir)MarkMpn.Sql4Cds.Controls.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/MarkMpn.Sql4Cds.Controls/MarkMpn.Sql4Cds.Controls.csproj
+++ b/MarkMpn.Sql4Cds.Controls/MarkMpn.Sql4Cds.Controls.csproj
@@ -171,7 +171,7 @@
     <EmbeddedResource Include="Images\XmlWriterNode.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PostBuildEvent>copy $(TargetDir)MarkMpn.Sql4Cds.Controls.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/MarkMpn.Sql4Cds.Controls/Properties/AssemblyInfo.cs
+++ b/MarkMpn.Sql4Cds.Controls/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("MarkMpn.Sql4Cds.Controls")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Mark Carrington")]
 [assembly: AssemblyProduct("MarkMpn.Sql4Cds.Controls")]
-[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyCopyright("Copyright © 2022 - 2023 Mark Carrington")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/MarkMpn.Sql4Cds.Engine.NetCore/MarkMpn.Sql4Cds.Engine.NetCore.csproj
+++ b/MarkMpn.Sql4Cds.Engine.NetCore/MarkMpn.Sql4Cds.Engine.NetCore.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>MarkMpn.Sql4Cds.Engine</AssemblyName>
     <RootNamespace>MarkMpn.Sql4Cds.Engine</RootNamespace>
+    <Copyright>Copyright © 2020 - 2023 Mark Carrington</Copyright>
   </PropertyGroup>
 
   <Import Project="..\MarkMpn.Sql4Cds.Engine\MarkMpn.Sql4Cds.Engine.projitems" Label="Shared" />

--- a/MarkMpn.Sql4Cds.Engine.NetFx/MarkMpn.Sql4Cds.Engine.NetFx.csproj
+++ b/MarkMpn.Sql4Cds.Engine.NetFx/MarkMpn.Sql4Cds.Engine.NetFx.csproj
@@ -87,4 +87,12 @@
   </ItemGroup>
   <Import Project="..\MarkMpn.Sql4Cds.Engine\MarkMpn.Sql4Cds.Engine.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy $(TargetDir)MarkMpn.Sql4Cds.Engine.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+copy $(TargetDir)Microsoft.ApplicationInsights.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+copy $(TargetDir)Microsoft.SqlServer.TransactSql.ScriptDom.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+copy $(TargetDir)XPath2.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+copy $(TargetDir)XPath2.Extensions.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/MarkMpn.Sql4Cds.Engine.NetFx/MarkMpn.Sql4Cds.Engine.NetFx.csproj
+++ b/MarkMpn.Sql4Cds.Engine.NetFx/MarkMpn.Sql4Cds.Engine.NetFx.csproj
@@ -87,7 +87,7 @@
   </ItemGroup>
   <Import Project="..\MarkMpn.Sql4Cds.Engine\MarkMpn.Sql4Cds.Engine.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PostBuildEvent>copy $(TargetDir)MarkMpn.Sql4Cds.Engine.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
 copy $(TargetDir)Microsoft.ApplicationInsights.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
 copy $(TargetDir)Microsoft.SqlServer.TransactSql.ScriptDom.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds

--- a/MarkMpn.Sql4Cds.Engine.NetFx/Properties/AssemblyInfo.cs
+++ b/MarkMpn.Sql4Cds.Engine.NetFx/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Mark Carrington")]
 [assembly: AssemblyProduct("MarkMpn.Sql4Cds.Engine")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyCopyright("Copyright © 2020 - 2023 Mark Carrington")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
@@ -1334,5 +1334,131 @@ FOR XML PATH";
                 Assert.AreEqual(DBNull.Value, cmd.ExecuteScalar());
             }
         }
+
+        [TestMethod]
+        public void VariantType()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSource))
+            using (var cmd = con.CreateCommand())
+            {
+                // Can select two variant values of different types in the same column
+                cmd.CommandText = "SELECT SERVERPROPERTY('edition') UNION ALL SELECT SERVERPROPERTY('editionid')";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    Assert.IsTrue(reader.Read());
+                    Assert.AreEqual("Enterprise Edition", reader.GetString(0));
+                    Assert.IsTrue(reader.Read());
+                    Assert.AreEqual(1804890536, reader.GetInt64(0));
+                    Assert.IsFalse(reader.Read());
+                }
+            }
+        }
+
+        [TestMethod]
+        public void VariantComparisons()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSource))
+            using (var cmd = con.CreateCommand())
+            {
+                // Variant values are compared according to the type family hierarchy
+                // https://dba.stackexchange.com/questions/56722/why-does-implicit-conversion-from-sql-variant-basetype-decimal-not-work-well-w
+                cmd.CommandText = @"
+declare
+    @v sql_variant = convert(decimal(28,8), 20.0);
+
+select sql_variant_property(@v, 'BaseType') as BaseType,         -- 'decimal',
+       iif(convert(int, 10.0)     < @v, 1, 0) as ResultInt,      -- 1
+       iif(convert(decimal, 10.0) < @v, 1, 0) as  ResultDecimal, -- 1
+       iif(convert(float, 10.0)   < @v, 1, 0) as  ResultFloat,   -- 0 !
+       iif(convert(float, 10.0)   < convert(float, @v), 1, 0) as  ResultFloatFloat,  -- 1              
+       iif(convert(float, 10.0)   < convert(decimal(28,8), @v), 1, 0) as  ResultFloatDecimal;   -- 1";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    Assert.IsTrue(reader.Read());
+
+                    var i = 0;
+                    Assert.AreEqual("decimal", reader.GetString(i++));
+                    Assert.AreEqual(1, reader.GetInt32(i++));
+                    Assert.AreEqual(1, reader.GetInt32(i++));
+                    Assert.AreEqual(0, reader.GetInt32(i++));
+                    Assert.AreEqual(1, reader.GetInt32(i++));
+                    Assert.AreEqual(1, reader.GetInt32(i++));
+
+                    Assert.IsFalse(reader.Read());
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SqlVariantProperty()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSource))
+            using (var cmd = con.CreateCommand())
+            {
+                // Variant values are compared according to the type family hierarchy
+                // https://dba.stackexchange.com/questions/56722/why-does-implicit-conversion-from-sql-variant-basetype-decimal-not-work-well-w
+                cmd.CommandText = @"
+declare
+    @v sql_variant = cast (46279.1 as decimal(8,2));
+
+SELECT   SQL_VARIANT_PROPERTY(@v,'BaseType') AS 'Base Type',  
+         SQL_VARIANT_PROPERTY(@v,'Precision') AS 'Precision',  
+         SQL_VARIANT_PROPERTY(@v,'Scale') AS 'Scale' ";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    Assert.IsTrue(reader.Read());
+
+                    var i = 0;
+                    Assert.AreEqual("decimal", reader.GetString(i++));
+                    Assert.AreEqual(8, reader.GetInt32(i++));
+                    Assert.AreEqual(2, reader.GetInt32(i++));
+
+                    Assert.IsFalse(reader.Read());
+                }
+            }
+        }
+
+        [TestMethod]
+        public void VariantTypes()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSource))
+            using (var cmd = con.CreateCommand())
+            {
+                // Variant values are compared according to the type family hierarchy
+                // https://dba.stackexchange.com/questions/56722/why-does-implicit-conversion-from-sql-variant-basetype-decimal-not-work-well-w
+                cmd.CommandText = @"
+declare
+    @v sql_variant = 1;
+declare
+    @n sql_variant;
+
+SELECT   @v
+UNION ALL
+SELECT   @n";
+
+                using (var reader = (Sql4CdsDataReader) cmd.ExecuteReader())
+                {
+                    Assert.AreEqual(typeof(object), reader.GetProviderSpecificFieldType(0));
+                    Assert.AreEqual(typeof(object), reader.GetFieldType(0));
+                    Assert.AreEqual("sql_variant", reader.GetDataTypeName(0));
+
+                    Assert.IsTrue(reader.Read());
+
+                    Assert.AreEqual(1, reader.GetInt32(0));
+                    Assert.AreEqual(1, reader.GetValue(0));
+                    Assert.AreEqual(new SqlInt32(1), reader.GetProviderSpecificValue(0));
+
+                    Assert.IsTrue(reader.Read());
+
+                    Assert.AreEqual(DBNull.Value, reader.GetValue(0));
+                    Assert.AreEqual(DBNull.Value, reader.GetProviderSpecificValue(0));
+
+                    Assert.IsFalse(reader.Read());
+                }
+            }
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
@@ -835,6 +835,25 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         }
 
         [TestMethod]
+        public void AliasedTVF()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSource))
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandText = "SELECT msg.* FROM SampleMessage('1') AS msg";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    Assert.IsTrue(reader.Read());
+                    Assert.AreEqual("1", reader.GetString(0));
+                    Assert.AreEqual(1, reader.GetInt32(1));
+
+                    Assert.IsFalse(reader.Read());
+                }
+            }
+        }
+
+        [TestMethod]
         public void CorrelatedNotExistsTypeConversion()
         {
             using (var con = new Sql4CdsConnection(_localDataSource))

--- a/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
@@ -1445,6 +1445,10 @@ SELECT   @n";
                     Assert.AreEqual(typeof(object), reader.GetFieldType(0));
                     Assert.AreEqual("sql_variant", reader.GetDataTypeName(0));
 
+                    var schema = reader.GetSchemaTable();
+                    Assert.AreEqual(typeof(object), schema.Rows[0]["DataType"]);
+                    Assert.AreEqual(typeof(object), schema.Rows[0]["ProviderSpecificDataType"]);
+
                     Assert.IsTrue(reader.Read());
 
                     Assert.AreEqual(1, reader.GetInt32(0));

--- a/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
@@ -1323,5 +1323,16 @@ FOR XML PATH";
                 Assert.AreEqual("C, B, A", actual);
             }
         }
+
+        [TestMethod]
+        public void JsonValueNull()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSource))
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandText = "SELECT JSON_VALUE('{ \"changedAttributes\": [ { \"logicalName\": \"column1\", \"oldValue\": null, \"newValue\": \"\" } ] }', '$.changedAttributes[0].oldValue')";
+                Assert.AreEqual(DBNull.Value, cmd.ExecuteScalar());
+            }
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -1060,7 +1060,8 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                 </fetch>");
             var subAssert = AssertNode<AssertNode>(nestedLoop.RightSource);
             var subAggregate = AssertNode<StreamAggregateNode>(subAssert.Source);
-            var subIndexSpool = AssertNode<IndexSpoolNode>(subAggregate.Source);
+            var subTop = AssertNode<TopNode>(subAggregate.Source);
+            var subIndexSpool = AssertNode<IndexSpoolNode>(subTop.Source);
             Assert.AreEqual("account.createdon", subIndexSpool.KeyColumn);
             Assert.AreEqual("@Expr2", subIndexSpool.SeekValue);
             var subAggregateFetch = AssertNode<FetchXmlScan>(subIndexSpool.Source);
@@ -1154,7 +1155,7 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             var subAggregate = AssertNode<StreamAggregateNode>(subAssert.Source);
             var subAggregateFetch = AssertNode<FetchXmlScan>(subAggregate.Source);
             AssertFetchXml(subAggregateFetch, @"
-                <fetch xmlns:generator='MarkMpn.SQL4CDS'>
+                <fetch xmlns:generator='MarkMpn.SQL4CDS' top='2'>
                     <entity name='account'>
                         <attribute name='name' />
                         <filter>
@@ -1240,7 +1241,8 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                 </fetch>");
             var subAssert = AssertNode<AssertNode>(nestedLoop.RightSource);
             var subAggregate = AssertNode<StreamAggregateNode>(subAssert.Source);
-            var subIndexSpool = AssertNode<IndexSpoolNode>(subAggregate.Source);
+            var subTop = AssertNode<TopNode>(subAggregate.Source);
+            var subIndexSpool = AssertNode<IndexSpoolNode>(subTop.Source);
             Assert.AreEqual("account.createdon", subIndexSpool.KeyColumn);
             Assert.AreEqual("@Expr2", subIndexSpool.SeekValue);
             var subFetch = AssertNode<FetchXmlScan>(subIndexSpool.Source);
@@ -1290,7 +1292,8 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                 </fetch>");
             var subAssert = AssertNode<AssertNode>(nestedLoop.RightSource);
             var subAggregate = AssertNode<StreamAggregateNode>(subAssert.Source);
-            var subIndexSpool = AssertNode<IndexSpoolNode>(subAggregate.Source);
+            var subTop = AssertNode<TopNode>(subAggregate.Source);
+            var subIndexSpool = AssertNode<IndexSpoolNode>(subTop.Source);
             Assert.AreEqual("account.createdon", subIndexSpool.KeyColumn);
             Assert.AreEqual("@Expr2", subIndexSpool.SeekValue);
             var subFetch = AssertNode<FetchXmlScan>(subIndexSpool.Source);
@@ -1342,7 +1345,8 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                 </fetch>");
             var subAssert = AssertNode<AssertNode>(nestedLoop.RightSource);
             var subAggregate = AssertNode<StreamAggregateNode>(subAssert.Source);
-            var subCompute = AssertNode<ComputeScalarNode>(subAggregate.Source);
+            var subTop = AssertNode<TopNode>(subAggregate.Source);
+            var subCompute = AssertNode<ComputeScalarNode>(subTop.Source);
             var subIndexSpool = AssertNode<IndexSpoolNode>(subCompute.Source);
             Assert.AreEqual("account.accountid", subIndexSpool.KeyColumn);
             Assert.AreEqual("@Expr2", subIndexSpool.SeekValue);

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -4186,6 +4186,31 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         }
 
         [TestMethod]
+        public void DistinctFromAllowsNull()
+        {
+            var planBuilder = new ExecutionPlanBuilder(_localDataSource.Values, this);
+
+            var query = @"
+                SELECT name FROM account WHERE name IS DISTINCT FROM 'Data8'";
+
+            var plans = planBuilder.Build(query, null, out _);
+
+            Assert.AreEqual(1, plans.Length);
+
+            var select = AssertNode<SelectNode>(plans[0]);
+            var fetch = AssertNode<FetchXmlScan>(select.Source);
+            AssertFetchXml(fetch, @"
+                <fetch>
+                    <entity name='account'>
+                        <attribute name='name' />
+                        <filter>
+                            <condition attribute='name' operator='ne' value='Data8' />
+                        </filter>
+                    </entity>
+                </fetch>");
+        }
+
+        [TestMethod]
         public void DoNotFoldFilterOnNameVirtualAttributeWithTooManyJoins()
         {
             var planBuilder = new ExecutionPlanBuilder(_localDataSource.Values, this);

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -6072,13 +6072,13 @@ FROM   account AS r;";
             var loop = AssertNode<NestedLoopNode>(select.Source);
             Assert.AreEqual(QualifiedJoinType.Inner, loop.JoinType);
             Assert.IsNull(loop.JoinCondition);
-            Assert.AreEqual("@Expr1", loop.OuterReferences["Expr2"]);
+            Assert.AreEqual("@Expr1", loop.OuterReferences["Expr1"]);
 
             var assert = AssertNode<AssertNode>(loop.LeftSource);
 
             var aggregate = AssertNode<StreamAggregateNode>(assert.Source);
-            Assert.AreEqual("contact.contactid", aggregate.Aggregates["Expr2"].SqlExpression.ToSql());
-            Assert.AreEqual(AggregateType.First, aggregate.Aggregates["Expr2"].AggregateType);
+            Assert.AreEqual("contact.contactid", aggregate.Aggregates["Expr1"].SqlExpression.ToSql());
+            Assert.AreEqual(AggregateType.First, aggregate.Aggregates["Expr1"].AggregateType);
 
             var contactFetch = AssertNode<FetchXmlScan>(aggregate.Source);
             AssertFetchXml(contactFetch, @"

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -5988,6 +5988,16 @@ FROM   account AS r;";
         }
 
         [TestMethod]
+        public void NestedExistsAndIn()
+        {
+            var planBuilder = new ExecutionPlanBuilder(_localDataSource.Values, this);
+
+            var query = "IF NOT EXISTS(SELECT * FROM account WHERE primarycontactid IN (SELECT contactid FROM contact WHERE firstname = 'Mark')) SELECT 1";
+
+            var plans = planBuilder.Build(query, null, out _);
+
+        }
+
 
         [TestMethod]
         public void DoNotFoldFilterOnParameterToIndexSpool()

--- a/MarkMpn.Sql4Cds.Engine.Tests/FakeXrmEasyTestsBase.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/FakeXrmEasyTestsBase.cs
@@ -68,6 +68,7 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             _context.CallerId = new EntityReference("systemuser", Guid.NewGuid());
             _context.AddFakeMessageExecutor<RetrieveVersionRequest>(new RetrieveVersionRequestExecutor());
             _context.AddGenericFakeMessageExecutor(SampleMessageExecutor.MessageName, new SampleMessageExecutor());
+            _context.AddGenericFakeMessageExecutor(SetStateMessageExecutor.MessageName, new SetStateMessageExecutor());
 
             _service = _context.GetOrganizationService();
             _dataSource = new DataSource { Name = "uat", Connection = _service, Metadata = new AttributeMetadataCache(_service), TableSizeCache = new StubTableSizeCache(), MessageCache = new StubMessageCache(), DefaultCollation = Collation.USEnglish };
@@ -77,6 +78,7 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             _context2.CallerId = _context.CallerId;
             _context2.AddFakeMessageExecutor<RetrieveVersionRequest>(new RetrieveVersionRequestExecutor());
             _context2.AddGenericFakeMessageExecutor(SampleMessageExecutor.MessageName, new SampleMessageExecutor());
+            _context2.AddGenericFakeMessageExecutor(SetStateMessageExecutor.MessageName, new SetStateMessageExecutor());
 
             _service2 = _context2.GetOrganizationService();
             _dataSource2 = new DataSource { Name = "prod", Connection = _service2, Metadata = new AttributeMetadataCache(_service2), TableSizeCache = new StubTableSizeCache(), MessageCache = new StubMessageCache(), DefaultCollation = Collation.USEnglish };
@@ -86,6 +88,7 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             _context3.CallerId = _context.CallerId;
             _context3.AddFakeMessageExecutor<RetrieveVersionRequest>(new RetrieveVersionRequestExecutor());
             _context3.AddGenericFakeMessageExecutor(SampleMessageExecutor.MessageName, new SampleMessageExecutor());
+            _context3.AddGenericFakeMessageExecutor(SetStateMessageExecutor.MessageName, new SetStateMessageExecutor());
 
             _service3 = _context3.GetOrganizationService();
             Collation.TryParse("French_CI_AI", out var frenchCIAI);

--- a/MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj
+++ b/MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="SampleMessageExecutor.cs" />
     <Compile Include="Sql2FetchXmlTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlVariantTests.cs" />
     <Compile Include="StubOptions.cs" />
     <Compile Include="StubMessageCache.cs" />
     <Compile Include="StubTableSizeCache.cs" />

--- a/MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj
+++ b/MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="OptionsWrapper.cs" />
     <Compile Include="PropertyEqualityComparer.cs" />
     <Compile Include="AdoProviderTests.cs" />
+    <Compile Include="SetStateMessageExecutor.cs" />
     <Compile Include="SampleMessageExecutor.cs" />
     <Compile Include="Sql2FetchXmlTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj
+++ b/MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj
@@ -104,10 +104,6 @@
     <None Include="Key.snk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\AutocompleteMenu\AutocompleteMenu-ScintillaNET.csproj">
-      <Project>{43cbc9aa-6a8e-463f-83a9-aff3124afdb6}</Project>
-      <Name>AutocompleteMenu-ScintillaNET</Name>
-    </ProjectReference>
     <ProjectReference Include="..\MarkMpn.Sql4Cds.Engine.NetFx\MarkMpn.Sql4Cds.Engine.NetFx.csproj">
       <Project>{23288bb2-0d6f-4329-9a5c-4c659567a652}</Project>
       <Name>MarkMpn.Sql4Cds.Engine.NetFx</Name>

--- a/MarkMpn.Sql4Cds.Engine.Tests/Metadata/Contact.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Metadata/Contact.cs
@@ -35,5 +35,11 @@ namespace MarkMpn.Sql4Cds.Engine.Tests.Metadata
 
         [AttributeLogicalName("createdon")]
         public DateTime? CreatedOn { get; set; }
+
+        [AttributeLogicalName("statecode")]
+        public OptionSetValue StateCode { get; set; }
+
+        [AttributeLogicalName("statuscode")]
+        public OptionSetValue StatusCode { get; set; }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/Properties/AssemblyInfo.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("MarkMpn.Sql4Cds.Engine.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyCopyright("Copyright © 2020 - 2023 Mark Carrington")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/MarkMpn.Sql4Cds.Engine.Tests/SetStateMessageExecutor.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/SetStateMessageExecutor.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using FakeXrmEasy;
+using FakeXrmEasy.FakeMessageExecutors;
+using Microsoft.Xrm.Sdk;
+
+namespace MarkMpn.Sql4Cds.Engine.Tests
+{
+    internal class SetStateMessageExecutor : IFakeMessageExecutor
+    {
+        public static string MessageName => "SetState";
+
+        public bool CanExecute(OrganizationRequest request)
+        {
+            return request.RequestName == MessageName;
+        }
+
+        public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
+        {
+            var lookup = (EntityReference)request.Parameters["EntityMoniker"];
+            var e = ctx.Data[lookup.LogicalName][lookup.Id];
+            e["statecode"] = ((OptionSetValue)request.Parameters["State"]).Value;
+            e["statuscode"] = ((OptionSetValue)request.Parameters["Status"]).Value;
+            return new OrganizationResponse();
+        }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(OrganizationRequest);
+        }
+    }
+}

--- a/MarkMpn.Sql4Cds.Engine.Tests/SqlVariantTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/SqlVariantTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlTypes;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MarkMpn.Sql4Cds.Engine.Tests
+{
+    [TestClass]
+    public class SqlVariantTests
+    {
+        [TestMethod]
+        public void NullSortsBeforeAllOtherValues()
+        {
+            Assert.IsTrue(SqlVariant.Null.CompareTo(SqlVariant.Null) == 0);
+            Assert.IsTrue(SqlVariant.Null.CompareTo(new SqlVariant(DataTypeHelpers.Int, new SqlInt32(1))) < 0);
+            Assert.IsTrue(new SqlVariant(DataTypeHelpers.Int, new SqlInt32(1)).CompareTo(SqlVariant.Null) > 0);
+        }
+
+        [TestMethod]
+        public void NullDoesNotEqualNull()
+        {
+            Assert.AreEqual(SqlVariant.Null == SqlVariant.Null, (SqlBoolean)false);
+        }
+
+        [TestMethod]
+        public void ValuesFromDifferentFamiliesAreNotEqual()
+        {
+            Assert.AreEqual(new SqlVariant(DataTypeHelpers.VarChar(1, Collation.USEnglish, CollationLabel.CoercibleDefault), Collation.USEnglish.ToSqlString("1")) == new SqlVariant(DataTypeHelpers.Int, new SqlInt32(1)), (SqlBoolean)false);
+        }
+
+        [TestMethod]
+        public void ValuesFromDifferentTypesInSameFamilyAreEqual()
+        {
+            Assert.AreEqual(new SqlVariant(DataTypeHelpers.BigInt, new SqlInt64(1)) == new SqlVariant(DataTypeHelpers.Int, new SqlInt32(1)), (SqlBoolean)true);
+        }
+
+        [TestMethod]
+        public void SortsAccordingToDataTypeFamilies()
+        {
+            var variant = SqlVariant.Null;
+            var dt = new SqlVariant(DataTypeHelpers.DateTime, new SqlDateTime(2000, 1, 1));
+            var approx = new SqlVariant(DataTypeHelpers.Float, new SqlSingle(1));
+            var exact = new SqlVariant(DataTypeHelpers.Int, new SqlInt32(1));
+            var ch = new SqlVariant(DataTypeHelpers.VarChar(10, Collation.USEnglish, CollationLabel.CoercibleDefault), Collation.USEnglish.ToSqlString("1"));
+            var nch = new SqlVariant(DataTypeHelpers.NVarChar(10, Collation.USEnglish, CollationLabel.CoercibleDefault), Collation.USEnglish.ToSqlString("1"));
+            var bin = new SqlVariant(DataTypeHelpers.VarBinary(10), new SqlBinary(new byte[] { 1 }));
+            var guid = new SqlVariant(DataTypeHelpers.UniqueIdentifier, new SqlGuid(Guid.NewGuid()));
+
+            var list = new List<SqlVariant> { variant, dt, approx, exact, ch, nch, bin, guid };
+            var rnd = new Random();
+
+            // Randomize the list, then sort it again
+            var randomized = list.OrderBy(obj => rnd.Next()).ToList();
+            randomized.Sort();
+
+            Assert.IsTrue(list.SequenceEqual(new[] { variant, dt, approx, exact, ch, nch, bin, guid }));
+        }
+    }
+}

--- a/MarkMpn.Sql4Cds.Engine.Tests/StubMessageCache.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/StubMessageCache.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using MarkMpn.Sql4Cds.Engine.ExecutionPlan;
+using Microsoft.Xrm.Sdk;
 
 namespace MarkMpn.Sql4Cds.Engine.Tests
 {
@@ -41,6 +42,32 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                         Type = typeof(int)
                     }
                 }.AsReadOnly()
+            };
+            _cache["SetState"] = new Message
+            {
+                Name = "SetState",
+                InputParameters = new List<MessageParameter>
+                {
+                    new MessageParameter
+                    {
+                        Name = "EntityMoniker",
+                        Position = 0,
+                        Type = typeof(EntityReference)
+                    },
+                    new MessageParameter
+                    {
+                        Name = "State",
+                        Position = 1,
+                        Type = typeof(OptionSetValue)
+                    },
+                    new MessageParameter
+                    {
+                        Name = "Status",
+                        Position = 2,
+                        Type = typeof(OptionSetValue)
+                    }
+                }.AsReadOnly(),
+                OutputParameters = new List<MessageParameter>().AsReadOnly()
             };
         }
 

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsCommand.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsCommand.cs
@@ -240,8 +240,8 @@ namespace MarkMpn.Sql4Cds.Engine
                 if (UseTDSEndpointDirectly)
                 {
 #if NETCOREAPP
-                var svc = (ServiceClient)_connection.DataSources[_connection.Database].Connection;
-                var con = new SqlConnection("server=" + svc.ConnectedOrgUriActual.Host);
+                    var svc = (ServiceClient)_connection.DataSources[_connection.Database].Connection;
+                    var con = new SqlConnection("server=" + svc.ConnectedOrgUriActual.Host);
 #else
                     var svc = (CrmServiceClient)_connection.DataSources[_connection.Database].Connection;
                     var con = new SqlConnection("server=" + svc.CrmConnectOrgUriActual.Host);

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 using System.Data.SqlTypes;
 using Microsoft.ApplicationInsights;
+using System.Reflection;
 #if NETCOREAPP
 using Microsoft.PowerPlatform.Dataverse.Client;
 #else
@@ -68,12 +69,16 @@ namespace MarkMpn.Sql4Cds.Engine
             _globalVariableTypes = new Dictionary<string, DataTypeReference>(StringComparer.OrdinalIgnoreCase)
             {
                 ["@@IDENTITY"] = DataTypeHelpers.EntityReference,
-                ["@@ROWCOUNT"] = DataTypeHelpers.Int
+                ["@@ROWCOUNT"] = DataTypeHelpers.Int,
+                ["@@SERVERNAME"] = DataTypeHelpers.NVarChar(100, _dataSources[_options.PrimaryDataSource].DefaultCollation, CollationLabel.CoercibleDefault),
+                ["@@VERSION"] = DataTypeHelpers.NVarChar(100, _dataSources[_options.PrimaryDataSource].DefaultCollation, CollationLabel.CoercibleDefault),
             };
             _globalVariableValues = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
             {
                 ["@@IDENTITY"] = SqlEntityReference.Null,
-                ["@@ROWCOUNT"] = (SqlInt32)0
+                ["@@ROWCOUNT"] = (SqlInt32)0,
+                ["@@SERVERNAME"] = GetServerName(_dataSources[_options.PrimaryDataSource]),
+                ["@@VERSION"] = GetVersion(_dataSources[_options.PrimaryDataSource])
             };
 
             _ai = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration("79761278-a908-4575-afbf-2f4d82560da6"));
@@ -84,6 +89,39 @@ namespace MarkMpn.Sql4Cds.Engine
                 ApplicationName = System.IO.Path.GetFileNameWithoutExtension(app.Location);
             else
                 ApplicationName = "SQL 4 CDS ADO.NET Provider";
+        }
+
+        private SqlString GetVersion(DataSource dataSource)
+        {
+            string orgVersion = null;
+
+#if NETCOREAPP
+            if (dataSource.Connection is ServiceClient svc)
+                orgVersion = svc.ConnectedOrgVersion.ToString();
+#else
+            if (dataSource.Connection is CrmServiceClient svc)
+                orgVersion = svc.ConnectedOrgVersion.ToString();
+#endif
+
+            if (orgVersion == null)
+                orgVersion = ((RetrieveVersionResponse)dataSource.Execute(new RetrieveVersionRequest())).Version;
+
+            var assembly = typeof(Sql4CdsConnection).Assembly;
+            var assemblyVersion = assembly.GetName().Version;
+            var assemblyCopyright = assembly
+                .GetCustomAttributes(typeof(AssemblyCopyrightAttribute), false)
+                .OfType<AssemblyCopyrightAttribute>()
+                .FirstOrDefault()?
+                .Copyright;
+            var assemblyFilename = assembly.Location;
+            var assemblyDate = System.IO.File.GetLastWriteTime(assemblyFilename);
+
+            return $"SQL 4 CDS - {assemblyVersion}   {assemblyDate}   {assemblyCopyright} (connected org version {orgVersion})";
+        }
+
+        private SqlString GetServerName(DataSource dataSource)
+        {
+            return dataSource.Name;
         }
 
         private static IOrganizationService Connect(string connectionString)

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
@@ -71,7 +71,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 ["@@IDENTITY"] = DataTypeHelpers.EntityReference,
                 ["@@ROWCOUNT"] = DataTypeHelpers.Int,
                 ["@@SERVERNAME"] = DataTypeHelpers.NVarChar(100, _dataSources[_options.PrimaryDataSource].DefaultCollation, CollationLabel.CoercibleDefault),
-                ["@@VERSION"] = DataTypeHelpers.NVarChar(100, _dataSources[_options.PrimaryDataSource].DefaultCollation, CollationLabel.CoercibleDefault),
+                ["@@VERSION"] = DataTypeHelpers.NVarChar(Int32.MaxValue, _dataSources[_options.PrimaryDataSource].DefaultCollation, CollationLabel.CoercibleDefault),
             };
             _globalVariableValues = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
             {
@@ -116,7 +116,7 @@ namespace MarkMpn.Sql4Cds.Engine
             var assemblyFilename = assembly.Location;
             var assemblyDate = System.IO.File.GetLastWriteTime(assemblyFilename);
 
-            return $"SQL 4 CDS - {assemblyVersion}   {assemblyDate}   {assemblyCopyright} (connected org version {orgVersion})";
+            return $"Microsoft Dataverse - {orgVersion}\r\n\tSQL 4 CDS - {assemblyVersion}\r\n\t{assemblyDate:MMM dd yyyy HH:mm:ss}\r\n\t{assemblyCopyright}";
         }
 
         private SqlString GetServerName(DataSource dataSource)

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
@@ -121,6 +121,18 @@ namespace MarkMpn.Sql4Cds.Engine
 
         private SqlString GetServerName(DataSource dataSource)
         {
+#if NETCOREAPP
+            var svc = dataSource.Connection as ServiceClient;
+
+            if (svc != null)
+                return new Uri(svc.ConnectedOrgUriActual).Host;
+#else
+            var svc = dataSource.Connection as CrmServiceClient;
+
+            if (svc != null)
+                return svc.CrmConnectOrgUriActual.Host;
+#endif
+
             return dataSource.Name;
         }
 

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
@@ -125,7 +125,7 @@ namespace MarkMpn.Sql4Cds.Engine
             var svc = dataSource.Connection as ServiceClient;
 
             if (svc != null)
-                return new Uri(svc.ConnectedOrgUriActual).Host;
+                return svc.ConnectedOrgUriActual.Host;
 #else
             var svc = dataSource.Connection as CrmServiceClient;
 

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsParameter.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsParameter.cs
@@ -214,7 +214,10 @@ namespace MarkMpn.Sql4Cds.Engine
                         break;
 
                     case DbType.Object:
-                        _dataType = DataTypeHelpers.Object(GetValue().GetType());
+                        if (Value is EntityReference || Value is SqlEntityReference)
+                            _dataType = DataTypeHelpers.EntityReference;
+                        else
+                            _dataType = DataTypeHelpers.Object(GetValue().GetType());
                         break;
 
                     case DbType.SByte:

--- a/MarkMpn.Sql4Cds.Engine/Collation.cs
+++ b/MarkMpn.Sql4Cds.Engine/Collation.cs
@@ -11,7 +11,7 @@ namespace MarkMpn.Sql4Cds.Engine
     /// <summary>
     /// Describes a collation to be used to compare strings
     /// </summary>
-    class Collation
+    public class Collation
     {
         private static Dictionary<string, int> _collationNameToLcid;
 
@@ -41,7 +41,7 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <param name="lcid">The locale ID to use</param>
         /// <param name="compareOptions">Additional comparison options</param>
         /// <param name="description">A description of the collation for display purposes</param>
-        public Collation(string name, int lcid, SqlCompareOptions compareOptions, string description)
+        internal Collation(string name, int lcid, SqlCompareOptions compareOptions, string description)
         {
             Name = name;
             LCID = lcid;
@@ -89,7 +89,7 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <param name="lcid">The locale ID to use</param>
         /// <param name="caseSensitive">Indicates if comparisons are case sensitive</param>
         /// <param name="accentSensitive">Indicates if comparisons are accent sensitive</param>
-        public Collation(int lcid, bool caseSensitive, bool accentSensitive)
+        internal Collation(int lcid, bool caseSensitive, bool accentSensitive)
         {
             var compareOptions = SqlCompareOptions.IgnoreKanaType | SqlCompareOptions.IgnoreWidth;
 
@@ -120,12 +120,12 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <summary>
         /// Returns the locale ID to use when comparing strings
         /// </summary>
-        public int LCID { get; }
+        internal int LCID { get; }
 
         /// <summary>
         /// Returns the additional options to use when comparing strings
         /// </summary>
-        public SqlCompareOptions CompareOptions { get; }
+        internal SqlCompareOptions CompareOptions { get; }
 
         /// <summary>
         /// Returns the name of the collation
@@ -143,7 +143,7 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <summary>
         /// Returns the default collation to be used for system data
         /// </summary>
-        public static Collation USEnglish { get; }
+        internal static Collation USEnglish { get; }
 
         /// <summary>
         /// Attempts to parse the name of a collation to the corresponding details
@@ -151,7 +151,7 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <param name="name">The name of the collation to parse</param>
         /// <param name="coll">The details of the collation parsed from the <paramref name="name"/></param>
         /// <returns><c>true</c> if the <paramref name="name"/> could be parsed, or <c>false</c> otherwise</returns>
-        public static bool TryParse(string name, out Collation coll)
+        internal static bool TryParse(string name, out Collation coll)
         {
             var compareOptions = SqlCompareOptions.IgnoreKanaType | SqlCompareOptions.IgnoreWidth;
             var parts = name.Split('_');
@@ -328,7 +328,7 @@ namespace MarkMpn.Sql4Cds.Engine
         /// </summary>
         /// <param name="value">The string value to apply the collation to</param>
         /// <returns>A new <see cref="SqlString"/> value with the given string <paramref name="value"/> and the current collation</returns>
-        public SqlString ToSqlString(string value)
+        internal SqlString ToSqlString(string value)
         {
             return new SqlString(value, LCID, CompareOptions);
         }

--- a/MarkMpn.Sql4Cds.Engine/DataTypeHelpers.cs
+++ b/MarkMpn.Sql4Cds.Engine/DataTypeHelpers.cs
@@ -72,7 +72,12 @@ namespace MarkMpn.Sql4Cds.Engine
 
         public static UserDataTypeReference Object(Type type)
         {
-            return new UserDataTypeReference { Name = new SchemaObjectName { Identifiers = { new Identifier { Value = type.FullName } } } };
+            return Object(type.FullName);
+        }
+
+        private static UserDataTypeReference Object(string name)
+        {
+            return new UserDataTypeReference { Name = new SchemaObjectName { Identifiers = { new Identifier { Value = name } } } };
         }
 
         public static SqlDataTypeReference Float { get; } = new SqlDataTypeReference { SqlDataTypeOption = SqlDataTypeOption.Float };
@@ -92,7 +97,7 @@ namespace MarkMpn.Sql4Cds.Engine
             return new SqlDataTypeReference { SqlDataTypeOption = SqlDataTypeOption.Time, Parameters = { new IntegerLiteral { Value = scale.ToString(CultureInfo.InvariantCulture) } } };
         }
 
-        public static UserDataTypeReference EntityReference { get; } = Object(typeof(SqlEntityReference));
+        public static UserDataTypeReference EntityReference { get; } = Object(nameof(EntityReference));
 
         public static XmlDataTypeReference Xml { get; } = new XmlDataTypeReference();
 
@@ -241,7 +246,7 @@ namespace MarkMpn.Sql4Cds.Engine
         {
             if (!(type is SqlDataTypeReference dataType))
             {
-                if (type is UserDataTypeReference udt && udt.Name.BaseIdentifier.Value == typeof(SqlEntityReference).FullName)
+                if (type.IsSameAs(EntityReference))
                     dataType = new SqlDataTypeReference { SqlDataTypeOption = SqlDataTypeOption.UniqueIdentifier };
                 else if (type is XmlDataTypeReference)
                     return Int32.MaxValue;

--- a/MarkMpn.Sql4Cds.Engine/DataTypeHelpers.cs
+++ b/MarkMpn.Sql4Cds.Engine/DataTypeHelpers.cs
@@ -96,6 +96,71 @@ namespace MarkMpn.Sql4Cds.Engine
 
         public static XmlDataTypeReference Xml { get; } = new XmlDataTypeReference();
 
+        public static SqlDataTypeReference Variant { get; } = new SqlDataTypeReference { SqlDataTypeOption = SqlDataTypeOption.Sql_Variant };
+
+        /// <summary>
+        /// Gets the data type family the type belongs to.
+        /// </summary>
+        /// <param name="type">The type to get the family for</param>
+        /// <returns>The family of the data type</returns>
+        /// <remarks>
+        /// Uses the definitions from https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16#data-type-categories
+        /// </remarks>
+        public static DataTypeFamily GetDataTypeFamily(this DataTypeReference type)
+        {
+            if (type is SqlDataTypeReference sqlType)
+            {
+                switch (sqlType.SqlDataTypeOption)
+                {
+                    case SqlDataTypeOption.BigInt:
+                    case SqlDataTypeOption.Bit:
+                    case SqlDataTypeOption.Decimal:
+                    case SqlDataTypeOption.Int:
+                    case SqlDataTypeOption.Money:
+                    case SqlDataTypeOption.Numeric:
+                    case SqlDataTypeOption.SmallInt:
+                    case SqlDataTypeOption.SmallMoney:
+                    case SqlDataTypeOption.TinyInt:
+                        return DataTypeFamily.ExactNumeric;
+
+                    case SqlDataTypeOption.Float:
+                    case SqlDataTypeOption.Real:
+                        return DataTypeFamily.ApproximateNumeric;
+
+                    case SqlDataTypeOption.Date:
+                    case SqlDataTypeOption.DateTime2:
+                    case SqlDataTypeOption.DateTime:
+                    case SqlDataTypeOption.DateTimeOffset:
+                    case SqlDataTypeOption.SmallDateTime:
+                    case SqlDataTypeOption.Time:
+                        return DataTypeFamily.DateTime;
+
+                    case SqlDataTypeOption.Char:
+                    case SqlDataTypeOption.Text:
+                    case SqlDataTypeOption.VarChar:
+                        return DataTypeFamily.Character;
+
+                    case SqlDataTypeOption.NChar:
+                    case SqlDataTypeOption.NText:
+                    case SqlDataTypeOption.NVarChar:
+                        return DataTypeFamily.UnicodeCharacter;
+
+                    case SqlDataTypeOption.Binary:
+                    case SqlDataTypeOption.Image:
+                    case SqlDataTypeOption.VarBinary:
+                        return DataTypeFamily.Binary;
+
+                    default:
+                        return DataTypeFamily.Other;
+                }
+            }
+
+            if (type is UserDataTypeReference)
+                return DataTypeFamily.Custom;
+
+            return DataTypeFamily.Other;
+        }
+
         /// <summary>
         /// Checks if a type represents an exact numeric type
         /// </summary>
@@ -635,5 +700,18 @@ namespace MarkMpn.Sql4Cds.Engine
         Implicit,
         Explicit,
         NoCollation
+    }
+
+    enum DataTypeFamily
+    {
+        Variant,
+        DateTime,
+        ApproximateNumeric,
+        ExactNumeric,
+        Character,
+        UnicodeCharacter,
+        Binary,
+        Other,
+        Custom
     }
 }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
@@ -56,7 +56,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// </summary>
         /// <param name="context">The context in which the node is being executed</param>
         /// <returns>A stream of <see cref="Entity"/> records</returns>
-        public IEnumerable<Entity> Execute(NodeExecutionContext context)
+        public virtual IEnumerable<Entity> Execute(NodeExecutionContext context)
         {
             if (context.Options.CancellationToken.IsCancellationRequested)
                 yield break;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
@@ -249,6 +249,17 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 return TranslateFetchXMLCriteria(context, metadata, paren.Expression, schema, allowedPrefix, targetEntityName, targetEntityAlias, items, out condition, out filter);
             }
 
+            if (criteria is DistinctPredicate distinct)
+            {
+                // Same logic as = or <> but without the null check
+                criteria = new BooleanComparisonExpression
+                {
+                    FirstExpression = distinct.FirstExpression,
+                    SecondExpression = distinct.SecondExpression,
+                    ComparisonType = distinct.IsNot ? BooleanComparisonType.IsNotDistinctFrom : BooleanComparisonType.IsDistinctFrom
+                };
+            }
+
             if (criteria is BooleanComparisonExpression comparison)
             {
                 // Handle most comparison operators (=, <> etc.)
@@ -318,6 +329,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 switch (type)
                 {
                     case BooleanComparisonType.Equals:
+                    case BooleanComparisonType.IsNotDistinctFrom:
                         op = @operator.eq;
                         break;
 
@@ -339,6 +351,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                     case BooleanComparisonType.NotEqualToBrackets:
                     case BooleanComparisonType.NotEqualToExclamation:
+                    case BooleanComparisonType.IsDistinctFrom:
                         op = @operator.ne;
                         break;
 
@@ -362,7 +375,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 }
                 else if (func != null && Enum.TryParse<@operator>(func.FunctionName.Value.ToLower(), out var customOperator))
                 {
-                    if (op == @operator.eq)
+                    if (type == BooleanComparisonType.Equals)
                     {
                         // If we've got the pattern `column = func()`, select the FetchXML operator from the function name
                         op = customOperator;
@@ -465,7 +478,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                 if (field2 == null)
                 {
-                    return TranslateFetchXMLCriteriaWithVirtualAttributes(context, meta, entityAlias, attrName, op, values, metadata, targetEntityAlias, items, out condition, out filter);
+                    return TranslateFetchXMLCriteriaWithVirtualAttributes(context, meta, entityAlias, attrName, type, op, values, metadata, targetEntityAlias, items, out condition, out filter);
                 }
                 else
                 {
@@ -497,6 +510,91 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         @operator = op,
                         ValueOf = RemoveAttributeAlias(attrName2, entityAlias, targetEntityAlias, items)
                     };
+
+                    if (op == @operator.ne && type == BooleanComparisonType.IsDistinctFrom)
+                    {
+                        // Need to also allow null values
+                        filter = new filter
+                        {
+                            type = filterType.or,
+                            Items = new object[]
+                            {
+                                condition,
+                                new filter
+                                {
+                                    type = filterType.and,
+                                    Items = new object[]
+                                    {
+                                        new condition
+                                        {
+                                            entityname = StandardizeAlias(entityAlias, targetEntityAlias, items),
+                                            attribute = RemoveAttributeAlias(attrName, entityAlias, targetEntityAlias, items),
+                                            @operator = @operator.notnull
+                                        },
+                                        new condition
+                                        {
+                                            entityname = StandardizeAlias(entityAlias, targetEntityAlias, items),
+                                            attribute = RemoveAttributeAlias(attrName2, entityAlias, targetEntityAlias, items),
+                                            @operator = @operator.@null
+                                        }
+                                    }
+                                },
+                                new filter
+                                {
+                                    type = filterType.and,
+                                    Items = new object[]
+                                    {
+                                        new condition
+                                        {
+                                            entityname = StandardizeAlias(entityAlias, targetEntityAlias, items),
+                                            attribute = RemoveAttributeAlias(attrName, entityAlias, targetEntityAlias, items),
+                                            @operator = @operator.@null
+                                        },
+                                        new condition
+                                        {
+                                            entityname = StandardizeAlias(entityAlias, targetEntityAlias, items),
+                                            attribute = RemoveAttributeAlias(attrName2, entityAlias, targetEntityAlias, items),
+                                            @operator = @operator.notnull
+                                        }
+                                    }
+                                }
+                            }
+                        };
+                        condition = null;
+                    }
+                    else if (op == @operator.eq && type == BooleanComparisonType.IsNotDistinctFrom)
+                    {
+                        // Need to also allow null values
+                        filter = new filter
+                        {
+                            type = filterType.or,
+                            Items = new object[]
+                            {
+                                condition,
+                                new filter
+                                {
+                                    type = filterType.and,
+                                    Items = new object[]
+                                    {
+                                        new condition
+                                        {
+                                            entityname = StandardizeAlias(entityAlias, targetEntityAlias, items),
+                                            attribute = RemoveAttributeAlias(attrName, entityAlias, targetEntityAlias, items),
+                                            @operator = @operator.@null
+                                        },
+                                        new condition
+                                        {
+                                            entityname = StandardizeAlias(entityAlias, targetEntityAlias, items),
+                                            attribute = RemoveAttributeAlias(attrName2, entityAlias, targetEntityAlias, items),
+                                            @operator = @operator.@null
+                                        }
+                                    }
+                                }
+                            }
+                        };
+                        condition = null;
+                    }
+
                     return true;
                 }
             }
@@ -532,7 +630,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                 var meta = metadata[entityName];
 
-                return TranslateFetchXMLCriteriaWithVirtualAttributes(context, meta, entityAlias, attrName, inPred.NotDefined ? @operator.notin : @operator.@in, inPred.Values.Cast<Literal>().ToArray(), metadata, targetEntityAlias, items, out condition, out filter);
+                return TranslateFetchXMLCriteriaWithVirtualAttributes(context, meta, entityAlias, attrName, null, inPred.NotDefined ? @operator.notin : @operator.@in, inPred.Values.Cast<Literal>().ToArray(), metadata, targetEntityAlias, items, out condition, out filter);
             }
 
             if (criteria is BooleanIsNullExpression isNull)
@@ -559,7 +657,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                 var meta = metadata[entityName];
 
-                return TranslateFetchXMLCriteriaWithVirtualAttributes(context, meta, entityAlias, attrName, isNull.IsNot ? @operator.notnull : @operator.@null, null, metadata, targetEntityAlias, items, out condition, out filter);
+                return TranslateFetchXMLCriteriaWithVirtualAttributes(context, meta, entityAlias, attrName, null, isNull.IsNot ? @operator.notnull : @operator.@null, null, metadata, targetEntityAlias, items, out condition, out filter);
             }
 
             if (criteria is LikePredicate like)
@@ -592,7 +690,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                 var meta = metadata[entityName];
 
-                return TranslateFetchXMLCriteriaWithVirtualAttributes(context, meta, entityAlias, attrName, like.NotDefined ? @operator.notlike : @operator.like, new[] { value }, metadata, targetEntityAlias, items, out condition, out filter);
+                return TranslateFetchXMLCriteriaWithVirtualAttributes(context, meta, entityAlias, attrName, null, like.NotDefined ? @operator.notlike : @operator.like, new[] { value }, metadata, targetEntityAlias, items, out condition, out filter);
             }
 
             if (criteria is FullTextPredicate ||
@@ -643,7 +741,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 if (!(attr is MultiSelectPicklistAttributeMetadata))
                     return false;
 
-                return TranslateFetchXMLCriteriaWithVirtualAttributes(context, meta, entityAlias, attrName, not == null ? @operator.containvalues : @operator.notcontainvalues, valueParts.Select(v => new IntegerLiteral { Value = v }).ToArray(), metadata, targetEntityAlias, items, out condition, out filter);
+                return TranslateFetchXMLCriteriaWithVirtualAttributes(context, meta, entityAlias, attrName, null, not == null ? @operator.containvalues : @operator.notcontainvalues, valueParts.Select(v => new IntegerLiteral { Value = v }).ToArray(), metadata, targetEntityAlias, items, out condition, out filter);
             }
 
             return false;
@@ -683,6 +781,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// <param name="meta">The metadata for the target entity the condition is for</param>
         /// <param name="entityAlias">The alias of the entity in the query the condition is for</param>
         /// <param name="attrName">The logical name of the attribute the condition is for</param>
+        /// <param name="type">The original SQL comparison type</param>
         /// <param name="op">The condition operator to apply</param>
         /// <param name="literals">The values to compare the attribute value to</param>
         /// <param name="metadata">The <see cref="IAttributeMetadataCache"/> to use to get metadata</param>
@@ -691,7 +790,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// <param name="filter">The FetchXML version of the <paramref name="criteria"/> that is generated by this method when it covers multiple conditions</param>
         /// <param name="condition">The FetchXML version of the <paramref name="criteria"/> that is generated by this method when it is for a single condition only</param>
         /// <returns><c>true</c> if the condition can be translated to FetchXML, or <c>false</c> otherwise</returns>
-        private bool TranslateFetchXMLCriteriaWithVirtualAttributes(NodeCompilationContext context, EntityMetadata meta, string entityAlias, string attrName, @operator op, ValueExpression[] literals, IAttributeMetadataCache metadata, string targetEntityAlias, object[] items, out condition condition, out filter filter)
+        private bool TranslateFetchXMLCriteriaWithVirtualAttributes(NodeCompilationContext context, EntityMetadata meta, string entityAlias, string attrName, BooleanComparisonType? type, @operator op, ValueExpression[] literals, IAttributeMetadataCache metadata, string targetEntityAlias, object[] items, out condition condition, out filter filter)
         {
             condition = null;
             filter = null;
@@ -721,17 +820,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             // Can't fold queries on PartyList attributes
             if (attribute != null && attribute.AttributeType == AttributeTypeCode.PartyList)
                 return false;
-
+            
             var values = literals == null ? null : literals
                 .Select(lit => new conditionValue
                 {
-                    Value = lit is Literal lit1
-                    ? lit1.Value
-                    : lit is VariableReference var1
-                        ? var1.Name
-                        : lit is GlobalVariableExpression glob
-                            ? glob.Name
-                            : null,
+                    Value = lit is NullLiteral nullLit ? null
+                        : lit is Literal lit1 ? lit1.Value
+                        : lit is VariableReference var1 ? var1.Name
+                        : lit is GlobalVariableExpression glob ? glob.Name
+                        : null,
                     IsVariable = lit is VariableReference || lit is GlobalVariableExpression
                 })
                 .ToArray();
@@ -740,6 +837,17 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             var isVariable = values == null || values.Length != 1 ? false : values[0].IsVariable;
 
             var usesItems = values != null && values.Length > 1 || op == @operator.@in || op == @operator.notin || op == @operator.containvalues || op == @operator.notcontainvalues;
+
+            // col = null etc. is always false. Can't be translated to FetchXML. But col IS [NOT] DISTINCT FROM null can be translated.
+            if (!usesItems && values != null && values.Length == 1 && value == null)
+            {
+                if (op == @operator.ne && type == BooleanComparisonType.IsDistinctFrom)
+                    op = @operator.notnull;
+                else if (op == @operator.eq && type == BooleanComparisonType.IsNotDistinctFrom)
+                    op = @operator.@null;
+                else
+                    return false;
+            }
 
             if (attribute is DateTimeAttributeMetadata && literals != null &&
                 (op == @operator.eq || op == @operator.ne || op == @operator.neq || op == @operator.gt || op == @operator.ge || op == @operator.lt || op == @operator.le || op == @operator.@in || op == @operator.notin))
@@ -930,7 +1038,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (meta.LogicalName == "solution" && linkName != null && !new FetchEntityType { Items = items }.GetLinkEntities(true).Any(link => link.alias == linkName))
                 return false;
 
-            if (op == @operator.ne || op == @operator.nebusinessid || op == @operator.neq || op == @operator.neuserid)
+            if ((op == @operator.ne || op == @operator.nebusinessid || op == @operator.neq || op == @operator.neuserid) && type != BooleanComparisonType.IsDistinctFrom)
             {
                 // FetchXML not-equal type operators treat NULL as not-equal to values, but T-SQL treats them as not-not-equal. Add
                 // an extra not-null condition to keep it compatible with T-SQL

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDataNode.cs
@@ -493,9 +493,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     condition = new condition
                     {
                         entityname = StandardizeAlias(entityAlias, targetEntityAlias, items),
-                        attribute = RemoveAttributeAlias(attrName.ToLowerInvariant(), entityAlias, targetEntityAlias, items),
+                        attribute = RemoveAttributeAlias(attrName, entityAlias, targetEntityAlias, items),
                         @operator = op,
-                        ValueOf = RemoveAttributeAlias(attrName2.ToLowerInvariant(), entityAlias, targetEntityAlias, items)
+                        ValueOf = RemoveAttributeAlias(attrName2, entityAlias, targetEntityAlias, items)
                     };
                     return true;
                 }
@@ -917,7 +917,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             condition = new condition
             {
                 entityname = StandardizeAlias(entityAlias, targetEntityAlias, items),
-                attribute = attrName.ToLowerInvariant(),
+                attribute = attrName,
                 @operator = op,
                 value = usesItems ? null : value,
                 Items = usesItems ? values : null,

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
@@ -419,8 +419,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     {
                         if (sourceSqlType.IsSameAs(DataTypeHelpers.EntityReference))
                         {
+                            convertedExpr = expr;
                             expr = originalExpr;
-                            convertedExpr = SqlTypeConverter.Convert(expr, sourceSqlType, sourceSqlType);
                             convertedExpr = SqlTypeConverter.Convert(convertedExpr, typeof(EntityReference));
                         }
                         else if (sourceSqlType == DataTypeHelpers.ImplicitIntForNullLiteral)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
@@ -720,10 +720,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             if (error != null)
             {
-                if (ContinueOnError)
-                    fault = fault ?? error.Fault;
-                else
-                    throw new ApplicationException($"Error {operationNames.InProgressLowercase} {GetDisplayName(0, meta)} - " + error.Fault.Message);
+                fault = fault ?? error.Fault;
+
+                if (!ContinueOnError)
+                    throw new FaultException<OrganizationServiceFault>(fault, new FaultReason(fault.Message));
             }
         }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseJoinNode.cs
@@ -156,7 +156,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         nullable = false;
                     }
 
-                    schema[column.Key] = new ColumnDefinition(column.Value.Type, nullable, column.Value.IsCalculated);
+                    schema[column.Key] = new ColumnDefinition(column.Value.Type, nullable, column.Value.IsCalculated, column.Value.IsVisible);
                 }
 
                 foreach (var alias in subSchema.Aliases)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseJoinNode.cs
@@ -81,8 +81,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             if (leftEntity != null)
             {
-                foreach (var attr in leftEntity.Attributes)
-                    merged[attr.Key] = attr.Value;
+                foreach (var attr in leftSchema.Schema)
+                    merged[attr.Key] = leftEntity[attr.Key];
             }
             else
             {
@@ -92,8 +92,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             if (rightEntity != null)
             {
-                foreach (var attr in rightEntity.Attributes)
-                    merged[attr.Key] = attr.Value;
+                foreach (var attr in rightSchema.Schema)
+                    merged[attr.Key] = rightEntity[attr.Key];
             }
             else
             {

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/DeleteNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/DeleteNode.cs
@@ -263,6 +263,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         protected override ExecuteMultipleResponse ExecuteMultiple(DataSource dataSource, IOrganizationService org, EntityMetadata meta, ExecuteMultipleRequest req)
         {
+            if (!req.Requests.All(r => r is DeleteRequest))
+                return base.ExecuteMultiple(dataSource, org, meta, req);
+
             if (meta.DataProviderId == DataProviders.ElasticDataProvider || dataSource.MessageCache.IsMessageAvailable(meta.LogicalName, "DeleteMultiple"))
             {
                 // Elastic tables can use DeleteMultiple for better performance than ExecuteMultiple

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
@@ -441,10 +441,6 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 }
             }
 
-            // Prefix all attributes of the main entity with the expected alias
-            foreach (var attribute in entity.Attributes.ToList())
-                entity[PrefixWithAlias(attribute.Key)] = attribute.Value;
-
             // Expose the type of lookup values
             foreach (var attribute in entity.Attributes.Where(attr => attr.Value is EntityReference).ToList())
             {
@@ -470,6 +466,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                 entity[col.Key] = sqlValue;
             }
+
+            // Prefix all attributes of the main entity with the expected alias
+            foreach (var attribute in entity.Attributes.ToList())
+                entity[PrefixWithAlias(attribute.Key)] = attribute.Value;
         }
 
         public override object Clone()

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -1511,7 +1511,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             [SqlDataTypeOption.UniqueIdentifier] = typeof(SqlGuid),
             [SqlDataTypeOption.VarBinary] = typeof(SqlBinary),
             [SqlDataTypeOption.VarChar] = typeof(SqlString),
-            [SqlDataTypeOption.Sql_Variant] = typeof(object),
+            [SqlDataTypeOption.Sql_Variant] = typeof(SqlVariant),
         };
 
         /// <summary>
@@ -1581,6 +1581,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             [typeof(SqlDate)] = DataTypeHelpers.Date,
             [typeof(SqlTime)] = DataTypeHelpers.Time(7),
             [typeof(SqlXml)] = DataTypeHelpers.Xml,
+            [typeof(SqlVariant)] = DataTypeHelpers.Variant,
         };
 
         /// <summary>

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -200,11 +200,17 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// <summary>
         /// A list of table aliases that should be excluded from the schema
         /// </summary>
+        [Category("FetchXML Scan")]
+        [DisplayName("Hidden Aliases")]
+        [Description("A list of table aliases that should be excluded from the schema")]
         public List<string> HiddenAliases { get; } = new List<string>();
 
         /// <summary>
         /// A list of additional columns that should be included in the schema
         /// </summary>
+        [Category("FetchXML Scan")]
+        [DisplayName("Column Mappings")]
+        [Description("A list of additional columns that should be included in the schema")]
         public List<SelectColumn> ColumnMappings { get; } = new List<SelectColumn>();
 
         public bool RequiresCustomPaging(IDictionary<string, DataSource> dataSources)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -230,6 +230,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return false;
         }
 
+        public override IEnumerable<Entity> Execute(NodeExecutionContext context)
+        {
+            ReturnFullSchema = false;
+            return base.Execute(context);
+        }
+
         protected override IEnumerable<Entity> ExecuteInternal(NodeExecutionContext context)
         {
             PagesRetrieved = 0;
@@ -237,7 +243,6 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (!context.DataSources.TryGetValue(DataSource, out var dataSource))
                 throw new NotSupportedQueryFragmentException("Missing datasource " + DataSource);
 
-            ReturnFullSchema = false;
             var schema = GetSchema(context);
 
             ApplyParameterValues(context);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using MarkMpn.Sql4Cds.Engine.FetchXml;
+using MarkMpn.Sql4Cds.Engine.Visitors;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Metadata;
@@ -160,7 +161,76 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (Filter == null)
                 return Source;
 
+            if (FoldScalarSubqueries(out var nestedLoop))
+                return nestedLoop.FoldQuery(context, hints);
+
             return this;
+        }
+
+        private bool FoldScalarSubqueries(out NestedLoopNode nestedLoop)
+        {
+            // If we have a filter condition that uses a non-correlated scalar subquery, e.g.
+            //
+            // SELECT * FROM account WHERE primarycontactid = (SELECT contactid FROM contact WHERE firstname = 'Mark')
+            //
+            // this will produce a query plan that looks like:
+            //
+            // SELECT ━━ FILTER ━━ NESTED LOOP ━━ FETCHXML (account)
+            //                          ┕━━ TABLE SPOOL ━━ ASSERT ━━ STREAM AGGREGATE ━━ FETCHXML (contact)
+            //
+            // Because the subquery is uncorrelated, we can move the subquery to the outer query and use the result to
+            // fold the filter down to the source. This will produce a query plan that looks like:
+            //
+            // SELECT ━━ NESTED LOOP ━━ ASSERT ━━ STREAM AGGREGATE ━━ FETCHXML (contact)
+            //                ┕━━ FILTER ━━ FETCHXML (account)
+            //
+            // The filter may then be able to be folded into the source FetchXML
+
+            nestedLoop = null;
+
+            if (Source is NestedLoopNode sourceLoop &&
+                sourceLoop.JoinType == QualifiedJoinType.LeftOuter &&
+                sourceLoop.SemiJoin &&
+                sourceLoop.JoinCondition == null &&
+                sourceLoop.OuterReferences.Count == 0 &&
+                sourceLoop.DefinedValues.Count == 1 &&
+                Filter.GetColumns().Contains(sourceLoop.DefinedValues.Single().Key))
+            {
+                var scalarSubqueryCol = sourceLoop.DefinedValues.Single().Key;
+                var scalarSubquerySource = sourceLoop.DefinedValues.Single().Value;
+
+                // The filter would previously have been e.g. "primarycontactid = Expr1"
+                // Expr1 will now be provided to the inner loop as a parameter, so we need to rewrite the filter to use it as
+                // "primarycontactid = @Expr2"
+                var rewrite = new RewriteVisitor(new Dictionary<ScalarExpression, ScalarExpression>
+                {
+                    { new ColumnReferenceExpression { MultiPartIdentifier = new MultiPartIdentifier { Identifiers = { new Identifier { Value = scalarSubqueryCol } } } }, new VariableReference { Name = "@" + scalarSubqueryCol } }
+                });
+                var filter = Filter.Clone();
+                filter.Accept(rewrite);
+
+                nestedLoop = new NestedLoopNode
+                {
+                    JoinType = QualifiedJoinType.Inner,
+                    OuterReferences = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { scalarSubquerySource, "@" + scalarSubqueryCol }
+                    },
+                    LeftSource = sourceLoop.RightSource,
+                    RightSource = filter == null ? sourceLoop.LeftSource : new FilterNode
+                    {
+                        Filter = filter,
+                        Source = sourceLoop.LeftSource
+                    }
+                };
+
+                if (nestedLoop.LeftSource is TableSpoolNode subquerySpool)
+                    nestedLoop.LeftSource = subquerySpool.Source;
+
+                return true;
+            }
+
+            return false;
         }
 
         private void ConvertOuterJoinsWithNonNullFiltersToInnerJoins(NodeCompilationContext context)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
@@ -189,7 +189,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             nestedLoop = null;
 
             if (Source is NestedLoopNode sourceLoop &&
-                sourceLoop.JoinType == QualifiedJoinType.LeftOuter &&
+                (sourceLoop.JoinType == QualifiedJoinType.LeftOuter || sourceLoop.JoinType == QualifiedJoinType.Inner) &&
                 sourceLoop.SemiJoin &&
                 sourceLoop.JoinCondition == null &&
                 sourceLoop.OuterReferences.Count == 0 &&

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FoldableJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FoldableJoinNode.cs
@@ -390,7 +390,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 return true;
             }
 
+            foreach (var alias in rightFetch.HiddenAliases)
+                leftFetch.HiddenAliases.Add(alias);
+
+            foreach (var mapping in rightFetch.ColumnMappings)
+                leftFetch.ColumnMappings.Add(mapping);
+
             folded = leftFetch;
+
             return true;
         }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/InsertNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/InsertNode.cs
@@ -220,6 +220,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         protected override ExecuteMultipleResponse ExecuteMultiple(DataSource dataSource, IOrganizationService org, EntityMetadata meta, ExecuteMultipleRequest req)
         {
+            if (!req.Requests.All(r => r is CreateRequest))
+                return base.ExecuteMultiple(dataSource, org, meta, req);
+
             if (meta.DataProviderId == DataProviders.ElasticDataProvider || dataSource.MessageCache.IsMessageAvailable(meta.LogicalName, "CreateMultiple"))
             {
                 // Elastic tables can use CreateMultiple for better performance than ExecuteMultiple

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MergeJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MergeJoinNode.cs
@@ -21,6 +21,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         [Category("Merge Join")]
         public bool ManyToMany { get; private set; }
 
+        public MergeJoinNode() { }
+
         protected override IEnumerable<Entity> ExecuteInternal(NodeExecutionContext context)
         {
             // https://sqlserverfast.com/epr/merge-join/
@@ -215,6 +217,40 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (folded != this)
                 return folded;
 
+            // Can't use a merge join if the join key types have different sort orders
+            if (LeftAttribute != null && RightAttribute != null)
+            {
+                var leftSchema = LeftSource.GetSchema(context);
+                leftSchema.ContainsColumn(LeftAttribute.GetColumnName(), out var leftColumn);
+                var leftType = leftSchema.Schema[leftColumn].Type;
+                
+                var rightSchema = RightSource.GetSchema(context);
+                rightSchema.ContainsColumn(RightAttribute.GetColumnName(), out var rightColumn);
+                var rightType = rightSchema.Schema[rightColumn].Type;
+
+                if (!IsConsistentSortTypes(leftType, rightType))
+                {
+                    var hashJoin = new HashJoinNode
+                    {
+                        LeftSource = LeftSource,
+                        RightSource = RightSource,
+                        LeftAttribute = LeftAttribute,
+                        RightAttribute = RightAttribute,
+                        JoinType = JoinType,
+                        AdditionalJoinCriteria = AdditionalJoinCriteria,
+                        SemiJoin = SemiJoin
+                    };
+
+                    foreach (var kvp in DefinedValues)
+                        hashJoin.DefinedValues.Add(kvp);
+
+                    hashJoin.LeftSource.Parent = hashJoin;
+                    hashJoin.RightSource.Parent = hashJoin;
+
+                    return hashJoin;
+                }
+            }
+
             // This is a many-to-many join if the left attribute is not unique
             if (LeftAttribute == null)
             {
@@ -288,6 +324,36 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             }
 
             return this;
+        }
+
+        private bool IsConsistentSortTypes(DataTypeReference leftType, DataTypeReference rightType)
+        {
+            if (leftType.IsSameAs(rightType))
+                return true;
+
+            // Types can be different but have the same logical sort order, e.g. all numeric types
+            if (leftType.IsSameAs(DataTypeHelpers.UniqueIdentifier) && rightType.IsSameAs(DataTypeHelpers.EntityReference) ||
+                leftType.IsSameAs(DataTypeHelpers.EntityReference) && rightType.IsSameAs(DataTypeHelpers.UniqueIdentifier))
+                return true;
+
+            if (leftType is SqlDataTypeReference leftSqlType && rightType is SqlDataTypeReference rightSqlType)
+            {
+                if (leftSqlType.SqlDataTypeOption.IsNumeric() && rightSqlType.SqlDataTypeOption.IsNumeric())
+                    return true;
+
+                if (leftSqlType.SqlDataTypeOption.IsDateTimeType() && rightSqlType.SqlDataTypeOption.IsDateTimeType())
+                    return true;
+
+                // Collations need to be the same for string types, but can be different lengths
+                if (leftSqlType.SqlDataTypeOption.IsStringType() && rightSqlType.SqlDataTypeOption.IsStringType() &&
+                    leftType is SqlDataTypeReferenceWithCollation leftCollation && rightType is SqlDataTypeReferenceWithCollation rightCollation &&
+                    leftCollation.Collation.Equals(rightCollation.Collation))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         protected override IReadOnlyList<string> GetSortOrder(INodeSchema outerSchema, INodeSchema innerSchema)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MergeJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MergeJoinNode.cs
@@ -29,10 +29,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             // TODO: Handle union & concatenate
 
             // Left & Right: GetNext, mark as unmatched
-            var leftSchema = LeftSource.GetSchema(context);
-            var rightSchema = RightSource.GetSchema(context);
             var left = LeftSource.Execute(context).GetEnumerator().WithPeekAhead();
             var right = RightSource.Execute(context).GetEnumerator().WithPeekAhead();
+            var leftSchema = LeftSource.GetSchema(context);
+            var rightSchema = RightSource.GetSchema(context);
             var mergedSchema = GetSchema(context, true);
             var expressionCompilationContext = new ExpressionCompilationContext(context, mergedSchema, null);
             var expressionExecutionContext = new ExpressionExecutionContext(context);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MetadataQueryNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MetadataQueryNode.cs
@@ -738,13 +738,13 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             // Return null literal if final value is null
             if (!value.Type.IsValueType)
-                value = Expression.Condition(Expression.Equal(value, Expression.Constant(null)), Expression.Constant(SqlTypeConverter.GetNullValue(targetType)), converted);
+                value = Expression.Condition(Expression.Equal(value, Expression.Constant(null)), Expression.Constant(SqlTypeConverter.GetNullValue(targetType), targetType), converted);
             else
                 value = converted;
 
             // Return null literal if original value is null
             if (!prop.PropertyType.IsValueType || prop.PropertyType.IsGenericType && prop.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
-                value = Expression.Condition(Expression.Equal(Expression.Property(param, prop), Expression.Constant(null)), Expression.Constant(SqlTypeConverter.GetNullValue(targetType)), value);
+                value = Expression.Condition(Expression.Equal(Expression.Property(param, prop), Expression.Constant(null)), Expression.Constant(SqlTypeConverter.GetNullValue(targetType), targetType), value);
 
             // Compile the function
             value = Expr.Box(value);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/NestedLoopNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/NestedLoopNode.cs
@@ -195,7 +195,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 assert.Source is StreamAggregateNode aggregate &&
                 aggregate.Aggregates.Count == 2 &&
                 aggregate.Aggregates[DefinedValues.Single().Value].AggregateType == AggregateType.First &&
-                aggregate.Source is IndexSpoolNode indexSpool &&
+                aggregate.Source is TopNode top &&
+                top.Source is IndexSpoolNode indexSpool &&
                 indexSpool.Source is FetchXmlScan fetch &&
                 LeftSource.EstimateRowsOut(context).Value < 100 &&
                 fetch.EstimateRowsOut(innerContext).Value > 5000)
@@ -214,7 +215,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     },
                     Parent = aggregate
                 };
-                aggregate.Source = filter.FoldQuery(innerContext, hints);
+                top.Source = filter;
+                aggregate.Source = top.FoldQuery(innerContext, hints);
             }
 
             return this;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/NodeSchema.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/NodeSchema.cs
@@ -115,11 +115,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
     class ColumnDefinition : IColumnDefinition
     {
-        public ColumnDefinition(DataTypeReference type, bool isNullable, bool isCalculated)
+        public ColumnDefinition(DataTypeReference type, bool isNullable, bool isCalculated, bool isVisible = true)
         {
             Type = type;
             IsNullable = isNullable;
             IsCalculated = isCalculated;
+            IsVisible = isVisible;
         }
 
         public DataTypeReference Type { get; }
@@ -127,6 +128,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         public bool IsNullable { get; }
 
         public bool IsCalculated { get; }
+
+        public bool IsVisible { get; }
 
         public override string ToString()
         {
@@ -138,12 +141,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
     {
         public static IColumnDefinition NotNull(this IColumnDefinition col)
         {
-            return new ColumnDefinition(col.Type, false, col.IsCalculated);
+            return new ColumnDefinition(col.Type, false, col.IsCalculated, col.IsVisible);
         }
 
         public static IColumnDefinition Null(this IColumnDefinition col)
         {
-            return new ColumnDefinition(col.Type, true, col.IsCalculated);
+            return new ColumnDefinition(col.Type, true, col.IsCalculated, col.IsVisible);
         }
     }
 
@@ -207,6 +210,11 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// Indicates if the column is the result of an internal calculation
         /// </summary>
         bool IsCalculated { get; }
+
+        /// <summary>
+        /// Indicates if the column is visible to the user for use in the SELECT clause
+        /// </summary>
+        bool IsVisible { get; }
     }
 
     class ColumnList : IDictionary<string, IColumnDefinition>, IReadOnlyDictionary<string, IColumnDefinition>

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SelectDataReader.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SelectDataReader.cs
@@ -252,10 +252,13 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 var column = _columnSet[i];
                 var sqlType = _schema.Schema[_columnSet[i].SourceColumn].Type;
                 var providerType = sqlType.ToNetType(out _);
-                var type = providerType == typeof(SqlEntityReference) || providerType == typeof(SqlXml) ? providerType : SqlTypeConverter.SqlToNetType(providerType);
+                var type = providerType == typeof(SqlEntityReference) || providerType == typeof(SqlXml) ? providerType : providerType == typeof(SqlVariant) ? typeof(object) : SqlTypeConverter.SqlToNetType(providerType);
                 var size = sqlType.GetSize();
                 var precision = sqlType.GetPrecision(255);
                 var scale = sqlType.GetScale(255);
+
+                if (providerType == typeof(SqlVariant))
+                    providerType = typeof(object);
 
                 schemaTable.Rows.Add(new object[]
                 {

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SortNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SortNode.cs
@@ -301,7 +301,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         entityName = FindEntityWithAttributeAlias(fetchXml, attrName);
                     }
 
-                    var fetchSort = new FetchOrderType { attribute = attrName.ToLowerInvariant(), descending = sortOrder.SortOrder == SortOrder.Descending };
+                    var fetchSort = new FetchOrderType { attribute = attrName, descending = sortOrder.SortOrder == SortOrder.Descending };
 
                     if (fetchXml.FetchXml.aggregate)
                     {

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SqlTypeConverter.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/SqlTypeConverter.cs
@@ -82,7 +82,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 [typeof(SqlDateTimeOffset)] = SqlDateTimeOffset.Null,
                 [typeof(SqlTime)] = SqlTime.Null,
                 [typeof(SqlXml)] = SqlXml.Null,
-                [typeof(object)] = null
+                [typeof(SqlVariant)] = SqlVariant.Null
             };
 
             _hijriCulture = (CultureInfo)CultureInfo.GetCultureInfo("ar-JO").Clone();
@@ -416,6 +416,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (fromType == SqlDataTypeOption.UniqueIdentifier && fromUser != null && toType == SqlDataTypeOption.UniqueIdentifier)
                 return true;
 
+            // Anything can be converted to sql_variant except timestamp, image, text, ntext, xml and hierarchyid
+            if (toType == SqlDataTypeOption.Sql_Variant &&
+                fromType != SqlDataTypeOption.Timestamp &&
+                fromType != SqlDataTypeOption.Image &&
+                fromType != SqlDataTypeOption.Text &&
+                fromType != SqlDataTypeOption.NText)
+                return true;
+
             return false;
         }
 
@@ -445,6 +453,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             // Require explicit conversion from xml to string/binary types
             if (fromXml != null && toSql != null && (toSql.SqlDataTypeOption.IsStringType() || toSql.SqlDataTypeOption == SqlDataTypeOption.Binary || toSql.SqlDataTypeOption == SqlDataTypeOption.VarBinary))
+                return true;
+
+            // Require explicit conversion from sql_variant to everything other than timestamp, image, text, ntext, xml and hierarchyid
+            if (fromSql?.SqlDataTypeOption == SqlDataTypeOption.Sql_Variant &&
+                toSql != null &&
+                toSql.SqlDataTypeOption != SqlDataTypeOption.Timestamp &&
+                toSql.SqlDataTypeOption != SqlDataTypeOption.Image &&
+                toSql.SqlDataTypeOption != SqlDataTypeOption.Text &&
+                toSql.SqlDataTypeOption != SqlDataTypeOption.NText)
                 return true;
 
             return false;
@@ -549,6 +566,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// <returns>An expression to generate values of the required type</returns>
         public static Expression Convert(Expression expr, DataTypeReference from, DataTypeReference to, Expression style = null, DataTypeReference styleType = null, ConvertCall convert = null)
         {
+            if (from.IsSameAs(to))
+                return expr;
+
             from.ToNetType(out var fromSqlType);
             var targetType = to.ToNetType(out var toSqlType);
 
@@ -573,6 +593,19 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             if (!CanChangeTypeImplicit(styleType, DataTypeHelpers.Int))
                 throw new NotSupportedQueryFragmentException($"No type conversion available from {styleType.ToSql()} to {DataTypeHelpers.Int.ToSql()}", convert.Style);
+
+            // Special case for conversion to sql_variant
+            if (to.IsSameAs(DataTypeHelpers.Variant))
+            {
+                var ctor = typeof(SqlVariant).GetConstructor(new[] { typeof(DataTypeReference), typeof(INullable) });
+                return Expression.New(ctor, Expression.Constant(from), Expression.Convert(expr, typeof(INullable)));
+            }
+
+            // Special case for conversion from sql_variant
+            if (from.IsSameAs(DataTypeHelpers.Variant))
+            {
+                return Expression.Convert(Expr.Call(() => Convert(Expr.Arg<SqlVariant>(), Expr.Arg<DataTypeReference>(), Expr.Arg<SqlInt32>()), expr, Expression.Constant(to), style), targetType);
+            }
 
             var targetCollation = (to as SqlDataTypeReferenceWithCollation)?.Collation;
 
@@ -1052,6 +1085,28 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         }
 
         /// <summary>
+        /// Specialized type conversion from sql_variant to a target type
+        /// </summary>
+        /// <param name="variant">The variant to convert</param>
+        /// <param name="targetType">The type to convert to</param>
+        /// <param name="style">The style of the conversion</param>
+        /// <returns>The underlying value of the variant converted to the target type</returns>
+        private static INullable Convert(SqlVariant variant, DataTypeReference targetType, SqlInt32 style)
+        {
+            if (variant.BaseType == null)
+                return GetNullValue(targetType.ToNetType(out _));
+
+            if (variant.BaseType.IsSameAs(targetType))
+                return variant.Value;
+
+            if (!CanChangeTypeExplicit(variant.BaseType, targetType))
+                throw new QueryExecutionException($"No type conversion available from {variant.BaseType.ToSql()} to {targetType.ToSql()}");
+
+            var conversion = GetConversion(variant.BaseType, targetType, style.IsNull ? (int?)null : style.Value);
+            return conversion(variant.Value);
+        }
+
+        /// <summary>
         /// Converts a standard CLR type to the equivalent SQL type
         /// </summary>
         /// <param name="type">The CLR type to convert from</param>
@@ -1064,7 +1119,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             var originalType = type;
             type = type.BaseType;
 
-            while (type != null)
+            while (type != null && type != typeof(object))
             {
                 if (_netToSqlTypeConversions.TryGetValue(type, out sqlType))
                 {
@@ -1248,8 +1303,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// </summary>
         /// <param name="sourceType">The type to convert from</param>
         /// <param name="destType">The type to convert to</param>
+        /// <param name="style">The style of the converesion</param>
         /// <returns>A function that converts between the requested types</returns>
-        public static Func<INullable, INullable> GetConversion(DataTypeReference sourceType, DataTypeReference destType)
+        public static Func<INullable, INullable> GetConversion(DataTypeReference sourceType, DataTypeReference destType, int? style = null)
         {
             var key = sourceType.ToSql() + " -> " + destType.ToSql();
 
@@ -1260,11 +1316,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 else
                     key += " COLLATE " + collation.Collation.LCID + ":" + collation.Collation.CompareOptions;
             }
+
+            if (style != null)
+                key += " STYLE " + style;
             
-            return _sqlConversions.GetOrAdd(key, _ => CompileConversion(sourceType, destType));
+            return _sqlConversions.GetOrAdd(key, _ => CompileConversion(sourceType, destType, style));
         }
 
-        private static Func<INullable, INullable> CompileConversion(DataTypeReference sourceType, DataTypeReference destType)
+        private static Func<INullable, INullable> CompileConversion(DataTypeReference sourceType, DataTypeReference destType, int? style = null)
         {
             if (sourceType.IsSameAs(destType))
                 return (INullable value) => value;
@@ -1274,7 +1333,16 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             var param = Expression.Parameter(typeof(INullable));
             var expression = (Expression)Expression.Convert(param, sourceNetType);
-            expression = Convert(expression, sourceType, destType);
+            var styleExpr = (Expression)null;
+            var styleType = (DataTypeReference)null;
+
+            if (style != null)
+            {
+                styleExpr = Expression.Constant(new SqlInt32(style.Value));
+                styleType = DataTypeHelpers.Int;
+            }
+
+            expression = Convert(expression, sourceType, destType, styleExpr, styleType);
             expression = Expression.Convert(expression, typeof(INullable));
             return Expression.Lambda<Func<INullable, INullable>>(expression, param).Compile();
         }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/UpdateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/UpdateNode.cs
@@ -403,6 +403,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         protected override ExecuteMultipleResponse ExecuteMultiple(DataSource dataSource, IOrganizationService org, EntityMetadata meta, ExecuteMultipleRequest req)
         {
+            if (!req.Requests.All(r => r is UpdateRequest))
+                return base.ExecuteMultiple(dataSource, org, meta, req);
+
             if (meta.DataProviderId == DataProviders.ElasticDataProvider || dataSource.MessageCache.IsMessageAvailable(meta.LogicalName, "UpdateMultiple"))
             {
                 // Elastic tables can use UpdateMultiple for better performance than ExecuteMultiple

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -3049,21 +3049,20 @@ namespace MarkMpn.Sql4Cds.Engine
                         };
                         loopRightSource = top;
                         
-                        subqueryCol = context.GetExpressionName();
                         var rowCountCol = context.GetExpressionName();
                         var aggregate = new HashMatchAggregateNode
                         {
                             Source = loopRightSource,
                             Aggregates =
                             {
-                                [subqueryCol] = new Aggregate
+                                [outputcol] = new Aggregate
                                 {
                                     AggregateType = AggregateType.First,
                                     SqlExpression = new ColumnReferenceExpression
                                     {
                                         MultiPartIdentifier = new MultiPartIdentifier
                                         {
-                                            Identifiers = { new Identifier { Value = subqueryPlan.ColumnSet[0].SourceColumn } }
+                                            Identifiers = { new Identifier { Value = subqueryCol } }
                                         }
                                     }
                                 },
@@ -3108,7 +3107,7 @@ namespace MarkMpn.Sql4Cds.Engine
                             JoinType = QualifiedJoinType.LeftOuter,
                             SemiJoin = true,
                             OutputRightSchema = false,
-                            DefinedValues = { [outputcol] = subqueryCol }
+                            DefinedValues = { [outputcol] = outputcol }
                         };
                     }
                 }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -3118,7 +3118,7 @@ namespace MarkMpn.Sql4Cds.Engine
             return null;
         }
 
-        private bool UseMergeJoin(IDataExecutionPlanNodeInternal node, IDataExecutionPlanNode subqueryPlan, NodeCompilationContext context, Dictionary<string, string> outerReferences, string subqueryCol, string inPredicateCol, bool semiJoin, out string outputCol, out MergeJoinNode merge)
+        private bool UseMergeJoin(IDataExecutionPlanNodeInternal node, IDataExecutionPlanNodeInternal subqueryPlan, NodeCompilationContext context, Dictionary<string, string> outerReferences, string subqueryCol, string inPredicateCol, bool semiJoin, out string outputCol, out MergeJoinNode merge)
         {
             outputCol = null;
             merge = null;
@@ -3198,7 +3198,7 @@ namespace MarkMpn.Sql4Cds.Engine
 
             // Give the inner fetch a unique alias and update the name of the inner key
             if (alias != null)
-                fetch.Alias = alias.Alias;
+                alias.FoldToFetchXML(fetch);
             else
                 fetch.Alias = context.GetExpressionName();
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -73,6 +73,8 @@ namespace MarkMpn.Sql4Cds.Engine
             // Add in standard global variables
             parameterTypes["@@IDENTITY"] = DataTypeHelpers.EntityReference;
             parameterTypes["@@ROWCOUNT"] = DataTypeHelpers.Int;
+            parameterTypes["@@SERVERNAME"] = DataTypeHelpers.NVarChar(100, DataSources[Options.PrimaryDataSource].DefaultCollation, CollationLabel.CoercibleDefault);
+            parameterTypes["@@VERSION"] = DataTypeHelpers.NVarChar(100, DataSources[Options.PrimaryDataSource].DefaultCollation, CollationLabel.CoercibleDefault);
 
             var queries = new List<IRootExecutionPlanNodeInternal>();
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -3039,6 +3039,14 @@ namespace MarkMpn.Sql4Cds.Engine
                     // to check for one row
                     if (!(subqueryPlan.Source.EstimateRowsOut(context) is RowCountEstimateDefiniteRange range) || range.Maximum > 1)
                     {
+                        // No point getting more than 2 rows as we only need to know if there is more than 1
+                        var top = new TopNode
+                        {
+                            Source = loopRightSource,
+                            Top = new IntegerLiteral { Value = "2" }
+                        };
+                        loopRightSource = top;
+                        
                         subqueryCol = context.GetExpressionName();
                         var rowCountCol = context.GetExpressionName();
                         var aggregate = new HashMatchAggregateNode

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -77,7 +77,7 @@ namespace MarkMpn.Sql4Cds.Engine
             var queries = new List<IRootExecutionPlanNodeInternal>();
 
             // Parse the SQL DOM
-            var dom = new TSql150Parser(Options.QuotedIdentifiers);
+            var dom = new TSql160Parser(Options.QuotedIdentifiers);
             var fragment = dom.Parse(new StringReader(sql), out var errors);
 
             // Check if there were any parse errors

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -3079,6 +3079,8 @@ namespace MarkMpn.Sql4Cds.Engine
                             ErrorMessage = "Subquery produced more than 1 row"
                         };
                         loopRightSource = assert;
+
+                        subqueryCol = outputcol;
                     }
 
                     // If the subquery is uncorrelated, add a table spool to cache the results
@@ -3107,7 +3109,7 @@ namespace MarkMpn.Sql4Cds.Engine
                             JoinType = QualifiedJoinType.LeftOuter,
                             SemiJoin = true,
                             OutputRightSchema = false,
-                            DefinedValues = { [outputcol] = outputcol }
+                            DefinedValues = { [outputcol] = subqueryCol }
                         };
                     }
                 }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -74,7 +74,7 @@ namespace MarkMpn.Sql4Cds.Engine
             parameterTypes["@@IDENTITY"] = DataTypeHelpers.EntityReference;
             parameterTypes["@@ROWCOUNT"] = DataTypeHelpers.Int;
             parameterTypes["@@SERVERNAME"] = DataTypeHelpers.NVarChar(100, DataSources[Options.PrimaryDataSource].DefaultCollation, CollationLabel.CoercibleDefault);
-            parameterTypes["@@VERSION"] = DataTypeHelpers.NVarChar(100, DataSources[Options.PrimaryDataSource].DefaultCollation, CollationLabel.CoercibleDefault);
+            parameterTypes["@@VERSION"] = DataTypeHelpers.NVarChar(Int32.MaxValue, DataSources[Options.PrimaryDataSource].DefaultCollation, CollationLabel.CoercibleDefault);
 
             var queries = new List<IRootExecutionPlanNodeInternal>();
 

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -82,6 +82,9 @@ namespace MarkMpn.Sql4Cds.Engine
 
                 var value = jtoken.Value<string>();
 
+                if (value == null)
+                    return SqlString.Null;
+
                 if (value.Length > 4000)
                 {
                     if (lax)

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -923,7 +923,7 @@ namespace MarkMpn.Sql4Cds.Engine
 
 #if NETCOREAPP
                     if (svc != null)
-                        machineName = new Uri(svc.ConnectedOrgUriActual).Host;
+                        machineName = svc.ConnectedOrgUriActual.Host;
 #else
                     if (svc != null)
                         machineName = svc.CrmConnectOrgUriActual.Host;

--- a/MarkMpn.Sql4Cds.Engine/IQueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds.Engine/IQueryExecutionOptions.cs
@@ -36,7 +36,7 @@ namespace MarkMpn.Sql4Cds.Engine
         bool BlockUpdateWithoutWhere { get; }
 
         /// <summary>
-        /// Indicates if a DELETE statement cannot be execyted unless it has a WHERE clause
+        /// Indicates if a DELETE statement cannot be executed unless it has a WHERE clause
         /// </summary>
         bool BlockDeleteWithoutWhere { get; }
 

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -11,25 +11,26 @@
     <iconUrl>https://markcarrington.dev/sql4cds-icon/</iconUrl>
     <description>Convert SQL queries to FetchXml and execute them against Dataverse / D365</description>
     <summary>Convert SQL queries to FetchXml and execute them against Dataverse / D365</summary>
-    <releaseNotes>Added support for long-term retention data
-Fixed errors with common XML queries
-Improved performance with subqueries
-Avoid exposing internal names for computed columns
-Convert outer joins with filters to inner joins
-Fixed use of UPDATE with CASE expression with a first value of NULL
-Fixed use of joins or subqueries with multiple correlated conditions
-Improved handling of LEFT OUTER JOIN using nested loop operator
-Implemented many-to-many joins using merge join operator
-Fixed cross-instance string comparison
-Lift more filters directly to FetchXML link-entity
-Extended folding of sorts to FetchXML around nested loops
-Improved ambiguous table name detection in UPDATE/DELETE statements with subqueries
-Avoid errors with un-aliased calculated columns in subqueries
-Improved error reporting for AVG and SUM aggregates on non-numeric types
-Handle MIN and MAX aggregates for primary key and lookup columns
-Added support for STRING_AGG function
-Fixed filtering metadata by attribute.sourcetype
-</releaseNotes>
+    <releaseNotes>Added sql_variant type support, including SQL_VARIANT_PROPERTY function
+Added IS [NOT] DISTINCT FROM predicate support
+Added @@SERVERNAME and @@VERSION global variables
+Added SERVERPROPERTY function support
+Added USE_LEGACY_UPDATE_MESSAGES query hint to use legacy update messages Assign, SetState, SetParentBusinessUnit and SetBusinessEquipment
+
+Subquery fixes:
+- Only include requested columns from CROSS APPLY and query-defined tables
+- Performance improvements for uncorrelated scalar subqueries
+- Only retrieve minimal rows for scalar subqueries
+- Fixed use of nested IN and EXISTS subqueries
+
+Fixed use of table-valued function with alias
+Fixed JSON_VALUE function with embedded null literals
+Fixed bulk DML operations that require non-standard requests
+Do not use merge joins for data types with different sort ordering
+Fixed filtering and sorting on non-lowercase attributes
+Fixed executing messages with OptionSetValue parameters
+Improved error reporting on batch DML statements
+    </releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>
     <tags>SQL CDS</tags>

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.projitems
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.projitems
@@ -117,6 +117,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)IQueryExecutionOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MessageCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SqlDateTypes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SqlVariant.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StateTransitionLoader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Visitors\ExplicitCollationVisitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Visitors\JoinConditionVisitor.cs" />

--- a/MarkMpn.Sql4Cds.Engine/SqlEntityReference.cs
+++ b/MarkMpn.Sql4Cds.Engine/SqlEntityReference.cs
@@ -10,7 +10,7 @@ namespace MarkMpn.Sql4Cds.Engine
 {
     public struct SqlEntityReference : INullable, IComparable
     {
-        private SqlGuid _guid;
+        private readonly SqlGuid _guid;
 
         public SqlEntityReference(string dataSource, string logicalName, SqlGuid id)
         {

--- a/MarkMpn.Sql4Cds.Engine/SqlVariant.cs
+++ b/MarkMpn.Sql4Cds.Engine/SqlVariant.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlTypes;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MarkMpn.Sql4Cds.Engine.ExecutionPlan;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace MarkMpn.Sql4Cds.Engine
+{
+    struct SqlVariant : INullable, IComparable
+    {
+        private SqlVariant(bool @null)
+        {
+            BaseType = DataTypeHelpers.Variant;
+            Value = null;
+        }
+
+        public SqlVariant(DataTypeReference baseType, INullable value)
+        {
+            BaseType = baseType ?? throw new ArgumentNullException(nameof(baseType));
+            Value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public static readonly SqlVariant Null = new SqlVariant(true);
+
+        public DataTypeReference BaseType { get; }
+
+        public INullable Value { get; }
+
+        public bool IsNull => Value == null || Value.IsNull;
+
+        public int CompareTo(object obj)
+        {
+            if (!(obj is SqlVariant sqlVariant))
+                throw new ArgumentException();
+            
+            // Null sorts before all other values
+            if (IsNull)
+            {
+                if (!sqlVariant.IsNull)
+                    return -1;
+
+                return 0;
+            }
+
+            if (sqlVariant.IsNull)
+                return 1;
+
+            // sql_variant sorting is based on data type family hierarchy order
+            // https://learn.microsoft.com/en-us/sql/t-sql/data-types/sql-variant-transact-sql?view=sql-server-ver16#comparing-sql_variant-values
+            var family1 = BaseType.GetDataTypeFamily();
+            var family2 = sqlVariant.BaseType.GetDataTypeFamily();
+
+            // If the types are in different families, use the precedence order of the families
+            if (family1 != family2)
+                return -family1.CompareTo(family2);
+
+            // Character values should be compared first based on their collations
+            if (BaseType is SqlDataTypeReferenceWithCollation coll1 &&
+                sqlVariant.BaseType is SqlDataTypeReferenceWithCollation coll2 &&
+                !coll1.Collation.Equals(coll2.Collation))
+            {
+                var comparison = coll1.Collation.LCID.CompareTo(coll2.Collation.LCID);
+
+                if (comparison == 0)
+                    comparison = coll1.Collation.CompareOptions.CompareTo(coll2.Collation.CompareOptions);
+
+                // This doesn't quite match the specification as we don't have LCID version or Sort ID available
+                if (comparison != 0)
+                    return comparison;
+            }
+
+            // If the types are different but in the same family, convert them to the same type based
+            // on the precedence order and then compare them
+            if (!SqlTypeConverter.CanMakeConsistentTypes(BaseType, sqlVariant.BaseType, null, out var consistentType))
+                throw new ArgumentException();
+
+            var value1 = SqlTypeConverter.GetConversion(BaseType, consistentType)(Value);
+            var value2 = SqlTypeConverter.GetConversion(sqlVariant.BaseType, consistentType)(sqlVariant.Value);
+
+            if (!(value1 is IComparable comparable1))
+                throw new ArgumentException();
+
+            return comparable1.CompareTo(value2);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is SqlVariant sqlVariant))
+                return false;
+
+            if (sqlVariant.IsNull || IsNull)
+            {
+                if (sqlVariant.IsNull)
+                    return IsNull;
+
+                return false;
+            }
+
+            return Value.Equals(sqlVariant.Value);
+        }
+
+        public override int GetHashCode()
+        {
+            return IsNull ? 0 : Value.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            if (IsNull)
+                return "Null";
+
+            return Value.ToString();
+        }
+
+        public static SqlBoolean operator ==(SqlVariant x, SqlVariant y) => !x.IsNull && x.CompareTo(y) == 0;
+
+        public static SqlBoolean operator !=(SqlVariant x, SqlVariant y) => !x.IsNull && x.CompareTo(y) != 0;
+
+        public static SqlBoolean operator <(SqlVariant x, SqlVariant y) => !x.IsNull && x.CompareTo(y) < 0;
+
+        public static SqlBoolean operator >(SqlVariant x, SqlVariant y) => !x.IsNull && x.CompareTo(y) > 0;
+
+        public static SqlBoolean operator <=(SqlVariant x, SqlVariant y) => !x.IsNull && x.CompareTo(y) <= 0;
+
+        public static SqlBoolean operator >=(SqlVariant x, SqlVariant y) => !x.IsNull && x.CompareTo(y) >= 0;
+    }
+}

--- a/MarkMpn.Sql4Cds.Engine/TSqlFragmentExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/TSqlFragmentExtensions.cs
@@ -445,6 +445,16 @@ namespace MarkMpn.Sql4Cds.Engine
                 };
             }
 
+            if (fragment is DistinctPredicate distinct)
+            {
+                return (T)(object)new DistinctPredicate
+                {
+                    IsNot = distinct.IsNot,
+                    FirstExpression = distinct.FirstExpression.Clone(),
+                    SecondExpression = distinct.SecondExpression.Clone(),
+                };
+            }
+
             throw new NotSupportedQueryFragmentException("Unhandled expression type", fragment);
         }
     }

--- a/MarkMpn.Sql4Cds.Engine/Visitors/ExistsSubqueryVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/ExistsSubqueryVisitor.cs
@@ -16,5 +16,10 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
             base.Visit(node);
             ExistsSubqueries.Add(node);
         }
+
+        public override void ExplicitVisit(ScalarSubquery node)
+        {
+            // Do not recurse into subqueries
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine/Visitors/InSubqueryVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/InSubqueryVisitor.cs
@@ -16,5 +16,10 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
             if (node.Subquery != null)
                 InSubqueries.Add(node);
         }
+
+        public override void ExplicitVisit(ScalarSubquery node)
+        {
+            // Do not recurse into subqueries
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine/Visitors/OptimizerHintValidatingVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/OptimizerHintValidatingVisitor.cs
@@ -54,6 +54,9 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
 
             // Custom hint to keep trying all records in a DML batch even if one fails
             "CONTINUE_ON_ERROR",
+
+            // Custom hint to use legacy specialized update messages - https://learn.microsoft.com/en-us/power-apps/developer/data-platform/org-service/entity-operations-update-delete?tabs=late#legacy-update-messages
+            "USE_LEGACY_UPDATE_MESSAGES",
         };
 
         private static readonly HashSet<string> _removableSql4CdsQueryHints = new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/MarkMpn.Sql4Cds.Engine/Visitors/TDSEndpointCompatibilityVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/TDSEndpointCompatibilityVisitor.cs
@@ -203,7 +203,8 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
 
         public override void Visit(GlobalVariableExpression node)
         {
-            if (node.Name.Equals("@@IDENTITY", StringComparison.OrdinalIgnoreCase))
+            if (node.Name.Equals("@@IDENTITY", StringComparison.OrdinalIgnoreCase) ||
+                node.Name.Equals("@@SERVERNAME", StringComparison.OrdinalIgnoreCase))
             {
                 IsCompatible = false;
                 return;

--- a/MarkMpn.Sql4Cds.Engine/Visitors/TDSEndpointCompatibilityVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/TDSEndpointCompatibilityVisitor.cs
@@ -299,6 +299,7 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
             {
                 case "JSON_VALUE":
                 case "JSON_PATH_EXISTS":
+                case "SQL_VARIANT_PROPERTY":
                     IsCompatible = false;
                     break;
             }
@@ -309,6 +310,12 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
         public override void Visit(ForClause node)
         {
             // Can't use FOR XML clause
+            IsCompatible = false;
+        }
+
+        public override void Visit(DistinctPredicate node)
+        {
+            // Can't use IS [NOT] DISTINCT FROM
             IsCompatible = false;
         }
     }

--- a/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/Autocomplete.cs
@@ -77,10 +77,6 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
             if (prevWord == null)
                 return Array.Empty<SqlAutocompleteItem>();
 
-            // Autocomplete variable names
-            if (currentWord.StartsWith("@") && !prevWord.Equals("declare", StringComparison.OrdinalIgnoreCase))
-                return FilterList(AutocompleteVariableName(currentWord, text.Substring(0, pos)), currentWord);
-
             switch (prevWord.ToLower())
             {
                 case "from":
@@ -505,6 +501,7 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
                             // * table/alias names
                             // * attribute names unique across tables
                             // * functions
+                            // * variables
                             var items = new List<SqlAutocompleteItem>();
                             var attributes = new List<AttributeMetadata>();
 
@@ -564,6 +561,8 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
                             items.AddRange(attributes.Where(a => a.IsValidForRead != false && a.AttributeOf == null).GroupBy(x => x.LogicalName).Where(g => g.Count() == 1).SelectMany(g => AttributeAutocompleteItem.CreateList(g.Single(), currentLength, false)));
 
                             items.AddRange(typeof(SqlFunctions).GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public).Select(m => new FunctionAutocompleteItem(m, currentLength)));
+
+                            items.AddRange(AutocompleteVariableName(currentWord, text.Substring(0, pos)));
 
                             if ((clause == "where" || clause == "set") && prevWord == "=")
                             {

--- a/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/Autocomplete.cs
@@ -88,6 +88,9 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
                 case "execute":
                     return FilterList(AutocompleteSprocName(currentWord), currentWord);
 
+                case "collate":
+                    return FilterList(Collation.GetAllCollations().OrderBy(c => c.Name).Select(c => new CollationAutocompleteItem(c, currentLength)), currentWord);
+
                 default:
                     // Find the FROM clause
                     var words = new List<string>();
@@ -1766,6 +1769,28 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
             {
                 get => _option.Label?.UserLocalizedLabel?.Label ?? Text;
                 set => base.ToolTipText = value;
+            }
+        }
+
+        class CollationAutocompleteItem : SqlAutocompleteItem
+        {
+            private readonly Collation _collation;
+
+            public CollationAutocompleteItem(Collation collation, int replaceLength) : base(collation.Name, replaceLength, CompletionItemKind.Field)
+            {
+                _collation = collation;
+            }
+
+            public override string ToolTipTitle
+            {
+                get => _collation.Name;
+                set { }
+            }
+
+            public override string ToolTipText
+            {
+                get => _collation.Description;
+                set { }
             }
         }
     }

--- a/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/FunctionMetadata.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/FunctionMetadata.cs
@@ -166,6 +166,12 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
 
             [Description("Deletes a specified length of characters in the first string at the start position and then inserts the second string into the first string at the start position")]
             public abstract string stuff(string character_expression, int start, int length, string replace_with_expression);
+
+            [Description("Returns property information about the server instance")]
+            public abstract object serverproperty(string propertyname);
+
+            [Description("Returns the base data type and other information about a sql_variant value")]
+            public abstract object sql_variant_property(object expression, string property);
         }
     }
 }

--- a/MarkMpn.Sql4Cds.LanguageServer/MarkMpn.Sql4Cds.LanguageServer.csproj
+++ b/MarkMpn.Sql4Cds.LanguageServer/MarkMpn.Sql4Cds.LanguageServer.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
+    <Copyright>Copyright © 2022 - 2023 Mark Carrington</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MarkMpn.Sql4Cds.SSMS.18/Properties/AssemblyInfo.cs
+++ b/MarkMpn.Sql4Cds.SSMS.18/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Mark Carrington")]
 [assembly: AssemblyProduct("MarkMpn.Sql4Cds.SSMS")]
-[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyCopyright("Copyright © 2021 - 2023 Mark Carrington")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/MarkMpn.Sql4Cds.SSMS.19/Properties/AssemblyInfo.cs
+++ b/MarkMpn.Sql4Cds.SSMS.19/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Mark Carrington")]
 [assembly: AssemblyProduct("MarkMpn.Sql4Cds.SSMS")]
-[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyCopyright("Copyright © 2021 - 2023 Mark Carrington")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/MarkMpn.Sql4Cds.Tests/AutocompleteTests.cs
+++ b/MarkMpn.Sql4Cds.Tests/AutocompleteTests.cs
@@ -115,7 +115,7 @@ namespace MarkMpn.Sql4Cds.Tests
             var sql = "SELECT * FROM account a left outer join contact c on a.accountid = c.parentcustomerid where ";
             var suggestions = _autocomplete.GetSuggestions(sql, sql.Length - 1).Where(s => s.GetType().Name != "FunctionAutocompleteItem").Select(s => s.Text).ToList();
 
-            CollectionAssert.AreEqual(new[] { "a", "accountid", "c", "contactid", "employees", "firstname", "fullname", "lastname", "name", "parentcustomerid", "parentcustomeridname", "parentcustomeridtype", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
+            CollectionAssert.AreEqual(new[] { "@@IDENTITY", "@@ROWCOUNT", "@@SERVERNAME", "@@VERSION", "a", "accountid", "c", "contactid", "employees", "firstname", "fullname", "lastname", "name", "parentcustomerid", "parentcustomeridname", "parentcustomeridtype", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace MarkMpn.Sql4Cds.Tests
             var sql = sql1 + "\r\n" + sql2;
             var suggestions = _autocomplete.GetSuggestions(sql, sql1.Length + 2 + sql2.IndexOf(" ") + 1).Where(s => s.GetType().Name != "FunctionAutocompleteItem").Select(s => s.Text).ToList();
 
-            CollectionAssert.AreEqual(new[] { "account", "accountid", "contact", "contactid", "employees", "firstname", "fullname", "lastname", "name", "parentcustomerid", "parentcustomeridname", "parentcustomeridtype", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
+            CollectionAssert.AreEqual(new[] { "@@IDENTITY", "@@ROWCOUNT", "@@SERVERNAME", "@@VERSION", "account", "accountid", "contact", "contactid", "employees", "firstname", "fullname", "lastname", "name", "parentcustomerid", "parentcustomeridname", "parentcustomeridtype", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
         }
 
         [TestMethod]
@@ -153,7 +153,7 @@ namespace MarkMpn.Sql4Cds.Tests
             var sql = "SELECT count( FROM account";
             var suggestions = _autocomplete.GetSuggestions(sql, sql.IndexOf("(")).Where(s => s.GetType().Name != "FunctionAutocompleteItem").Select(s => s.Text).ToList();
 
-            CollectionAssert.AreEqual(new[] { "account", "accountid", "createdon", "employees", "name", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
+            CollectionAssert.AreEqual(new[] { "@@IDENTITY", "@@ROWCOUNT", "@@SERVERNAME", "@@VERSION", "account", "accountid", "createdon", "employees", "name", "primarycontactid", "primarycontactidname", "turnover" }, suggestions);
         }
 
         [TestMethod]
@@ -375,6 +375,20 @@ namespace MarkMpn.Sql4Cds.Tests
             var suggestions = _autocomplete.GetSuggestions(sql, sql.Length - 1).Select(s => s.Text).ToList();
 
             CollectionAssert.IsSubsetOf(new[] { "lastname" }, suggestions);
+        }
+
+        [TestMethod]
+        public void SuggestVariables()
+        {
+            var sql = @"
+                DECLARE @i int
+                DECLARE @x varchar
+
+                SELECT * FROM account WHERE name = @";
+
+            var suggestions = _autocomplete.GetSuggestions(sql, sql.Length - 1).Select(s => s.Text).ToList();
+
+            CollectionAssert.IsSubsetOf(new[] { "@i", "@x", "@@ROWCOUNT", "@@IDENTITY", "@@SERVERNAME", "@@VERSION" }, suggestions);
         }
     }
 }

--- a/MarkMpn.Sql4Cds.XTB/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds.XTB/Autocomplete.cs
@@ -77,10 +77,6 @@ namespace MarkMpn.Sql4Cds.XTB
             if (prevWord == null)
                 return Array.Empty<SqlAutocompleteItem>();
 
-            // Autocomplete variable names
-            if (currentWord.StartsWith("@") && !prevWord.Equals("declare", StringComparison.OrdinalIgnoreCase))
-                return FilterList(AutocompleteVariableName(currentWord, text.Substring(0, pos)), currentWord);
-
             switch (prevWord.ToLower())
             {
                 case "from":
@@ -505,6 +501,7 @@ namespace MarkMpn.Sql4Cds.XTB
                             // * table/alias names
                             // * attribute names unique across tables
                             // * functions
+                            // * variables
                             var items = new List<SqlAutocompleteItem>();
                             var attributes = new List<AttributeMetadata>();
 
@@ -564,6 +561,8 @@ namespace MarkMpn.Sql4Cds.XTB
                             items.AddRange(attributes.Where(a => a.IsValidForRead != false && a.AttributeOf == null).GroupBy(x => x.LogicalName).Where(g => g.Count() == 1).SelectMany(g => AttributeAutocompleteItem.CreateList(g.Single(), currentLength, false)));
 
                             items.AddRange(typeof(FunctionMetadata.SqlFunctions).GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public).Select(m => new FunctionAutocompleteItem(m, currentLength)));
+
+                            items.AddRange(AutocompleteVariableName(currentWord, text.Substring(0, pos)));
 
                             if ((clause == "where" || clause == "set") && prevWord == "=")
                             {

--- a/MarkMpn.Sql4Cds.XTB/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds.XTB/Autocomplete.cs
@@ -88,6 +88,9 @@ namespace MarkMpn.Sql4Cds.XTB
                 case "execute":
                     return FilterList(AutocompleteSprocName(currentWord), currentWord);
 
+                case "collate":
+                    return FilterList(Collation.GetAllCollations().OrderBy(c => c.Name).Select(c => new CollationAutocompleteItem(c, currentLength)), currentWord);
+
                 default:
                     // Find the FROM clause
                     var words = new List<string>();
@@ -1748,6 +1751,28 @@ namespace MarkMpn.Sql4Cds.XTB
             {
                 get => _option.Label?.UserLocalizedLabel?.Label ?? Text;
                 set => base.ToolTipText = value;
+            }
+        }
+
+        class CollationAutocompleteItem : SqlAutocompleteItem
+        {
+            private readonly Collation _collation;
+
+            public CollationAutocompleteItem(Collation collation, int replaceLength) : base(collation.Name, replaceLength, 13)
+            {
+                _collation = collation;
+            }
+
+            public override string ToolTipTitle
+            {
+                get => _collation.Name;
+                set { }
+            }
+
+            public override string ToolTipText
+            {
+                get => _collation.Description;
+                set { }
             }
         }
     }

--- a/MarkMpn.Sql4Cds.XTB/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds.XTB/Autocomplete.cs
@@ -77,6 +77,10 @@ namespace MarkMpn.Sql4Cds.XTB
             if (prevWord == null)
                 return Array.Empty<SqlAutocompleteItem>();
 
+            // Autocomplete variable names
+            if (currentWord.StartsWith("@") && !prevWord.Equals("declare", StringComparison.OrdinalIgnoreCase))
+                return FilterList(AutocompleteVariableName(currentWord, text.Substring(0, pos)), currentWord);
+
             switch (prevWord.ToLower())
             {
                 case "from":
@@ -850,6 +854,30 @@ namespace MarkMpn.Sql4Cds.XTB
                 // Could be a sproc name
                 if (schemaName.Equals("dbo", StringComparison.OrdinalIgnoreCase) && _dataSources.TryGetValue(instanceName, out var instance) && instance.Messages != null)
                     list.AddRange(instance.Messages.GetAllMessages().Where(x => x.IsValidAsStoredProcedure()).Select(e => new SprocAutocompleteItem(e, lastPartLength)));
+            }
+
+            list.Sort();
+            return list;
+        }
+
+        private IEnumerable<SqlAutocompleteItem> AutocompleteVariableName(string currentWord, string text)
+        {
+            var list = new List<SqlAutocompleteItem>();
+
+            // Add the known global variables
+            list.Add(new VariableAutocompleteItem("@@IDENTITY", currentWord.Length));
+            list.Add(new VariableAutocompleteItem("@@ROWCOUNT", currentWord.Length));
+            list.Add(new VariableAutocompleteItem("@@SERVERNAME", currentWord.Length));
+            list.Add(new VariableAutocompleteItem("@@VERSION", currentWord.Length));
+
+            // Find any other variable declarations in the preceding SQL
+            var regex = new System.Text.RegularExpressions.Regex(@"\bdeclare\s+(@[a-z0-9_]+)", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            var matches = regex.Matches(text);
+
+            foreach (System.Text.RegularExpressions.Match match in matches)
+            {
+                var variableName = match.Groups[1].Value;
+                list.Add(new VariableAutocompleteItem(variableName, currentWord.Length));
             }
 
             list.Sort();
@@ -1772,6 +1800,25 @@ namespace MarkMpn.Sql4Cds.XTB
             public override string ToolTipText
             {
                 get => _collation.Description;
+                set { }
+            }
+        }
+
+        class VariableAutocompleteItem : SqlAutocompleteItem
+        {
+            public VariableAutocompleteItem(string name, int replaceLength) : base(name, replaceLength, 13)
+            {
+            }
+
+            public override string ToolTipTitle
+            {
+                get => Text;
+                set { }
+            }
+
+            public override string ToolTipText
+            {
+                get => Text.StartsWith("@@") ? "Global variable" : "User-defined variable";
                 set { }
             }
         }

--- a/MarkMpn.Sql4Cds.XTB/DocumentWindowBase.cs
+++ b/MarkMpn.Sql4Cds.XTB/DocumentWindowBase.cs
@@ -148,7 +148,7 @@ namespace MarkMpn.Sql4Cds.XTB
         {
             base.OnClosing(e);
 
-            if (Modified && this is ISaveableDocumentWindow saveable)
+            if (Modified && !Settings.Instance.RememberSession && this is ISaveableDocumentWindow saveable)
             {
                 using (var form = new ConfirmCloseForm(new[] { DisplayName }, true))
                 {

--- a/MarkMpn.Sql4Cds.XTB/FunctionMetadata.cs
+++ b/MarkMpn.Sql4Cds.XTB/FunctionMetadata.cs
@@ -166,6 +166,12 @@ namespace MarkMpn.Sql4Cds.XTB
 
             [Description("Deletes a specified length of characters in the first string at the start position and then inserts the second string into the first string at the start position")]
             public abstract string stuff(string character_expression, int start, int length, string replace_with_expression);
+
+            [Description("Returns property information about the server instance")]
+            public abstract object serverproperty(string propertyname);
+
+            [Description("Returns the base data type and other information about a sql_variant value")]
+            public abstract object sql_variant_property(object expression, string property);
         }
     }
 }

--- a/MarkMpn.Sql4Cds.XTB/MarkMpn.Sql4Cds.XTB.csproj
+++ b/MarkMpn.Sql4Cds.XTB/MarkMpn.Sql4Cds.XTB.csproj
@@ -295,4 +295,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy $(TargetDir)MarkMpn.Sql4Cds.XTB.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/MarkMpn.Sql4Cds.XTB/MarkMpn.Sql4Cds.XTB.csproj
+++ b/MarkMpn.Sql4Cds.XTB/MarkMpn.Sql4Cds.XTB.csproj
@@ -295,7 +295,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PostBuildEvent>copy $(TargetDir)MarkMpn.Sql4Cds.XTB.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/MarkMpn.Sql4Cds.XTB/PluginControl.cs
+++ b/MarkMpn.Sql4Cds.XTB/PluginControl.cs
@@ -182,13 +182,13 @@ namespace MarkMpn.Sql4Cds.XTB
                         try
                         {
                             query.RestoreSessionDetails(Settings.Instance.Session[contentIndex++]);
+                            return (IDockContent)query;
                         }
                         catch
                         {
                             ((Form)query).Close();
+                            return null;
                         }
-
-                        return (IDockContent)query;
                     });
                 }
             }
@@ -233,7 +233,7 @@ namespace MarkMpn.Sql4Cds.XTB
                 }
             }
 
-            if (dockPanel.DocumentsCount == 0)
+            if (!dockPanel.Contents.OfType<IDocumentWindow>().Any())
                 CreateQuery(_objectExplorer.SelectedConnection, null);
         }
 
@@ -459,7 +459,7 @@ namespace MarkMpn.Sql4Cds.XTB
 
         private void saveAllToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var unsavedDocuments = dockPanel.Documents
+            var unsavedDocuments = dockPanel.Contents
                 .OfType<ISaveableDocumentWindow>()
                 .Where(query => query.Modified)
                 .ToArray();
@@ -625,7 +625,7 @@ namespace MarkMpn.Sql4Cds.XTB
         {
             if (Settings.Instance.RememberSession)
             {
-                Settings.Instance.Session = dockPanel.Documents.OfType<IDocumentWindow>().Select(query => query.GetSessionDetails()).ToArray();
+                Settings.Instance.Session = dockPanel.Contents.OfType<IDocumentWindow>().Select(query => query.GetSessionDetails()).ToArray();
 
                 using (var memoryStream = new MemoryStream())
                 {
@@ -643,7 +643,7 @@ namespace MarkMpn.Sql4Cds.XTB
 
         public override void ClosingPlugin(PluginCloseInfo info)
         {
-            if (!ConfirmBulkClose(dockPanel.DocumentsToArray(), info.Silent))
+            if (!ConfirmBulkClose(dockPanel.Contents.OfType<IDocumentWindow>().Cast<IDockContent>().ToArray(), info.Silent))
             {
                 info.Cancel = true;
                 return;
@@ -872,7 +872,7 @@ in
                 }
             }
 
-            var unsavedDocuments = dockPanel.Documents
+            var unsavedDocuments = dockPanel.Contents
                 .OfType<ISaveableDocumentWindow>()
                 .Where(query => query.Modified)
                 .ToArray();

--- a/MarkMpn.Sql4Cds.XTB/PluginControl.cs
+++ b/MarkMpn.Sql4Cds.XTB/PluginControl.cs
@@ -15,6 +15,7 @@ using Microsoft.Xrm.Sdk;
 using WeifenLuo.WinFormsUI.Docking;
 using XrmToolBox.Extensibility;
 using XrmToolBox.Extensibility.Interfaces;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace MarkMpn.Sql4Cds.XTB
 {
@@ -31,12 +32,17 @@ namespace MarkMpn.Sql4Cds.XTB
             InitializeComponent();
             _plugin = plugin;
             dockPanel.Theme = new VS2015LightTheme();
+
+            // Loads or creates the settings for the plugin
+            if (!SettingsManager.Instance.TryLoad(_plugin.GetType(), out Settings settings))
+                settings = new Settings();
+
+            Settings.Instance = settings;
+
             _dataSources = new Dictionary<string, DataSource>(StringComparer.OrdinalIgnoreCase);
             _objectExplorer = new ObjectExplorer(_dataSources, WorkAsync, con => CreateQuery(con, ""), ConnectObjectExplorer);
-            _objectExplorer.Show(dockPanel, DockState.DockLeft);
             _objectExplorer.CloseButtonVisible = false;
             _properties = new PropertiesWindow();
-            _properties.Show(dockPanel, DockState.DockRightAutoHide);
             _properties.SelectedObjectChanged += OnSelectedObjectChanged;
             _ai = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration("79761278-a908-4575-afbf-2f4d82560da6"));
             tscbConnection.Items.Add("Add Connection...");
@@ -93,8 +99,6 @@ namespace MarkMpn.Sql4Cds.XTB
 
                 if (!tscbConnection.Items.Contains(detail))
                     tscbConnection.Items.Insert(tscbConnection.Items.Count - 1, detail);
-
-                CreateQuery(detail, "");
             }
             else
             {
@@ -145,51 +149,92 @@ namespace MarkMpn.Sql4Cds.XTB
 
         private void PluginControl_Load(object sender, EventArgs e)
         {
-            // Loads or creates the settings for the plugin
-            if (!SettingsManager.Instance.TryLoad(_plugin.GetType(), out Settings settings))
-                settings = new Settings();
+            tsbIncludeFetchXml.Checked = Settings.Instance.IncludeFetchXml;
 
-            Settings.Instance = settings;
-
-            tsbIncludeFetchXml.Checked = settings.IncludeFetchXml;
-
-            if (settings.RememberSession && settings.Session != null)
+            if (Settings.Instance.DockLayout != null)
             {
-                foreach (var doc in dockPanel.Documents.OfType<Form>().ToArray())
-                    doc.Close();
-
-                foreach (var tab in settings.Session)
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(Settings.Instance.DockLayout)))
                 {
-                    IDocumentWindow query = null;
+                    var contentIndex = 0;
 
-                    switch (tab.Type)
+                    dockPanel.LoadFromXml(stream, (name) =>
                     {
-                        case "SQL":
+                        if (name == _objectExplorer.GetType().FullName)
+                            return _objectExplorer;
+
+                        if (name == _properties.GetType().FullName)
+                            return _properties;
+
+                        if (!Settings.Instance.RememberSession)
+                            return null;
+
+                        IDocumentWindow query = null;
+
+                        if (name == typeof(SqlQueryControl).FullName)
                             query = CreateQuery(_objectExplorer.SelectedConnection, null);
-                            break;
-
-                        case "FetchXML":
+                        else if (name == typeof(FetchXmlControl).FullName)
                             query = CreateFetchXML(null);
-                            break;
-
-                        case "M":
+                        else if (name == typeof(MQueryControl).FullName)
                             query = CreateM(null);
-                            break;
+                        else
+                            return null;
 
-                        default:
-                            continue;
-                    }
+                        try
+                        {
+                            query.RestoreSessionDetails(Settings.Instance.Session[contentIndex++]);
+                        }
+                        catch
+                        {
+                            ((Form)query).Close();
+                        }
 
-                    try
+                        return (IDockContent)query;
+                    });
+                }
+            }
+            else
+            {
+                _objectExplorer.Show(dockPanel, DockState.DockLeft);
+                _properties.Show(dockPanel, DockState.DockRightAutoHide);
+
+                if (Settings.Instance.RememberSession)
+                {
+                    foreach (var tab in Settings.Instance.Session)
                     {
-                        query.RestoreSessionDetails(tab);
-                    }
-                    catch
-                    {
-                        ((Form)query).Close();
+                        IDocumentWindow query = null;
+
+                        switch (tab.Type)
+                        {
+                            case "SQL":
+                                query = CreateQuery(_objectExplorer.SelectedConnection, null);
+                                break;
+
+                            case "FetchXML":
+                                query = CreateFetchXML(null);
+                                break;
+
+                            case "M":
+                                query = CreateM(null);
+                                break;
+
+                            default:
+                                continue;
+                        }
+
+                        try
+                        {
+                            query.RestoreSessionDetails(tab);
+                        }
+                        catch
+                        {
+                            ((Form)query).Close();
+                        }
                     }
                 }
             }
+
+            if (dockPanel.DocumentsCount == 0)
+                CreateQuery(_objectExplorer.SelectedConnection, null);
         }
 
         private void tsbExecute_Click(object sender, EventArgs e)
@@ -579,9 +624,19 @@ namespace MarkMpn.Sql4Cds.XTB
         private void SaveSettings()
         {
             if (Settings.Instance.RememberSession)
+            {
                 Settings.Instance.Session = dockPanel.Documents.OfType<IDocumentWindow>().Select(query => query.GetSessionDetails()).ToArray();
+
+                using (var memoryStream = new MemoryStream())
+                {
+                    dockPanel.SaveAsXml(memoryStream, Encoding.UTF8);
+                    Settings.Instance.DockLayout = Encoding.UTF8.GetString(memoryStream.ToArray());
+                }
+            }
             else
+            {
                 Settings.Instance.Session = null;
+            }
 
             SettingsManager.Instance.Save(_plugin.GetType(), Settings.Instance);
         }

--- a/MarkMpn.Sql4Cds.XTB/PluginControl.cs
+++ b/MarkMpn.Sql4Cds.XTB/PluginControl.cs
@@ -165,7 +165,7 @@ namespace MarkMpn.Sql4Cds.XTB
                         if (name == _properties.GetType().FullName)
                             return _properties;
 
-                        if (!Settings.Instance.RememberSession)
+                        if (!Settings.Instance.RememberSession || Settings.Instance.Session == null)
                             return null;
 
                         IDocumentWindow query = null;
@@ -197,7 +197,7 @@ namespace MarkMpn.Sql4Cds.XTB
                 _objectExplorer.Show(dockPanel, DockState.DockLeft);
                 _properties.Show(dockPanel, DockState.DockRightAutoHide);
 
-                if (Settings.Instance.RememberSession)
+                if (Settings.Instance.RememberSession && Settings.Instance.Session != null)
                 {
                     foreach (var tab in Settings.Instance.Session)
                     {

--- a/MarkMpn.Sql4Cds.XTB/Properties/AssemblyInfo.cs
+++ b/MarkMpn.Sql4Cds.XTB/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("MarkMpn.Sql4Cds.XTB")]
-[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyCopyright("Copyright © 2019 - 2023 Mark Carrington")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/MarkMpn.Sql4Cds.XTB/QueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds.XTB/QueryExecutionOptions.cs
@@ -66,7 +66,7 @@ namespace MarkMpn.Sql4Cds.XTB
                 if (e.BypassCustomPluginExecution)
                     msg += "\r\n\r\nThis operation will bypass any custom plugins.";
 
-                var result = MessageBox.Show(_host, msg + "\r\n\r\nDo you want to proceed?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);
+                var result = ShowMessageBox(msg);
 
                 if (result == DialogResult.No)
                     return false;
@@ -88,7 +88,7 @@ namespace MarkMpn.Sql4Cds.XTB
                 if (e.BypassCustomPluginExecution)
                     msg += "\r\n\r\nThis operation will bypass any custom plugins.";
 
-                var result = MessageBox.Show(_host, msg + "\r\n\r\nDo you want to proceed?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);
+                var result = ShowMessageBox(msg);
 
                 if (result == DialogResult.No)
                     return false;
@@ -110,7 +110,7 @@ namespace MarkMpn.Sql4Cds.XTB
                 if (e.BypassCustomPluginExecution)
                     msg += "\r\n\r\nThis operation will bypass any custom plugins.";
 
-                var result = MessageBox.Show(_host, msg + "\r\n\r\nDo you want to proceed?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);
+                var result = ShowMessageBox(msg);
 
                 if (result == DialogResult.No)
                     return false;
@@ -163,6 +163,14 @@ namespace MarkMpn.Sql4Cds.XTB
         private void Progress(double? progress, string message)
         {
             _worker.ReportProgress(progress == null ? -1 : (int)(progress * 100), message);
+        }
+
+        private DialogResult ShowMessageBox(string msg)
+        {
+            if (_host.InvokeRequired)
+                return (DialogResult)_host.Invoke(new Func<string, DialogResult>(ShowMessageBox), msg);
+
+            return MessageBox.Show(_host, msg + "\r\n\r\nDo you want to proceed?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);
         }
 
         public void Dispose()

--- a/MarkMpn.Sql4Cds.XTB/Settings.cs
+++ b/MarkMpn.Sql4Cds.XTB/Settings.cs
@@ -64,6 +64,8 @@ namespace MarkMpn.Sql4Cds.XTB
         public FetchXml2SqlOptions FetchXml2SqlOptions { get; set; } = new FetchXml2SqlOptions();
 
         public ColumnOrdering ColumnOrdering { get; set; } = ColumnOrdering.Alphabetical;
+
+        public string DockLayout { get; set; }
     }
 
     public class TabContent

--- a/MarkMpn.Sql4Cds.XTB/SqlQueryControl.cs
+++ b/MarkMpn.Sql4Cds.XTB/SqlQueryControl.cs
@@ -728,7 +728,10 @@ namespace MarkMpn.Sql4Cds.XTB
                 var messageSuffix = "";
                 IRootExecutionPlanNode plan = null;
 
-                if (e.Error is QueryException queryException)
+                if (error is Sql4CdsException sql4CdsException)
+                    error = sql4CdsException.InnerException;
+
+                if (error is QueryException queryException)
                 {
                     plan = queryException.Query;
                     index = _params.Offset + queryException.Query.Index;
@@ -743,6 +746,8 @@ namespace MarkMpn.Sql4Cds.XTB
 
                     messageSuffix = "\r\nSee the Execution Plan tab for details of where this error occurred";
                     ShowResult(plan, new ExecuteParams { Execute = true, IncludeFetchXml = true, Sql = plan?.Sql }, null, null, queryExecution);
+                    index = _params.Offset + plan.Index;
+                    length = plan.Length;
 
                     if (queryExecution.InnerException != null)
                         error = queryExecution.InnerException;

--- a/MarkMpn.Sql4Cds.sln
+++ b/MarkMpn.Sql4Cds.sln
@@ -6,6 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkMpn.Sql4Cds.Engine.Tests", "MarkMpn.Sql4Cds.Engine.Tests\MarkMpn.Sql4Cds.Engine.Tests.csproj", "{4448712A-17B8-4D1B-8CEE-6F8CB558FCC1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkMpn.Sql4Cds", "MarkMpn.Sql4Cds\MarkMpn.Sql4Cds.csproj", "{A7AF5D13-A44E-426D-B3FC-AE390832C7DF}"
+	ProjectSection(ProjectDependencies) = postProject
+		{8050B824-A28B-4631-8A95-D127859A9216} = {8050B824-A28B-4631-8A95-D127859A9216}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkMpn.Sql4Cds.Tests", "MarkMpn.Sql4Cds.Tests\MarkMpn.Sql4Cds.Tests.csproj", "{081AA0FB-A019-430A-B05A-F55CAC7C50FD}"
 EndProject

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -22,24 +22,32 @@ plugins or integrations by writing familiar SQL and converting it.
 
 Using the preview TDS Endpoint, SELECT queries can also be run that aren't convertible to FetchXML.</description>
     <summary>Convert SQL queries to FetchXML and execute them against Dataverse / D365</summary>
-    <releaseNotes>Added support for long-term retention data
-Fixed errors with common XML queries
-Improved performance with subqueries
-Avoid exposing internal names for computed columns
-Convert outer joins with filters to inner joins
-Fixed use of UPDATE with CASE expression with a first value of NULL
-Fixed use of joins or subqueries with multiple correlated conditions
-Improved handling of LEFT OUTER JOIN using nested loop operator
-Implemented many-to-many joins using merge join operator
-Fixed cross-instance string comparison
-Lift more filters directly to FetchXML link-entity
-Extended folding of sorts to FetchXML around nested loops
-Improved ambiguous table name detection in UPDATE/DELETE statements with subqueries
-Avoid errors with un-aliased calculated columns in subqueries
-Improved error reporting for AVG and SUM aggregates on non-numeric types
-Handle MIN and MAX aggregates for primary key and lookup columns
-Added support for STRING_AGG function
-Fixed filtering metadata by attribute.sourcetype
+    <releaseNotes>Added sql_variant type support, including SQL_VARIANT_PROPERTY function
+Added IS [NOT] DISTINCT FROM predicate support
+Added @@SERVERNAME and @@VERSION global variables
+Added SERVERPROPERTY function support
+Added USE_LEGACY_UPDATE_MESSAGES query hint to use legacy update messages Assign, SetState, SetParentBusinessUnit and SetBusinessEquipment
+
+Subquery fixes:
+- Only include requested columns from CROSS APPLY and query-defined tables
+- Performance improvements for uncorrelated scalar subqueries
+- Only retrieve minimal rows for scalar subqueries
+- Fixed use of nested IN and EXISTS subqueries
+
+Fixed use of table-valued function with alias
+Fixed JSON_VALUE function with embedded null literals
+Fixed bulk DML operations that require non-standard requests
+Do not use merge joins for data types with different sort ordering
+Fixed filtering and sorting on non-lowercase attributes
+Fixed executing messages with OptionSetValue parameters
+Improved error reporting on batch DML statements
+
+Updated minimum XTB version
+Improved plugin load logic to avoid version problems with dependencies
+Added autocomplete for collation names and variable names
+Fixed cross-threading error when showing warning messages
+Preserve tool window locations
+Improved display of string values containing line breaks and tabs
 </releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -45,7 +45,7 @@ Fixed filtering metadata by attribute.sourcetype
     <language>en-GB</language>
     <tags>XrmToolBox SQL CDS</tags>
     <dependencies>
-      <dependency id="XrmToolBox" version="1.2022.10.58" />
+      <dependency id="XrmToolBox" version="1.2023.6.65" />
     </dependencies>
   </metadata>
   <files>

--- a/MarkMpn.Sql4Cds/MarkMpn.Sql4Cds.csproj
+++ b/MarkMpn.Sql4Cds/MarkMpn.Sql4Cds.csproj
@@ -101,18 +101,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PostBuildEvent>copy $(TargetDir)MarkMpn.Sql4Cds.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins
-
-copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)MarkMpn.Sql4Cds.XTB.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
-copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)MarkMpn.Sql4Cds.Controls.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
-copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)MarkMpn.Sql4Cds.Engine.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
-copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)Microsoft.ApplicationInsights.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
-copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)Microsoft.SqlServer.TransactSql.ScriptDom.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
-copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)XPath2.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
-copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)XPath2.Extensions.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
-</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>copy $(TargetDir)MarkMpn.Sql4Cds.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins
 </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/MarkMpn.Sql4Cds/MarkMpn.Sql4Cds.csproj
+++ b/MarkMpn.Sql4Cds/MarkMpn.Sql4Cds.csproj
@@ -99,9 +99,17 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PostBuildEvent>copy $(TargetDir)MarkMpn.Sql4Cds.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins
+
+copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)MarkMpn.Sql4Cds.XTB.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)MarkMpn.Sql4Cds.Controls.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)MarkMpn.Sql4Cds.Engine.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)Microsoft.ApplicationInsights.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)Microsoft.SqlServer.TransactSql.ScriptDom.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)XPath2.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)XPath2.Extensions.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
+</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.  

--- a/MarkMpn.Sql4Cds/MarkMpn.Sql4Cds.csproj
+++ b/MarkMpn.Sql4Cds/MarkMpn.Sql4Cds.csproj
@@ -111,6 +111,10 @@ copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)XPath2.dll %25appdata%25\MscrmTo
 copy $(SolutionDir)MarkMpn.Sql4Cds.XTB\$(OutDir)XPath2.Extensions.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds
 </PostBuildEvent>
   </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>copy $(TargetDir)MarkMpn.Sql4Cds.dll %25appdata%25\MscrmTools\XrmToolBox\Plugins
+</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.  
   <Target Name="BeforeBuild">

--- a/MarkMpn.Sql4Cds/Properties/AssemblyInfo.cs
+++ b/MarkMpn.Sql4Cds/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Mark Carrington")]
 [assembly: AssemblyProduct("MarkMpn.Sql4Cds")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyCopyright("Copyright © 2019 - 2023 Mark Carrington")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
## Engine
Added `sql_variant` type support, including `SQL_VARIANT_PROPERTY` function
Added `IS [NOT] DISTINCT FROM` predicate support
Added `@@SERVERNAME` and `@@VERSION` global variables
Added `SERVERPROPERTY` function support
Added `USE_LEGACY_UPDATE_MESSAGES` query hint to use legacy update messages `Assign`, `SetState`, `SetParentBusinessUnit` and `SetBusinessEquipment`

Subquery fixes:
* Only include requested columns from `CROSS APPLY` and query-defined tables
* Performance improvements for uncorrelated scalar subqueries
* Only retrieve minimal rows for scalar subqueries
* Fixed use of nested `IN` and `EXISTS` subqueries

Fixed use of table-valued function with alias
Fixed `JSON_VALUE` function with embedded null literals
Fixed bulk DML operations that require non-standard requests
Do not use merge joins for data types with different sort ordering 
Fixed filtering and sorting on non-lowercase attributes
Fixed executing messages with OptionSetValue parameters
Improved error reporting on batch DML statements

## XTB
Updated minimum XTB version
Improved plugin load logic to avoid version problems with dependencies 
Added autocomplete for collation names and variable names
Fixed cross-threading error when showing warning messages
Preserve tool window locations
Improved display of string values containing line breaks and tabs

## ADS
Added autocomplete for collation names and variable names