### PR TITLE
Fixes

### DIFF
--- a/AzureDataStudioExtension/CHANGELOG.md
+++ b/AzureDataStudioExtension/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v7.6.1)(https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.6.1) - 2023-10-15
+
+Fixed use of `IN` subqueries when data source cannot be converted to FetchXML
+Fixed use of `LIKE` filters with data containing embedded returns
+Fixed incorrect row count estimates with joins of huge tables
+Fixed left outer join in nested loop when the first record has no matching records from the right source
+Fixed use of partitioned aggregates within a loop
+Avoid errors when using `DEBUG_BYPASS_OPTIMIZATION` hint
+Avoid using custom paging for `IN` and `EXISTS` filters, and where a single child record is guaranteed by the filters
+
 ## [v7.6.0](https://github.com/MarkMpn/Sql4Cds/releases/tag/v7.6.0) - 2023-09-30
 
 Allow updating many-to-many intersect tables

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -1896,20 +1896,17 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
 
             var select = AssertNode<SelectNode>(plans[0]);
             var fetch = AssertNode<FetchXmlScan>(select.Source);
-            Assert.IsTrue(fetch.UsingCustomPaging);
+            Assert.IsFalse(fetch.UsingCustomPaging);
             AssertFetchXml(fetch, @"
                 <fetch>
                     <entity name='account'>
                         <attribute name='accountid' />
                         <attribute name='name' />
                         <link-entity name='contact' alias='Expr2' from='parentcustomerid' to='accountid' link-type='outer'>
-                            <attribute name='contactid' />
-                            <order attribute='contactid' />
                         </link-entity>
                         <filter>
                             <condition entityname='Expr2' attribute='contactid' operator='null' />
                         </filter>
-                        <order attribute='accountid' />
                     </entity>
                 </fetch>");
         }
@@ -2775,24 +2772,20 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
 
             var fetch = AssertNode<FetchXmlScan>(select.Source);
 
-            Assert.IsTrue(fetch.UsingCustomPaging);
+            Assert.IsFalse(fetch.UsingCustomPaging);
             AssertFetchXml(fetch, @"
                 <fetch>
                     <entity name='account'>
                         <attribute name='name' />
-                        <attribute name='accountid' />
                         <link-entity name='contact' alias='Expr1' from='createdon' to='createdon' link-type='outer'>
-                            <attribute name='contactid' />
                             <filter>
                                 <condition attribute='firstname' operator='eq' value='Mark' />
                             </filter>
-                            <order attribute='contactid' />
                         </link-entity>
                         <filter>
                             <condition attribute='name' operator='like' value='Data8%' />
                             <condition entityname='Expr1' attribute='contactid' operator='null' />
                         </filter>
-                        <order attribute='accountid' />
                     </entity>
                 </fetch>");
         }
@@ -6384,6 +6377,52 @@ INNER JOIN account app ON app.accountid = dups.accountid
 WHERE  app.name = 'Data8'";
 
             var plans = planBuilder.Build(query, null, out _);
+        }
+
+        [TestMethod]
+        public void DoNotUseCustomPagingForInJoin()
+        {
+            // https://github.com/MarkMpn/Sql4Cds/issues/366
+
+            _supportedJoins.Add(JoinOperator.Any);
+
+            try
+            {
+                var planBuilder = new ExecutionPlanBuilder(_dataSources.Values, new OptionsWrapper(this) { PrimaryDataSource = "uat" });
+
+                var query = @"
+SELECT contactid
+FROM   contact
+WHERE  contactid IN (SELECT DISTINCT primarycontactid FROM account WHERE name = 'Data8')
+AND    contactid NOT IN (SELECT DISTINCT primarycontactid FROM account WHERE employees IS NULL)";
+
+                var plans = planBuilder.Build(query, null, out _);
+                var select = AssertNode<SelectNode>(plans[0]);
+                var fetch = AssertNode<FetchXmlScan>(select.Source);
+                AssertFetchXml(fetch, @"
+                    <fetch xmlns:generator='MarkMpn.SQL4CDS'>
+                        <entity name='contact'>
+                            <attribute name='contactid' />
+                            <link-entity name='account' from='primarycontactid' to='contactid' link-type='in' alias='Expr1'>
+                                <filter>
+                                    <condition attribute='name' operator='eq' value='Data8' />
+                                </filter>
+                            </link-entity>
+                            <link-entity name='account' from='primarycontactid' to='contactid' link-type='outer' alias='Expr3'>
+                                <filter>
+                                    <condition attribute='employees' operator='null' />
+                                </filter>
+                            </link-entity>
+                            <filter>
+                                <condition entityname='Expr3' attribute='accountid' operator='null' />
+                            </filter>
+                        </entity>
+                    </fetch>");
+            }
+            finally
+            {
+                _supportedJoins.Remove(JoinOperator.Any);
+            }
         }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -3672,7 +3672,7 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                     </entity>
                 </fetch>");
             var sort = AssertNode<SortNode>(merge.RightSource);
-            Assert.AreEqual("entity.metadataid ASC", sort.Sorts[0].ToSql());
+            Assert.AreEqual("entity.metadataid", sort.Sorts[0].ToSql());
             var meta = AssertNode<MetadataQueryNode>(sort.Source);
         }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -1257,7 +1257,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (!patIndex || !endWildcard)
                 regexBuilder.Append("$");
 
