### PR TITLE
Remove BypassCustomPluginExecution from pre-delete confirmation

### DIFF
--- a/MarkMpn.Sql4Cds.XTB/QueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds.XTB/QueryExecutionOptions.cs
@@ -104,14 +104,14 @@ namespace MarkMpn.Sql4Cds.XTB
 
         private bool ConfirmDelete(Sql4CdsConnection con, ConfirmDmlStatementEventArgs e)
         {
-            if (e.Count > Settings.Instance.DeleteWarnThreshold || e.BypassCustomPluginExecution)
+            if (e.Count > Settings.Instance.DeleteWarnThreshold)
             {
                 var msg = $"Delete will affect {e.Count:N0} {GetDisplayName(e.Count, e.Metadata)}.";
                 if (e.BypassCustomPluginExecution)
                     msg += "\r\n\r\nThis operation will bypass any custom plugins.";
 
                 var result = ShowMessageBox(msg);
-
+                
                 if (result == DialogResult.No)
                     return false;
             }


### PR DESCRIPTION
If there 10 separate delete statements there will be 10 prompts (if delete count > threshold), just because BypassCustomPluginExecution is checked. So, I have removed this check. 