### PR TITLE
V9 fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
@@ -2049,5 +2049,31 @@ END CATCH";
                 Assert.AreEqual("Dapper", name);
             }
         }
+
+        [TestMethod]
+        public void IfExists()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSources))
+            {
+                string message = null;
+
+                con.InfoMessage += (sender, e) =>
+                {
+                    message = e.Message.Message;
+                };
+
+                con.Execute(@"
+                    IF EXISTS(SELECT * FROM account WHERE name = 'Data8')
+                    BEGIN
+                        PRINT 'Exists'
+                    END
+                    ELSE
+                    BEGIN
+                        PRINT 'Not Exists'
+                    END");
+
+                Assert.AreEqual("Not Exists", message);
+            }
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/JsonPathTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/JsonPathTests.cs
@@ -86,35 +86,35 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnUnknownMode()
         {
             new JsonPath("laxtrict $.path.to.\"sub-object\"");
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnExtraQuotes()
         {
             new JsonPath("laxtrict $.path.to.\"\"sub-object\"\"");
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnMissingLeadingDollar()
         {
             new JsonPath("path.to.\"sub-object\"");
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnDoublePeriod()
         {
             new JsonPath("$.path..to.\"sub-object\"");
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnTrailingPeriod()
         {
             new JsonPath("$.path.to.\"sub-object\".");
@@ -139,28 +139,28 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnNegativeIndexer()
         {
             new JsonPath("$.path.to.\"sub-object\"[-1]");
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnAlphaIndexer()
         {
             new JsonPath("$.path.to.\"sub-object\"[x]");
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnMissingCloseBracket()
         {
             new JsonPath("$.path.to.\"sub-object\"[1");
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnMissingOpeningBracket()
         {
             new JsonPath("$.path.to1]");
@@ -185,21 +185,21 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnDollarNotAtStart()
         {
             new JsonPath("$.path.$.to");
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnUnquotedDollar()
         {
             new JsonPath("$.path$");
         }
 
         [TestMethod]
-        [ExpectedException(typeof(JsonException))]
+        [ExpectedException(typeof(JsonPathException))]
         public void FailsOnLeadingNumber()
         {
             new JsonPath("$.1path");

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsError.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsError.cs
@@ -387,6 +387,11 @@ namespace MarkMpn.Sql4Cds.Engine
             return Create(13611, fragment);
         }
 
+        internal static Sql4CdsError JsonPathFormatError(char c, int index)
+        {
+            return Create(13607, null, Collation.USEnglish.ToSqlString(c.ToString()), (SqlInt32)index);
+        }
+
         internal static Sql4CdsError XQueryMissingVariable(string name)
         {
             return Create(9501, null, (SqlInt32)name.Length, Collation.USEnglish.ToSqlString(name));

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsError.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsError.cs
@@ -106,6 +106,11 @@ namespace MarkMpn.Sql4Cds.Engine
             return new Sql4CdsError(template.Class, template.Number, (string)ExpressionFunctions.FormatMessage(template.Message, null, values.Select(v => Collation.USEnglish.ToSqlString(v.ToString())).Cast<INullable>().ToArray()), fragment);
         }
 
+        internal static Sql4CdsError InternalError(string message, TSqlFragment fragment = null)
+        {
+            return new Sql4CdsError(16, 10337, message, fragment);
+        }
+
         internal static Sql4CdsError NotSupported(TSqlFragment fragment, string clause)
         {
             return Create(40517, fragment, (SqlInt32)clause.Length, Collation.USEnglish.ToSqlString(clause));

--- a/MarkMpn.Sql4Cds.Engine/Ado/SqlDataReaderWrapper.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/SqlDataReaderWrapper.cs
@@ -21,8 +21,8 @@ namespace MarkMpn.Sql4Cds.Engine
             _sqlCommand = sqlCommand;
             cancellationToken.Register(() => _sqlCommand.Cancel());
 
-            HandleException(() => _sqlDataReader = sqlCommand.ExecuteReader(behavior));
             _node = node;
+            HandleException(() => _sqlDataReader = sqlCommand.ExecuteReader(behavior));
 
             foreach (SqlParameter parameter in sqlCommand.Parameters)
                 _node.Parameters.Add(parameter.ParameterName);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseDmlNode.cs
@@ -764,7 +764,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 .Where(r => r.Fault != null)
                 .ToList();
 
-            Interlocked.Add(ref count, resp.Responses.Count - errorResponses.Count);
+            Interlocked.Add(ref count, req.Requests.Count - errorResponses.Count);
             Interlocked.Add(ref errorCount, errorResponses.Count);
 
             var error = errorResponses.FirstOrDefault(item => FilterErrors(context, req.Requests[item.RequestIndex], item.Fault));

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/DeleteNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/DeleteNode.cs
@@ -168,7 +168,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     confirmArgs.Cancel = true;
                 context.Options.ConfirmDelete(confirmArgs);
                 if (confirmArgs.Cancel)
-                    throw new OperationCanceledException("DELETE cancelled by user");
+                    throw new QueryExecutionException(new Sql4CdsError(11, 0, 0, null, null, 0, "DELETE cancelled by user", null));
 
                 using (_timer.Run())
                 {
@@ -194,10 +194,6 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 if (ex.Node == null)
                     ex.Node = this;
 
-                throw;
-            }
-            catch (OperationCanceledException)
-            {
                 throw;
             }
             catch (Exception ex)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -747,7 +747,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             }
 
             foreach (var linkEntity in items.OfType<FetchLinkEntityType>())
+            {
+                if (linkEntity.alias == null || linkEntity.Items == null)
+                    continue;
+
                 PrefixAliasedScalarAttributes(entity, linkEntity.Items, linkEntity.alias.EscapeIdentifier());
+            }
         }
 
         private Dictionary<string, List<ParameterizedCondition>> FindParameterizedConditions()

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/InsertNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/InsertNode.cs
@@ -136,7 +136,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     confirmArgs.Cancel = true;
                 context.Options.ConfirmInsert(confirmArgs);
                 if (confirmArgs.Cancel)
-                    throw new OperationCanceledException("INSERT cancelled by user");
+                    throw new QueryExecutionException(new Sql4CdsError(11, 0, 0, null, null, 0, "INSERT cancelled by user", null));
 
                 using (_timer.Run())
                 {
@@ -164,10 +164,6 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 if (ex.Node == null)
                     ex.Node = this;
 
-                throw;
-            }
-            catch (OperationCanceledException)
-            {
                 throw;
             }
             catch (Exception ex)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/QueryExecutionException.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/QueryExecutionException.cs
@@ -40,14 +40,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     else if (innerEx is FaultException<OrganizationServiceFault> innerFaultEx)
                         errors.Add(new Sql4CdsError(16, FaultCodeToSqlError(innerFaultEx.Detail), innerFaultEx.Message));
                     else
-                        errors.Add(new Sql4CdsError(16, 10337, innerEx.Message));
+                        errors.Add(Sql4CdsError.InternalError(innerEx.Message));
                 }
 
                 Errors = errors;
             }
             else
             {
-                Errors = new[] { new Sql4CdsError(16, 10337, message) };
+                Errors = new[] { Sql4CdsError.InternalError(message) };
             }
         }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/UpdateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/UpdateNode.cs
@@ -150,7 +150,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     confirmArgs.Cancel = true;
                 context.Options.ConfirmUpdate(confirmArgs);
                 if (confirmArgs.Cancel)
-                    throw new OperationCanceledException("UPDATE cancelled by user");
+                    throw new QueryExecutionException(new Sql4CdsError(11, 0, 0, null, null, 0, "UPDATE cancelled by user", null));
 
                 var isSysAdminOrBackOfficeIntegrationUser = new Lazy<bool>(() =>
                 {
@@ -415,10 +415,6 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 if (ex.Node == null)
                     ex.Node = this;
 
-                throw;
-            }
-            catch (OperationCanceledException)
-            {
                 throw;
             }
             catch (Exception ex)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -4097,7 +4097,7 @@ namespace MarkMpn.Sql4Cds.Engine
         {
             if (reference is NamedTableReference table)
             {
-                if (table.SchemaObject.Identifiers.Count == 1 && _cteSubplans.TryGetValue(table.SchemaObject.BaseIdentifier.Value, out var cteSubplan))
+                if (table.SchemaObject.Identifiers.Count == 1 && _cteSubplans != null && _cteSubplans.TryGetValue(table.SchemaObject.BaseIdentifier.Value, out var cteSubplan))
                 {
                     var aliasNode = (AliasNode)cteSubplan.Clone();
 

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1181,7 +1181,7 @@ namespace MarkMpn.Sql4Cds.Engine
             if (message.IsNull)
                 return SqlString.Null;
 
-            var regex = new Regex("%(?<flag>[-+0# ])?(?<width>([0-9]+|\\*))?(\\.(?<precision>([0-9]+|\\*)))?(?<size>h|l)?(?<type>[diosuxX]|I64d|S_MSG)");
+            var regex = new Regex("%(?<flag>[-+0# ])?(?<width>([0-9]+|\\*))?(\\.(?<precision>([0-9]+|\\*)))?(?<size>h|l)?(?<type>[diosuxXc]|I64d|S_MSG)");
             var paramIndex = 0;
 
             T GetValue<T>()
@@ -1290,6 +1290,7 @@ namespace MarkMpn.Sql4Cds.Engine
 
                     case "s":
                     case "S_MSG":
+                    case "c":
                         var strValue = GetValue<SqlString>();
 
                         if (strValue.IsNull)

--- a/MarkMpn.Sql4Cds.Engine/JsonPath.cs
+++ b/MarkMpn.Sql4Cds.Engine/JsonPath.cs
@@ -77,7 +77,7 @@ namespace MarkMpn.Sql4Cds.Engine
                     i++;
 
                     if (i == expression.Length)
-                        throw new JsonPathException(Sql4CdsError.JsonPathFormatError(expression[i], i + 1));
+                        throw new JsonPathException(Sql4CdsError.JsonPathFormatError(expression[i - 1], i));
 
                     if (expression[i] == '"')
                     {

--- a/MarkMpn.Sql4Cds.Engine/NotSupportedQueryFragmentException.cs
+++ b/MarkMpn.Sql4Cds.Engine/NotSupportedQueryFragmentException.cs
@@ -30,6 +30,7 @@ namespace MarkMpn.Sql4Cds.Engine
         public NotSupportedQueryFragmentException(string message, TSqlFragment fragment, Exception innerException) : base(message, innerException)
         {
             Fragment = fragment;
+            Errors = new[] { Sql4CdsError.InternalError(message, fragment) };
         }
 
         /// <summary>

--- a/MarkMpn.Sql4Cds.Engine/NotSupportedQueryFragmentException.cs
+++ b/MarkMpn.Sql4Cds.Engine/NotSupportedQueryFragmentException.cs
@@ -37,9 +37,8 @@ namespace MarkMpn.Sql4Cds.Engine
         /// Creates a new <see cref="NotSupportedQueryFragmentException"/>
         /// </summary>
         /// <param name="error">The error to return</param>
-        public NotSupportedQueryFragmentException(Sql4CdsError error) : this(error.Message)
+        public NotSupportedQueryFragmentException(Sql4CdsError error) : this(error, null)
         {
-            Errors = new[] { error };
         }
 
         /// <summary>
@@ -47,8 +46,9 @@ namespace MarkMpn.Sql4Cds.Engine
         /// </summary>
         /// <param name="error">The error to return</param>
         /// <param name="innerException">The original exception</param>
-        public NotSupportedQueryFragmentException(Sql4CdsError error, Exception innerException) : this(error.Message, error.Fragment, innerException)
+        public NotSupportedQueryFragmentException(Sql4CdsError error, Exception innerException) : base(error.Message, innerException)
         {
+            Fragment = error.Fragment;
             Errors = new[] { error };
         }
 

--- a/MarkMpn.Sql4Cds.SSMS.20.Setup/HeatGeneratedFileList.wxs
+++ b/MarkMpn.Sql4Cds.SSMS.20.Setup/HeatGeneratedFileList.wxs
@@ -50,8 +50,11 @@
             <Component Id="Microsoft.Data.SqlClient.dll" Guid="*">
                 <File Id="Microsoft.Data.SqlClient.dll" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.Data.SqlClient.dll" />
             </Component>
-            <Component Id="Microsoft.Data.SqlClient.pdb" Guid="*">
-                <File Id="Microsoft.Data.SqlClient.pdb" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.Data.SqlClient.pdb" />
+            <Component Id="Microsoft.Data.SqlClient.SNI.arm64.dll" Guid="*">
+                <File Id="Microsoft.Data.SqlClient.SNI.arm64.dll" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.Data.SqlClient.SNI.arm64.dll" />
+            </Component>
+            <Component Id="Microsoft.Data.SqlClient.SNI.arm64.pdb" Guid="*">
+                <File Id="Microsoft.Data.SqlClient.SNI.arm64.pdb" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.Data.SqlClient.SNI.arm64.pdb" />
             </Component>
             <Component Id="Microsoft.Data.SqlClient.SNI.x64.dll" Guid="*">
                 <File Id="Microsoft.Data.SqlClient.SNI.x64.dll" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.Data.SqlClient.SNI.x64.dll" />
@@ -70,6 +73,9 @@
             </Component>
             <Component Id="Microsoft.Identity.Client.Extensions.Msal.dll" Guid="*">
                 <File Id="Microsoft.Identity.Client.Extensions.Msal.dll" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.Identity.Client.Extensions.Msal.dll" />
+            </Component>
+            <Component Id="Microsoft.IdentityModel.Abstractions.dll" Guid="*">
+                <File Id="Microsoft.IdentityModel.Abstractions.dll" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.IdentityModel.Abstractions.dll" />
             </Component>
             <Component Id="Microsoft.IdentityModel.Clients.ActiveDirectory.dll" Guid="*">
                 <File Id="Microsoft.IdentityModel.Clients.ActiveDirectory.dll" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
@@ -103,6 +109,9 @@
             </Component>
             <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.dll" Guid="*">
                 <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.dll" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.SqlServer.TransactSql.ScriptDom.dll" />
+            </Component>
+            <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.pdb" Guid="*">
+                <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.pdb" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.SqlServer.TransactSql.ScriptDom.pdb" />
             </Component>
             <Component Id="Microsoft.VisualStudio.CoreUtility.dll" Guid="*">
                 <File Id="Microsoft.VisualStudio.CoreUtility.dll" KeyPath="yes" Source="$(var.HarvestPath)\Microsoft.VisualStudio.CoreUtility.dll" />
@@ -194,6 +203,12 @@
             <Component Id="System.IdentityModel.Tokens.Jwt.dll" Guid="*">
                 <File Id="System.IdentityModel.Tokens.Jwt.dll" KeyPath="yes" Source="$(var.HarvestPath)\System.IdentityModel.Tokens.Jwt.dll" />
             </Component>
+            <Component Id="System.IO.FileSystem.AccessControl.dll" Guid="*">
+                <File Id="System.IO.FileSystem.AccessControl.dll" KeyPath="yes" Source="$(var.HarvestPath)\System.IO.FileSystem.AccessControl.dll" />
+            </Component>
+            <Component Id="System.Memory.Data.dll" Guid="*">
+                <File Id="System.Memory.Data.dll" KeyPath="yes" Source="$(var.HarvestPath)\System.Memory.Data.dll" />
+            </Component>
             <Component Id="System.Memory.dll" Guid="*">
                 <File Id="System.Memory.dll" KeyPath="yes" Source="$(var.HarvestPath)\System.Memory.dll" />
             </Component>
@@ -227,7 +242,16 @@
             <Component Id="System.ValueTuple.dll" Guid="*">
                 <File Id="System.ValueTuple.dll" KeyPath="yes" Source="$(var.HarvestPath)\System.ValueTuple.dll" />
             </Component>
+            <Component Id="XPath2.dll" Guid="*">
+                <File Id="XPath2.dll" KeyPath="yes" Source="$(var.HarvestPath)\XPath2.dll" />
+            </Component>
+            <Component Id="XPath2.Extensions.dll" Guid="*">
+                <File Id="XPath2.Extensions.dll" KeyPath="yes" Source="$(var.HarvestPath)\XPath2.Extensions.dll" />
+            </Component>
             <Directory Id="cs" Name="cs">
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" KeyPath="yes" Source="$(var.HarvestPath)\cs\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
+                </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll" KeyPath="yes" Source="$(var.HarvestPath)\cs\Microsoft.VisualStudio.Threading.resources.dll" />
                 </Component>
@@ -238,6 +262,9 @@
             <Directory Id="de" Name="de">
                 <Component Id="Microsoft.Data.SqlClient.resources.dll" Guid="*">
                     <File Id="Microsoft.Data.SqlClient.resources.dll" KeyPath="yes" Source="$(var.HarvestPath)\de\Microsoft.Data.SqlClient.resources.dll" />
+                </Component>
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_1" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_1" KeyPath="yes" Source="$(var.HarvestPath)\de\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
                 </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_1" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_1" KeyPath="yes" Source="$(var.HarvestPath)\de\Microsoft.VisualStudio.Threading.resources.dll" />
@@ -250,6 +277,9 @@
                 <Component Id="Microsoft.Data.SqlClient.resources.dll_1" Guid="*">
                     <File Id="Microsoft.Data.SqlClient.resources.dll_1" KeyPath="yes" Source="$(var.HarvestPath)\es\Microsoft.Data.SqlClient.resources.dll" />
                 </Component>
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_2" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_2" KeyPath="yes" Source="$(var.HarvestPath)\es\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
+                </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_2" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_2" KeyPath="yes" Source="$(var.HarvestPath)\es\Microsoft.VisualStudio.Threading.resources.dll" />
                 </Component>
@@ -260,6 +290,9 @@
             <Directory Id="fr" Name="fr">
                 <Component Id="Microsoft.Data.SqlClient.resources.dll_2" Guid="*">
                     <File Id="Microsoft.Data.SqlClient.resources.dll_2" KeyPath="yes" Source="$(var.HarvestPath)\fr\Microsoft.Data.SqlClient.resources.dll" />
+                </Component>
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_3" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_3" KeyPath="yes" Source="$(var.HarvestPath)\fr\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
                 </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_3" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_3" KeyPath="yes" Source="$(var.HarvestPath)\fr\Microsoft.VisualStudio.Threading.resources.dll" />
@@ -272,6 +305,9 @@
                 <Component Id="Microsoft.Data.SqlClient.resources.dll_3" Guid="*">
                     <File Id="Microsoft.Data.SqlClient.resources.dll_3" KeyPath="yes" Source="$(var.HarvestPath)\it\Microsoft.Data.SqlClient.resources.dll" />
                 </Component>
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_4" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_4" KeyPath="yes" Source="$(var.HarvestPath)\it\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
+                </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_4" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_4" KeyPath="yes" Source="$(var.HarvestPath)\it\Microsoft.VisualStudio.Threading.resources.dll" />
                 </Component>
@@ -282,6 +318,9 @@
             <Directory Id="ja" Name="ja">
                 <Component Id="Microsoft.Data.SqlClient.resources.dll_4" Guid="*">
                     <File Id="Microsoft.Data.SqlClient.resources.dll_4" KeyPath="yes" Source="$(var.HarvestPath)\ja\Microsoft.Data.SqlClient.resources.dll" />
+                </Component>
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_5" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_5" KeyPath="yes" Source="$(var.HarvestPath)\ja\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
                 </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_5" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_5" KeyPath="yes" Source="$(var.HarvestPath)\ja\Microsoft.VisualStudio.Threading.resources.dll" />
@@ -294,6 +333,9 @@
                 <Component Id="Microsoft.Data.SqlClient.resources.dll_5" Guid="*">
                     <File Id="Microsoft.Data.SqlClient.resources.dll_5" KeyPath="yes" Source="$(var.HarvestPath)\ko\Microsoft.Data.SqlClient.resources.dll" />
                 </Component>
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_6" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_6" KeyPath="yes" Source="$(var.HarvestPath)\ko\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
+                </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_6" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_6" KeyPath="yes" Source="$(var.HarvestPath)\ko\Microsoft.VisualStudio.Threading.resources.dll" />
                 </Component>
@@ -302,6 +344,9 @@
                 </Component>
             </Directory>
             <Directory Id="pl" Name="pl">
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_7" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_7" KeyPath="yes" Source="$(var.HarvestPath)\pl\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
+                </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_7" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_7" KeyPath="yes" Source="$(var.HarvestPath)\pl\Microsoft.VisualStudio.Threading.resources.dll" />
                 </Component>
@@ -312,6 +357,9 @@
             <Directory Id="pt_BR" Name="pt-BR">
                 <Component Id="Microsoft.Data.SqlClient.resources.dll_6" Guid="*">
                     <File Id="Microsoft.Data.SqlClient.resources.dll_6" KeyPath="yes" Source="$(var.HarvestPath)\pt-BR\Microsoft.Data.SqlClient.resources.dll" />
+                </Component>
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_8" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_8" KeyPath="yes" Source="$(var.HarvestPath)\pt-BR\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
                 </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_8" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_8" KeyPath="yes" Source="$(var.HarvestPath)\pt-BR\Microsoft.VisualStudio.Threading.resources.dll" />
@@ -324,6 +372,9 @@
                 <Component Id="Microsoft.Data.SqlClient.resources.dll_7" Guid="*">
                     <File Id="Microsoft.Data.SqlClient.resources.dll_7" KeyPath="yes" Source="$(var.HarvestPath)\ru\Microsoft.Data.SqlClient.resources.dll" />
                 </Component>
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_9" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_9" KeyPath="yes" Source="$(var.HarvestPath)\ru\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
+                </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_9" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_9" KeyPath="yes" Source="$(var.HarvestPath)\ru\Microsoft.VisualStudio.Threading.resources.dll" />
                 </Component>
@@ -332,6 +383,9 @@
                 </Component>
             </Directory>
             <Directory Id="tr" Name="tr">
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_10" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_10" KeyPath="yes" Source="$(var.HarvestPath)\tr\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
+                </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_10" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_10" KeyPath="yes" Source="$(var.HarvestPath)\tr\Microsoft.VisualStudio.Threading.resources.dll" />
                 </Component>
@@ -343,6 +397,9 @@
                 <Component Id="Microsoft.Data.SqlClient.resources.dll_8" Guid="*">
                     <File Id="Microsoft.Data.SqlClient.resources.dll_8" KeyPath="yes" Source="$(var.HarvestPath)\zh-Hans\Microsoft.Data.SqlClient.resources.dll" />
                 </Component>
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_11" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_11" KeyPath="yes" Source="$(var.HarvestPath)\zh-Hans\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
+                </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_11" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_11" KeyPath="yes" Source="$(var.HarvestPath)\zh-Hans\Microsoft.VisualStudio.Threading.resources.dll" />
                 </Component>
@@ -353,6 +410,9 @@
             <Directory Id="zh_Hant" Name="zh-Hant">
                 <Component Id="Microsoft.Data.SqlClient.resources.dll_9" Guid="*">
                     <File Id="Microsoft.Data.SqlClient.resources.dll_9" KeyPath="yes" Source="$(var.HarvestPath)\zh-Hant\Microsoft.Data.SqlClient.resources.dll" />
+                </Component>
+                <Component Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_12" Guid="*">
+                    <File Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_12" KeyPath="yes" Source="$(var.HarvestPath)\zh-Hant\Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
                 </Component>
                 <Component Id="Microsoft.VisualStudio.Threading.resources.dll_12" Guid="*">
                     <File Id="Microsoft.VisualStudio.Threading.resources.dll_12" KeyPath="yes" Source="$(var.HarvestPath)\zh-Hant\Microsoft.VisualStudio.Threading.resources.dll" />
@@ -381,13 +441,15 @@
             <ComponentRef Id="Microsoft.Bcl.AsyncInterfaces.dll" />
             <ComponentRef Id="Microsoft.Crm.Sdk.Proxy.dll" />
             <ComponentRef Id="Microsoft.Data.SqlClient.dll" />
-            <ComponentRef Id="Microsoft.Data.SqlClient.pdb" />
+            <ComponentRef Id="Microsoft.Data.SqlClient.SNI.arm64.dll" />
+            <ComponentRef Id="Microsoft.Data.SqlClient.SNI.arm64.pdb" />
             <ComponentRef Id="Microsoft.Data.SqlClient.SNI.x64.dll" />
             <ComponentRef Id="Microsoft.Data.SqlClient.SNI.x64.pdb" />
             <ComponentRef Id="Microsoft.Data.SqlClient.SNI.x86.dll" />
             <ComponentRef Id="Microsoft.Data.SqlClient.SNI.x86.pdb" />
             <ComponentRef Id="Microsoft.Identity.Client.dll" />
             <ComponentRef Id="Microsoft.Identity.Client.Extensions.Msal.dll" />
+            <ComponentRef Id="Microsoft.IdentityModel.Abstractions.dll" />
             <ComponentRef Id="Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
             <ComponentRef Id="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll" />
             <ComponentRef Id="Microsoft.IdentityModel.JsonWebTokens.dll" />
@@ -399,6 +461,7 @@
             <ComponentRef Id="Microsoft.SqlServer.ConnectionInfo.dll" />
             <ComponentRef Id="Microsoft.SqlServer.RegSvrEnum.dll" />
             <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.dll" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.pdb" />
             <ComponentRef Id="Microsoft.VisualStudio.CoreUtility.dll" />
             <ComponentRef Id="Microsoft.VisualStudio.Imaging.dll" />
             <ComponentRef Id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll" />
@@ -429,6 +492,8 @@
             <ComponentRef Id="System.Configuration.ConfigurationManager.dll" />
             <ComponentRef Id="System.Diagnostics.DiagnosticSource.dll" />
             <ComponentRef Id="System.IdentityModel.Tokens.Jwt.dll" />
+            <ComponentRef Id="System.IO.FileSystem.AccessControl.dll" />
+            <ComponentRef Id="System.Memory.Data.dll" />
             <ComponentRef Id="System.Memory.dll" />
             <ComponentRef Id="System.Numerics.Vectors.dll" />
             <ComponentRef Id="System.Runtime.CompilerServices.Unsafe.dll" />
@@ -440,40 +505,55 @@
             <ComponentRef Id="System.Text.Json.dll" />
             <ComponentRef Id="System.Threading.Tasks.Extensions.dll" />
             <ComponentRef Id="System.ValueTuple.dll" />
+            <ComponentRef Id="XPath2.dll" />
+            <ComponentRef Id="XPath2.Extensions.dll" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll" />
             <ComponentRef Id="Microsoft.Data.SqlClient.resources.dll" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_1" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_1" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_1" />
             <ComponentRef Id="Microsoft.Data.SqlClient.resources.dll_1" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_2" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_2" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_2" />
             <ComponentRef Id="Microsoft.Data.SqlClient.resources.dll_2" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_3" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_3" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_3" />
             <ComponentRef Id="Microsoft.Data.SqlClient.resources.dll_3" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_4" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_4" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_4" />
             <ComponentRef Id="Microsoft.Data.SqlClient.resources.dll_4" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_5" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_5" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_5" />
             <ComponentRef Id="Microsoft.Data.SqlClient.resources.dll_5" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_6" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_6" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_6" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_7" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_7" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_7" />
             <ComponentRef Id="Microsoft.Data.SqlClient.resources.dll_6" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_8" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_8" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_8" />
             <ComponentRef Id="Microsoft.Data.SqlClient.resources.dll_7" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_9" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_9" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_9" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_10" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_10" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_10" />
             <ComponentRef Id="Microsoft.Data.SqlClient.resources.dll_8" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_11" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_11" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_11" />
             <ComponentRef Id="Microsoft.Data.SqlClient.resources.dll_9" />
+            <ComponentRef Id="Microsoft.SqlServer.TransactSql.ScriptDom.resources.dll_12" />
             <ComponentRef Id="Microsoft.VisualStudio.Threading.resources.dll_12" />
             <ComponentRef Id="Microsoft.VisualStudio.Validation.resources.dll_12" />
         </ComponentGroup>

--- a/MarkMpn.Sql4Cds.SSMS.20.Setup/MarkMpn.Sql4Cds.SSMS.20.Setup.wixproj
+++ b/MarkMpn.Sql4Cds.SSMS.20.Setup/MarkMpn.Sql4Cds.SSMS.20.Setup.wixproj
@@ -21,7 +21,7 @@
     <SuppressValidation>True</SuppressValidation>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants>HarvestPath=..\MarkMpn.Sql4Cds.SSMS.19\bin\$(Configuration)</DefineConstants>
+    <DefineConstants>HarvestPath=..\MarkMpn.Sql4Cds.SSMS.20\bin\$(Configuration)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
   </PropertyGroup>
@@ -49,6 +49,6 @@
 	</Target>
 	-->
   <Target Name="BeforeBuild">
-    <HeatDirectory Directory="..\MarkMpn.Sql4Cds.SSMS.19\bin\$(Configuration)" PreprocessorVariable="var.HarvestPath" OutputFile="HeatGeneratedFileList.wxs" ComponentGroupName="HeatGenerated" DirectoryRefId="INSTALLFOLDER" AutogenerateGuids="true" ToolPath="$(WixToolPath)" SuppressFragments="true" SuppressRegistry="true" SuppressRootDirectory="true" SuppressUniqueIds="true" RunAsSeparateProcess="true" />
+    <HeatDirectory Directory="..\MarkMpn.Sql4Cds.SSMS.20\bin\$(Configuration)" PreprocessorVariable="var.HarvestPath" OutputFile="HeatGeneratedFileList.wxs" ComponentGroupName="HeatGenerated" DirectoryRefId="INSTALLFOLDER" AutogenerateGuids="true" ToolPath="$(WixToolPath)" SuppressFragments="true" SuppressRegistry="true" SuppressRootDirectory="true" SuppressUniqueIds="true" RunAsSeparateProcess="true" />
   </Target>
 </Project>


### PR DESCRIPTION
Fixed NullReferenceExceptions triggered when:

* executing a conditional `SELECT` query - fixes #462
* retrieving results from a Fetch XML query using `IN` or `EXISTS`
* handling an error returned from TDS Endpoint - fixes #463
* handling internal errors such as `UPDATE` without `WHERE`