-            return new Regex(regexBuilder.ToString(), pattern.SqlCompareOptions.HasFlag(SqlCompareOptions.IgnoreCase) ? RegexOptions.IgnoreCase : RegexOptions.None);
+            var regexOptions = RegexOptions.Multiline;
+
+            if (pattern.SqlCompareOptions.HasFlag(SqlCompareOptions.IgnoreCase))
+                regexOptions |= RegexOptions.IgnoreCase;
+
+            return new Regex(regexBuilder.ToString(), regexOptions);
         }
 
         private static SqlBoolean Like(SqlString value, SqlString pattern, SqlString escape, bool not)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FoldableJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FoldableJoinNode.cs
@@ -728,6 +728,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             else
             {
                 estimate = leftMax * rightMax;
+
+                // Check for overflow
+                if (estimate < leftMax || estimate < rightMax)
+                    estimate = Int32.MaxValue;
             }
 
             if (leftIsRange && rightIsRange)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/NestedLoopNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/NestedLoopNode.cs
@@ -114,7 +114,17 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 }
 
                 if (!hasRight && JoinType == QualifiedJoinType.LeftOuter)
+                {
+                    if (rightSchema == null)
+                    {
+                        rightSchema = RightSource.GetSchema(rightCompilationContext);
+                        mergedSchema = GetSchema(context, true);
+                        joinCondition = JoinCondition?.Compile(new ExpressionCompilationContext(context, mergedSchema, null));
+                        joinConditionContext = joinCondition == null ? null : new ExpressionExecutionContext(context);
+                    }
+
                     yield return Merge(left, leftSchema, null, rightSchema);
+                }
             }
         }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/PartitionedAggregateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/PartitionedAggregateNode.cs
@@ -90,7 +90,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             InitializePartitionedAggregates(expressionCompilationContext);
             var aggregates = CreateAggregateFunctions(expressionExecutionContext, true);
 
-            var fetchXmlNode = (FetchXmlScan)Source;
+            // Clone the source FetchXmlScan node so we can safely modify it later by adding the partitioning filter
+            // We might be called in a loop and need to execute again, so don't make any changes to the original
+            // source query.
+            var fetchXmlNode = (FetchXmlScan)Source.Clone();
 
             var name = fetchXmlNode.Entity.name;
             var meta = context.DataSources[fetchXmlNode.DataSource].Metadata[name];

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanOptimizer.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanOptimizer.cs
@@ -52,10 +52,8 @@ namespace MarkMpn.Sql4Cds.Engine
             var context = new NodeCompilationContext(DataSources, Options, ParameterTypes);
 
             // Move any additional operators down to the FetchXml
-            var nodes =
-                hints != null && hints.OfType<UseHintList>().Any(list => list.Hints.Any(h => h.Value.Equals("DEBUG_BYPASS_OPTIMIZATION", StringComparison.OrdinalIgnoreCase)))
-                ? new[] { node }
-                : node.FoldQuery(context, hints);
+            var bypassOptimization = hints != null && hints.OfType<UseHintList>().Any(list => list.Hints.Any(h => h.Value.Equals("DEBUG_BYPASS_OPTIMIZATION", StringComparison.OrdinalIgnoreCase)));
+            var nodes = bypassOptimization ? new[] { node } : node.FoldQuery(context, hints);
 
             foreach (var n in nodes)
             {
@@ -66,7 +64,8 @@ namespace MarkMpn.Sql4Cds.Engine
                 SortFetchXmlElements(n);
 
                 // Let the nodes know that folding is now finished so they can do any internal tidy-up
-                MarkComplete(n);
+                if (!bypassOptimization)
+                    MarkComplete(n);
             }
 
             return nodes;

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -11,13 +11,13 @@
     <iconUrl>https://markcarrington.dev/sql4cds-icon/</iconUrl>
     <description>Convert SQL queries to FetchXml and execute them against Dataverse / D365</description>
     <summary>Convert SQL queries to FetchXml and execute them against Dataverse / D365</summary>
-    <releaseNotes>Allow updating many-to-many intersect tables
-Allow folding `NOT EXISTS` predicates to FetchXML for improved performance
-Improved sorting reliability on audit and elastic tables
-Fixed KeyNotFoundException from certain joins
-Fixed NullReferenceException when applying filters to certain joins
-Preserve additional join criteria on `metadata` schema tables
-Fixed use of `SELECT *` in subqueries
+    <releaseNotes>Fixed use of IN subqueries when data source cannot be converted to FetchXML
+Fixed use of LIKE filters with data containing embedded returns
+Fixed incorrect row count estimates with joins of huge tables
+Fixed left outer join in nested loop when the first record has no matching records from the right source
+Fixed use of partitioned aggregates within a loop
+Avoid errors when using DEBUG_BYPASS_OPTIMIZATION hint
+Avoid using custom paging for IN and EXISTS filters, and where a single child record is guaranteed by the filters
     </releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds.Engine/TSqlFragmentExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/TSqlFragmentExtensions.cs
@@ -1,11 +1,16 @@
 ﻿using Microsoft.SqlServer.TransactSql.ScriptDom;
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace MarkMpn.Sql4Cds.Engine
 {
     public static class TSqlFragmentExtensions
     {
+        private static ConcurrentDictionary<Type, Func<TSqlFragment, TSqlFragment>> _fragmentCloneMethods = new ConcurrentDictionary<Type, Func<TSqlFragment, TSqlFragment>>();
+
         /// <summary>
         /// Converts a <see cref="TSqlFragment"/> to the corresponding SQL string
         /// </summary>
@@ -37,425 +42,100 @@ namespace MarkMpn.Sql4Cds.Engine
             if (fragment == null)
                 return null;
 
-            if (fragment is ColumnReferenceExpression col)
+            var cloner = _fragmentCloneMethods.GetOrAdd(fragment.GetType(), CreateCloneMethod);
+
+            return (T)cloner(fragment);
+        }
+
+        private static Func<TSqlFragment, TSqlFragment> CreateCloneMethod(Type type)
+        {
+            var variables = new List<ParameterExpression>();
+            var paramExpr = Expression.Parameter(typeof(TSqlFragment));
+            var typedParam = Expression.Variable(type);
+            variables.Add(typedParam);
+            var clone = Expression.Variable(type);
+            variables.Add(clone);
+            var loopIndex = Expression.Variable(typeof(int));
+            variables.Add(loopIndex);
+            var body = new List<Expression>();
+
+            body.Add(Expression.Assign(typedParam, Expression.Convert(paramExpr, type)));
+            body.Add(Expression.Assign(clone, Expression.New(type.GetConstructor(Array.Empty<Type>()))));
+
+            // Loop over all properties and generate get/clone/set expressions
+            // For IList<T> properties, loop over all values and clone/add
+            foreach (var prop in type.GetProperties())
             {
-                return (T)(object)new ColumnReferenceExpression
+                if (prop.GetIndexParameters().Length > 0)
+                    continue;
+
+                if (prop.Name != nameof(TSqlFragment.ScriptTokenStream) && prop.PropertyType.IsGenericType && prop.PropertyType.GetGenericTypeDefinition() == typeof(IList<>))
                 {
-                    Collation = col.Collation.Clone(),
-                    ColumnType = col.ColumnType,
-                    MultiPartIdentifier = col.MultiPartIdentifier.Clone(),
-                };
-            }
+                    var itemType = prop.PropertyType.GetGenericArguments()[0];
+                    var collectionType = typeof(ICollection<>).MakeGenericType(itemType);
+                    var indexerProp = prop.PropertyType.GetProperties().Single(p => p.GetIndexParameters().Length == 1);
 
-            if (fragment is Identifier id)
-            {
-                return (T)(object)new Identifier
+                    var loopEnd = Expression.Label();
+                    body.Add(Expression.Assign(loopIndex, Expression.Constant(0)));
+                    body.Add(
+                        Expression.Loop(
+                            Expression.Block(
+                                Expression.IfThen(
+                                    Expression.Equal(
+                                        loopIndex,
+                                        Expression.Property(
+                                            Expression.Convert(
+                                                Expression.Property(typedParam, prop),
+                                                collectionType
+                                                ),
+                                            nameof(ICollection<object>.Count)
+                                            )
+                                        ),
+                                    Expression.Break(loopEnd)
+                                    ),
+                                Expression.Call(
+                                    Expression.Convert(Expression.Property(clone, prop), collectionType),
+                                    nameof(ICollection<object>.Add),
+                                    Array.Empty<Type>(),
+                                    typeof(TSqlFragment).IsAssignableFrom(itemType)
+                                    ? (Expression)Expression.Call(typeof(TSqlFragmentExtensions).GetMethod(nameof(Clone)).MakeGenericMethod(itemType), Expression.MakeIndex(Expression.Property(typedParam, prop), indexerProp, new[] { loopIndex }))
+                                    : Expression.MakeIndex(Expression.Property(typedParam, prop), indexerProp, new[] { loopIndex })
+                                    ),
+                                Expression.PostIncrementAssign(loopIndex)
+                                ),
+                            loopEnd
+                            )
+                        );
+                }
+                else if (prop.CanWrite)
                 {
-                    QuoteType = id.QuoteType,
-                    Value = id.Value,
-                };
+                    if (typeof(TSqlFragment).IsAssignableFrom(prop.PropertyType))
+                    {
+                        body.Add(
+                            Expression.Assign(
+                                Expression.Property(clone, prop),
+                                Expression.Call(typeof(TSqlFragmentExtensions).GetMethod(nameof(Clone)).MakeGenericMethod(prop.PropertyType), Expression.Property(typedParam, prop))
+                                )
+                            );
+                    }
+                    else
+                    {
+                        body.Add(
+                            Expression.Assign(
+                                Expression.Property(clone, prop),
+                                Expression.Property(typedParam, prop)
+                                )
+                            );
+                    }
+                }
             }
 
-            if (fragment is IdentifierLiteral guid)
-            {
-                return (T)(object)new IdentifierLiteral
-                {
-                    Collation = guid.Collation.Clone(),
-                    QuoteType = guid.QuoteType,
-                    Value = guid.Value,
-                };
-            }
+            var returnTarget = Expression.Label(typeof(TSqlFragment));
+            body.Add(Expression.Return(returnTarget, clone));
+            body.Add(Expression.Label(returnTarget, clone));
 
-            if (fragment is IntegerLiteral i)
-            {
-                return (T)(object)new IntegerLiteral
-                {
-                    Collation = i.Collation.Clone(),
-                    Value = i.Value,
-                };
-            }
-
-            if (fragment is MoneyLiteral money)
-            {
-                return (T)(object)new MoneyLiteral
-                {
-                    Collation = money.Collation.Clone(),
-                    Value = money.Value,
-                };
-            }
-
-            if (fragment is NullLiteral n)
-            {
-                return (T)(object)new NullLiteral
-                {
-                    Collation = n.Collation.Clone(),
-                    Value = n.Value,
-                };
-            }
-
-            if (fragment is NumericLiteral num)
-            {
-                return (T)(object)new NumericLiteral
-                {
-                    Collation = num.Collation.Clone(),
-                    Value = num.Value,
-                };
-            }
-
-            if (fragment is RealLiteral real)
-            {
-                return (T)(object)new RealLiteral
-                {
-                    Collation = real.Collation.Clone(),
-                    Value = real.Value,
-                };
-            }
-
-            if (fragment is StringLiteral str)
-            {
-                return (T)(object)new StringLiteral
-                {
-                    Collation = str.Collation.Clone(),
-                    IsLargeObject = str.IsLargeObject,
-                    IsNational = str.IsNational,
-                    Value = str.Value,
-                };
-            }
-
-            if (fragment is OdbcLiteral odbc)
-            {
-                return (T)(object)new OdbcLiteral
-                {
-                    Collation = odbc.Collation.Clone(),
-                    IsNational = odbc.IsNational,
-                    OdbcLiteralType = odbc.OdbcLiteralType,
-                    Value = odbc.Value,
-                };
-            }
-
-            if (fragment is MaxLiteral max)
-            {
-                return (T)(object)new MaxLiteral
-                {
-                    Collation = max.Collation.Clone(),
-                    Value = max.Value
-                };
-            }
-
-            if (fragment is BooleanBinaryExpression boolBin)
-            {
-                return (T)(object)new BooleanBinaryExpression
-                {
-                    BinaryExpressionType = boolBin.BinaryExpressionType,
-                    FirstExpression = boolBin.FirstExpression.Clone(),
-                    SecondExpression = boolBin.SecondExpression.Clone(),
-                };
-            }
-
-            if (fragment is BooleanComparisonExpression cmp)
-            {
-                return (T)(object)new BooleanComparisonExpression
-                {
-                    ComparisonType = cmp.ComparisonType,
-                    FirstExpression = cmp.FirstExpression.Clone(),
-                    SecondExpression = cmp.SecondExpression.Clone(),
-                };
-            }
-
-            if (fragment is BooleanParenthesisExpression boolParen)
-            {
-                return (T)(object)new BooleanParenthesisExpression
-                {
-                    Expression = boolParen.Expression.Clone(),
-                };
-            }
-
-            if (fragment is InPredicate inPred)
-            {
-                var clone = new InPredicate
-                {
-                    Expression = inPred.Expression.Clone(),
-                    NotDefined = inPred.NotDefined,
-                    Subquery = inPred.Subquery.Clone(),
-                };
-
-                foreach (var value in inPred.Values)
-                    clone.Values.Add(value.Clone());
-
-                return (T)(object)clone;
-            }
-
-            if (fragment is BooleanIsNullExpression isNull)
-            {
-                return (T)(object)new BooleanIsNullExpression
-                {
-                    Expression = isNull.Expression.Clone(),
-                    IsNot = isNull.IsNot,
-                };
-            }
-
-            if (fragment is LikePredicate like)
-            {
-                return (T)(object)new LikePredicate
-                {
-                    EscapeExpression = like.EscapeExpression.Clone(),
-                    FirstExpression = like.FirstExpression.Clone(),
-                    NotDefined = like.NotDefined,
-                    OdbcEscape = like.OdbcEscape,
-                    SecondExpression = like.SecondExpression.Clone(),
-                };
-            }
-
-            if (fragment is BooleanNotExpression not)
-            {
-                return (T)(object)new BooleanNotExpression
-                {
-                    Expression = not.Expression.Clone(),
-                };
-            }
-
-            if (fragment is FullTextPredicate fullText)
-            {
-                var clone = new FullTextPredicate
-                {
-                    FullTextFunctionType = fullText.FullTextFunctionType,
-                    LanguageTerm = fullText.LanguageTerm.Clone(),
-                    PropertyName = fullText.PropertyName.Clone(),
-                    Value = fullText.Value.Clone(),
-                };
-
-                foreach (var c in fullText.Columns)
-                    clone.Columns.Add(c.Clone());
-
-                return (T)(object)clone;
-            }
-
-            if (fragment is BinaryExpression bin)
-            {
-                return (T)(object)new BinaryExpression
-                {
-                    BinaryExpressionType = bin.BinaryExpressionType,
-                    FirstExpression = bin.FirstExpression.Clone(),
-                    SecondExpression = bin.SecondExpression.Clone(),
-                };
-            }
-
-            if (fragment is FunctionCall func)
-            {
-                var clone = new FunctionCall
-                {
-                    CallTarget = func.CallTarget.Clone(),
-                    Collation = func.Collation.Clone(),
-                    FunctionName = func.FunctionName.Clone(),
-                    OverClause = func.OverClause.Clone(),
-                    UniqueRowFilter = func.UniqueRowFilter,
-                    WithinGroupClause = func.WithinGroupClause.Clone(),
-                };
-
-                foreach (var p in func.Parameters)
-                    clone.Parameters.Add(p.Clone());
-
-                return (T)(object)clone;
-            }
-
-            if (fragment is ParenthesisExpression paren)
-            {
-                return (T)(object)new ParenthesisExpression
-                {
-                    Collation = paren.Collation.Clone(),
-                    Expression = paren.Expression.Clone(),
-                };
-            }
-
-            if (fragment is UnaryExpression unary)
-            {
-                return (T)(object)new UnaryExpression
-                {
-                    Expression = unary.Expression.Clone(),
-                    UnaryExpressionType = unary.UnaryExpressionType,
-                };
-            }
-
-            if (fragment is VariableReference var)
-            {
-                return (T)(object)new VariableReference
-                {
-                    Collation = var.Collation.Clone(),
-                    Name = var.Name,
-                };
-            }
-
-            if (fragment is SimpleCaseExpression simpleCase)
-            {
-                var clone = new SimpleCaseExpression
-                {
-                    Collation = simpleCase.Collation.Clone(),
-                    ElseExpression = simpleCase.ElseExpression.Clone(),
-                    InputExpression = simpleCase.InputExpression.Clone(),
-                };
-
-                foreach (var w in simpleCase.WhenClauses)
-                    clone.WhenClauses.Add(w.Clone());
-
-                return (T)(object)clone;
-            }
-
-            if (fragment is SimpleWhenClause simpleWhenClause)
-            {
-                return (T)(object)new SimpleWhenClause
-                {
-                    ThenExpression = simpleWhenClause.ThenExpression.Clone(),
-                    WhenExpression = simpleWhenClause.WhenExpression.Clone(),
-                };
-            }
-
-            if (fragment is SearchedCaseExpression searchedCase)
-            {
-                var clone = new SearchedCaseExpression
-                {
-                    Collation = searchedCase.Collation.Clone(),
-                    ElseExpression = searchedCase.ElseExpression.Clone(),
-                };
-
-                foreach (var w in searchedCase.WhenClauses)
-                    clone.WhenClauses.Add(w.Clone());
-
-                return (T)(object)clone;
-            }
-
-            if (fragment is SearchedWhenClause searchedWhenClause)
-            {
-                return (T)(object)new SearchedWhenClause
-                {
-                    ThenExpression = searchedWhenClause.ThenExpression.Clone(),
-                    WhenExpression = searchedWhenClause.WhenExpression.Clone(),
-                };
-            }
-
-            if (fragment is ConvertCall convert)
-            {
-                return (T)(object)new ConvertCall
-                {
-                    Collation = convert.Collation.Clone(),
-                    DataType = convert.DataType.Clone(),
-                    Parameter = convert.Parameter.Clone(),
-                    Style = convert.Style.Clone(),
-                };
-            }
-
-            if (fragment is SqlDataTypeReference sqlDataType)
-            {
-                var clone = new SqlDataTypeReference
-                {
-                    Name = sqlDataType.Name.Clone(),
-                    SqlDataTypeOption = sqlDataType.SqlDataTypeOption,
-                };
-
-                foreach (var p in sqlDataType.Parameters)
-                    clone.Parameters.Add(p.Clone());
-
-                return (T)(object)clone;
-            }
-
-            if (fragment is SchemaObjectName name)
-            {
-                var clone = new SchemaObjectName();
-
-                foreach (var nameId in name.Identifiers)
-                    clone.Identifiers.Add(nameId.Clone());
-
-                return (T)(object)clone;
-            }
-
-            if (fragment is MultiPartIdentifier mid)
-            {
-                var clone = new MultiPartIdentifier();
-
-                foreach (var cid in mid.Identifiers)
-                    clone.Identifiers.Add(cid.Clone());
-
-                return (T)(object)clone;
-            }
-
-            if (fragment is UserDataTypeReference userDataType)
-            {
-                var clone = new UserDataTypeReference
-                {
-                    Name = userDataType.Name.Clone(),
-                };
-
-                foreach (var p in userDataType.Parameters)
-                    clone.Parameters.Add(p.Clone());
-
-                return (T)(object)clone;
-            }
-
-            if (fragment is XmlDataTypeReference xmlDataType)
-            {
-                return (T)(object)new XmlDataTypeReference
-                {
-                    Name = xmlDataType.Name.Clone(),
-                    XmlDataTypeOption = xmlDataType.XmlDataTypeOption,
-                    XmlSchemaCollection = xmlDataType.XmlSchemaCollection?.Clone()
-                };
-            }
-
-            if (fragment is CastCall cast)
-            {
-                return (T)(object)new CastCall
-                {
-                    Collation = cast.Collation.Clone(),
-                    DataType = cast.DataType.Clone(),
-                    Parameter = cast.Parameter.Clone(),
-                };
-            }
-
-            if (fragment is ParameterlessCall parameterless)
-            {
-                return (T)(object)new ParameterlessCall
-                {
-                    Collation = parameterless.Collation.Clone(),
-                    ParameterlessCallType = parameterless.ParameterlessCallType,
-                };
-            }
-
-            if (fragment is GlobalVariableExpression global)
-            {
-                return (T)(object)new GlobalVariableExpression
-                {
-                    Collation = global.Collation.Clone(),
-                    Name = global.Name,
-                };
-            }
-
-            if (fragment is ExpressionWithSortOrder sort)
-            {
-                return (T)(object)new ExpressionWithSortOrder
-                {
-                    Expression = sort.Expression.Clone(),
-                    SortOrder = sort.SortOrder,
-                };
-            }
-
-            if (fragment is ExpressionCallTarget callTarget)
-            {
-                return (T)(object)new ExpressionCallTarget
-                {
-                    Expression = callTarget.Expression.Clone(),
-                };
-            }
-
-            if (fragment is DistinctPredicate distinct)
-            {
-                return (T)(object)new DistinctPredicate
-                {
-                    IsNot = distinct.IsNot,
-                    FirstExpression = distinct.FirstExpression.Clone(),
-                    SecondExpression = distinct.SecondExpression.Clone(),
-                };
-            }
-
-            throw new NotSupportedQueryFragmentException("Unhandled expression type", fragment);
+            var block = Expression.Block(typeof(TSqlFragment), variables, body);
+            return Expression.Lambda<Func<TSqlFragment,TSqlFragment>>(block, paramExpr).Compile();
         }
     }
 }

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -22,15 +22,13 @@ plugins or integrations by writing familiar SQL and converting it.
 
 Using the preview TDS Endpoint, SELECT queries can also be run that aren't convertible to FetchXML.</description>
     <summary>Convert SQL queries to FetchXML and execute them against Dataverse / D365</summary>
-    <releaseNotes>Allow updating many-to-many intersect tables
-Allow folding `NOT EXISTS` predicates to FetchXML for improved performance
-Improved sorting reliability on audit and elastic tables
-Fixed KeyNotFoundException from certain joins
-Fixed NullReferenceException when applying filters to certain joins
-Preserve additional join criteria on `metadata` schema tables
-Fixed use of `SELECT *` in subqueries
-Added option to reset tool windows
-Fixed error message when cancelling query
+    <releaseNotes>Fixed use of IN subqueries when data source cannot be converted to FetchXML
+Fixed use of LIKE filters with data containing embedded returns
+Fixed incorrect row count estimates with joins of huge tables
+Fixed left outer join in nested loop when the first record has no matching records from the right source
+Fixed use of partitioned aggregates within a loop
+Avoid errors when using DEBUG_BYPASS_OPTIMIZATION hint
+Avoid using custom paging for IN and EXISTS filters, and where a single child record is guaranteed by the filters
     </releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds/MarkMpn.Sql4Cds.csproj
+++ b/MarkMpn.Sql4Cds/MarkMpn.Sql4Cds.csproj
@@ -73,6 +73,7 @@
   <ItemGroup>
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WindowsExplorerFileSelector.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MarkMpn.Sql4Cds.Controls\MarkMpn.Sql4Cds.Controls.csproj">

--- a/MarkMpn.Sql4Cds/WindowsExplorerFileSelector.cs
+++ b/MarkMpn.Sql4Cds/WindowsExplorerFileSelector.cs
@@ -1,0 +1,285 @@
+﻿/*
+ * Created by SharpDevelop.
+ * User: Aurimas Rekstys
+ * Date: 6/24/2018
+ * Time: 6:44 PM
+ * https://raw.githubusercontent.com/aurire/windows-explorer-files-selector/master/windows-explorer-file-selector/windows-explorer-file-selector.cs
+ * 
+ */
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace windowsExplorerFileSelector
+{
+
+    [Flags]
+    internal enum SHCONT : ushort
+    {
+        SHCONTF_CHECKING_FOR_CHILDREN = 0x0010,
+        SHCONTF_FOLDERS = 0x0020,
+        SHCONTF_NONFOLDERS = 0x0040,
+        SHCONTF_INCLUDEHIDDEN = 0x0080,
+        SHCONTF_INIT_ON_FIRST_NEXT = 0x0100,
+        SHCONTF_NETPRINTERSRCH = 0x0200,
+        SHCONTF_SHAREABLE = 0x0400,
+        SHCONTF_STORAGE = 0x0800,
+        SHCONTF_NAVIGATION_ENUM = 0x1000,
+        SHCONTF_FASTITEMS = 0x2000,
+        SHCONTF_FLATLIST = 0x4000,
+        SHCONTF_ENABLE_ASYNC = 0x8000
+    }
+
+    [ComImport,
+    Guid("000214E6-0000-0000-C000-000000000046"),
+    InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
+    ComConversionLoss]
+    internal interface IShellFolder
+    {
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        void ParseDisplayName(IntPtr hwnd, [In, MarshalAs(UnmanagedType.Interface)] IBindCtx pbc, [In, MarshalAs(UnmanagedType.LPWStr)] string pszDisplayName, [Out] out uint pchEaten, [Out] out IntPtr ppidl, [In, Out] ref uint pdwAttributes);
+        [PreserveSig]
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        int EnumObjects([In] IntPtr hwnd, [In] SHCONT grfFlags, [MarshalAs(UnmanagedType.Interface)] out IEnumIDList ppenumIDList);
+
+        [PreserveSig]
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        int BindToObject([In] IntPtr pidl, [In, MarshalAs(UnmanagedType.Interface)] IBindCtx pbc, [In] ref Guid riid, [Out, MarshalAs(UnmanagedType.Interface)] out IShellFolder ppv);
+
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        void BindToStorage([In] ref IntPtr pidl, [In, MarshalAs(UnmanagedType.Interface)] IBindCtx pbc, [In] ref Guid riid, out IntPtr ppv);
+
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        void CompareIDs([In] IntPtr lParam, [In] ref IntPtr pidl1, [In] ref IntPtr pidl2);
+
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        void CreateViewObject([In] IntPtr hwndOwner, [In] ref Guid riid, out IntPtr ppv);
+
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        void GetAttributesOf([In] uint cidl, [In] IntPtr apidl, [In, Out] ref uint rgfInOut);
+
+
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        void GetUIObjectOf([In] IntPtr hwndOwner, [In] uint cidl, [In] IntPtr apidl, [In] ref Guid riid, [In, Out] ref uint rgfReserved, out IntPtr ppv);
+
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        void GetDisplayNameOf([In] ref IntPtr pidl, [In] uint uFlags, out IntPtr pName);
+
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        void SetNameOf([In] IntPtr hwnd, [In] ref IntPtr pidl, [In, MarshalAs(UnmanagedType.LPWStr)] string pszName, [In] uint uFlags, [Out] IntPtr ppidlOut);
+    }
+
+    [ComImport,
+    Guid("000214F2-0000-0000-C000-000000000046"),
+    InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IEnumIDList
+    {
+        [PreserveSig]
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        int Next(uint celt, IntPtr rgelt, out uint pceltFetched);
+
+        [PreserveSig]
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        int Skip([In] uint celt);
+
+        [PreserveSig]
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        int Reset();
+
+        [PreserveSig]
+        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+        int Clone([MarshalAs(UnmanagedType.Interface)] out IEnumIDList ppenum);
+    }
+
+
+
+    static class ShowSelectedInExplorer
+    {
+
+
+        class NativeMethods
+        {
+            static readonly int pointerSize = Marshal.SizeOf(typeof(IntPtr));
+
+            [DllImport("ole32.dll", EntryPoint = "CreateBindCtx")]
+            public static extern int CreateBindCtx_(int reserved, out IBindCtx ppbc);
+
+            public static IBindCtx CreateBindCtx()
+            {
+                IBindCtx result;
+                Marshal.ThrowExceptionForHR(CreateBindCtx_(0, out result));
+                return result;
+            }
+
+            [DllImport("shell32.dll", EntryPoint = "SHGetDesktopFolder", CharSet = CharSet.Unicode, SetLastError = true)]
+            static extern int SHGetDesktopFolder_([MarshalAs(UnmanagedType.Interface)] out IShellFolder ppshf);
+
+            public static IShellFolder SHGetDesktopFolder()
+            {
+                IShellFolder result;
+                Marshal.ThrowExceptionForHR(SHGetDesktopFolder_(out result));
+                return result;
+            }
+
+            [DllImport("shell32.dll", EntryPoint = "SHOpenFolderAndSelectItems")]
+            static extern int SHOpenFolderAndSelectItems_(
+                [In] IntPtr pidlFolder, uint cidl, [In, Optional, MarshalAs(UnmanagedType.LPArray)] IntPtr[] apidl, int dwFlags
+            );
+
+            public static void SHOpenFolderAndSelectItems(IntPtr pidlFolder, IntPtr[] apidl, int dwFlags)
+            {
+                var cidl = (apidl != null) ? (uint)apidl.Length : 0U;
+                var result = NativeMethods.SHOpenFolderAndSelectItems_(pidlFolder, cidl, apidl, dwFlags);
+                Marshal.ThrowExceptionForHR(result);
+            }
+
+            [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+            public static extern IntPtr ILCreateFromPath([In, MarshalAs(UnmanagedType.LPWStr)] string pszPath);
+
+            [DllImport("shell32.dll")]
+            public static extern void ILFree([In] IntPtr pidl);
+        }
+
+        static IntPtr GetShellFolderChildrenRelativePIDL(IShellFolder parentFolder, string displayName)
+        {
+            var bindCtx = NativeMethods.CreateBindCtx();
+
+            uint pchEaten;
+            uint pdwAttributes = 0;
+            IntPtr ppidl;
+            parentFolder.ParseDisplayName(IntPtr.Zero, null, displayName, out pchEaten, out ppidl, ref pdwAttributes);
+
+            return ppidl;
+        }
+
+        static IntPtr PathToAbsolutePIDL(string path)
+        {
+            var desktopFolder = NativeMethods.SHGetDesktopFolder();
+            return GetShellFolderChildrenRelativePIDL(desktopFolder, path);
+        }
+
+        static Guid IID_IShellFolder = typeof(IShellFolder).GUID;
+        static int pointerSize = Marshal.SizeOf(typeof(IntPtr));
+
+        static IShellFolder PIDLToShellFolder(IShellFolder parent, IntPtr pidl)
+        {
+            IShellFolder folder;
+            var result = parent.BindToObject(pidl, null, ref IID_IShellFolder, out folder);
+            Marshal.ThrowExceptionForHR((int)result);
+            return folder;
+        }
+
+        static IShellFolder PIDLToShellFolder(IntPtr pidl)
+        {
+            return PIDLToShellFolder(NativeMethods.SHGetDesktopFolder(), pidl);
+        }
+
+        static void SHOpenFolderAndSelectItems(IntPtr pidlFolder, IntPtr[] apidl, bool edit)
+        {
+            NativeMethods.SHOpenFolderAndSelectItems(pidlFolder, apidl, edit ? 1 : 0);
+        }
+
+        public static void FileOrFolder(string path, bool edit = false)
+        {
+            if (path == null)
+                throw new ArgumentNullException("path");
+
+            var pidl = PathToAbsolutePIDL(path);
+            try
+            {
+                SHOpenFolderAndSelectItems(pidl, null, edit);
+            }
+            finally
+            {
+                NativeMethods.ILFree(pidl);
+            }
+        }
+
+        static IEnumerable<FileSystemInfo> PathToFileSystemInfo(IEnumerable<string> paths)
+        {
+            foreach (var path in paths)
+            {
+                string fixedPath = path;
+                if (fixedPath.EndsWith(Path.DirectorySeparatorChar.ToString()) || fixedPath.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+                {
+                    fixedPath = fixedPath.Remove(fixedPath.Length - 1);
+                }
+
+                if (Directory.Exists(fixedPath))
+                    yield return new DirectoryInfo(fixedPath);
+                else if (File.Exists(fixedPath))
+                    yield return new FileInfo(fixedPath);
+                else
+                {
+                    throw new FileNotFoundException("The specified file or folder doesn't exists : " + fixedPath, fixedPath);
+                }
+            }
+        }
+
+        public static void FilesOrFolders(string parentDirectory, ICollection<string> filenames)
+        {
+            if (filenames == null)
+                throw new ArgumentNullException("filenames");
+            if (filenames.Count == 0)
+                return;
+
+            var parentPidl = PathToAbsolutePIDL(parentDirectory);
+            try
+            {
+                var parent = PIDLToShellFolder(parentPidl);
+
+                List<IntPtr> filesPidl = new List<IntPtr>(filenames.Count);
+                foreach (var filename in filenames)
+                {
+                    filesPidl.Add(GetShellFolderChildrenRelativePIDL(parent, filename));
+                }
+
+                try
+                {
+                    SHOpenFolderAndSelectItems(parentPidl, filesPidl.ToArray(), false);
+                }
+                finally
+                {
+                    foreach (var pidl in filesPidl)
+                    {
+                        NativeMethods.ILFree(pidl);
+                    }
+                }
+            }
+            finally
+            {
+                NativeMethods.ILFree(parentPidl);
+            }
+        }
+
+        public static void FilesOrFolders(string[] paths)
+        {
+            FilesOrFolders((IEnumerable<string>)paths);
+        }
+
+        public static void FilesOrFolders(IEnumerable<string> paths)
+        {
+            FilesOrFolders(PathToFileSystemInfo(paths));
+        }
+
+        public static void FilesOrFolders(IEnumerable<FileSystemInfo> paths)
+        {
+            if (paths == null)
+                throw new ArgumentNullException("paths");
+            if (paths.Count() == 0)
+                return;
+
+            var explorerWindows = paths.GroupBy(p => Path.GetDirectoryName(p.FullName));
+
+            foreach (var explorerWindowPaths in explorerWindows)
+            {
+                var parentDirectory = Path.GetDirectoryName(explorerWindowPaths.First().FullName);
+                FilesOrFolders(parentDirectory, explorerWindowPaths.Select(fsi => fsi.Name).ToList());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Enable cloning all SQL fragments
Fixed use of `LIKE` with data containing embedded returns
Fixed incorrect row count estimates due to arithmetic overflow
Fixed left outer join in nested loop when first record has no matching records from right source
Fixed use of partitioned aggregates within a loop
Avoid errors when viewing naïve execution plan with `DEBUG_BYPASS_OPTIMIZATION` hint
Avoid using custom paging for `IN` and `EXISTS` filters, and where a single child record is guaranteed by the filters