### PR TITLE
V9 fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
@@ -235,7 +235,7 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         [TestMethod]
         public void NestedFilters()
         {
-            var query = "SELECT accountid, name FROM account WHERE name = 'test' OR (accountid is not null and name like 'foo%')";
+            var query = "SELECT accountid, name FROM account WHERE name = 'test' OR (employees is not null and name like 'foo%')";
 
             var planBuilder = new ExecutionPlanBuilder(_localDataSources.Values, this);
             var queries = planBuilder.Build(query, null, out _);
@@ -248,7 +248,7 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                         <filter type='or'>
                             <condition attribute='name' operator='eq' value='test' />
                             <filter type='and'>
-                                <condition attribute='accountid' operator='not-null' />
+                                <condition attribute='employees' operator='not-null' />
                                 <condition attribute='name' operator='like' value='foo%' />
                             </filter>
                         </filter>

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseJoinNode.cs
@@ -192,7 +192,13 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             foreach (var definedValue in DefinedValues)
             {
                 innerSchema.ContainsColumn(definedValue.Value, out var innerColumn);
-                schema[definedValue.Key] = innerSchema.Schema[innerColumn].Invisible().Calculated();
+
+                var definedValueSchemaCol = innerSchema.Schema[innerColumn].Invisible().Calculated();
+
+                if (JoinType == QualifiedJoinType.LeftOuter)
+                    definedValueSchemaCol = definedValueSchemaCol.Null();
+
+                schema[definedValue.Key] = definedValueSchemaCol;
             }
 
             _lastLeftSchema = outerSchema;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
@@ -1470,6 +1470,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         private bool FoldFiltersToDataSources(NodeCompilationContext context, IList<OptimizerHint> hints, Dictionary<BooleanExpression, ConvertedSubquery> subqueryExpressions)
         {
+            if (Filter == null)
+                return false;
+
             var foldedFilters = false;
 
             // Find all the data source nodes we could fold this into. Include direct data sources, those from either side of an inner join, or the main side of an outer join

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FoldableJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FoldableJoinNode.cs
@@ -117,10 +117,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             // Left outer join - right key must be non-null
             // Right outer join - left key must be non-null
             if (JoinType == QualifiedJoinType.Inner || JoinType == QualifiedJoinType.RightOuter)
-                LeftSource = AddNotNullFilter(LeftSource, LeftAttribute, context, hints);
+                LeftSource = AddNotNullFilter(LeftSource, LeftAttribute, context, hints, false);
 
             if (JoinType == QualifiedJoinType.Inner || JoinType == QualifiedJoinType.LeftOuter)
-                RightSource = AddNotNullFilter(RightSource, RightAttribute, context, hints);
+                RightSource = AddNotNullFilter(RightSource, RightAttribute, context, hints, false);
 
             if (FoldSingleRowJoinToNestedLoop(context, hints, leftSchema, rightSchema, out folded))
                 return folded;
@@ -142,7 +142,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return folded;
         }
 
-        private IDataExecutionPlanNodeInternal AddNotNullFilter(IDataExecutionPlanNodeInternal source, ColumnReferenceExpression attribute, NodeCompilationContext context, IList<OptimizerHint> hints)
+        protected IDataExecutionPlanNodeInternal AddNotNullFilter(IDataExecutionPlanNodeInternal source, ColumnReferenceExpression attribute, NodeCompilationContext context, IList<OptimizerHint> hints, bool required)
         {
             var schema = source.GetSchema(context);
             if (!schema.ContainsColumn(attribute.GetColumnName(), out var colName))
@@ -163,7 +163,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             var folded = filter.FoldQuery(context, hints);
 
-            if (folded != filter)
+            if (required || folded != filter)
             {
                 folded.Parent = this;
                 return folded;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashJoinNode.cs
@@ -152,27 +152,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             // Make sure the join keys are not null - the SqlType classes override == to prevent NULL = NULL
             // but .Equals used by the hash table allows them to match
-            LeftSource = new FilterNode
-            {
-                Source = LeftSource,
-                Filter = new BooleanIsNullExpression
-                {
-                    Expression = LeftAttribute,
-                    IsNot = true
-                }
-            }.FoldQuery(context, hints);
-            LeftSource.Parent = this;
-
-            RightSource = new FilterNode
-            {
-                Source = RightSource,
-                Filter = new BooleanIsNullExpression
-                {
-                    Expression = RightAttribute,
-                    IsNot = true
-                }
-            }.FoldQuery(context, hints);
-            RightSource.Parent = this;
+            LeftSource = AddNotNullFilter(LeftSource, LeftAttribute, context, hints, true);
+            RightSource = AddNotNullFilter(RightSource, RightAttribute, context, hints, true);
 
             return this;
         }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashJoinNode.cs
@@ -150,6 +150,30 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     JoinType = QualifiedJoinType.LeftOuter;
             }
 
+            // Make sure the join keys are not null - the SqlType classes override == to prevent NULL = NULL
+            // but .Equals used by the hash table allows them to match
+            LeftSource = new FilterNode
+            {
+                Source = LeftSource,
+                Filter = new BooleanIsNullExpression
+                {
+                    Expression = LeftAttribute,
+                    IsNot = true
+                }
+            }.FoldQuery(context, hints);
+            LeftSource.Parent = this;
+
+            RightSource = new FilterNode
+            {
+                Source = RightSource,
+                Filter = new BooleanIsNullExpression
+                {
+                    Expression = RightAttribute,
+                    IsNot = true
+                }
+            }.FoldQuery(context, hints);
+            RightSource.Parent = this;
+
             return this;
         }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
@@ -340,6 +340,11 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     (fetchXml.Entity.name == "audit" || metadata[fetchXml.Entity.name].DataProviderId == DataProviders.ElasticDataProvider))
                     canUseFetchXmlAggregate = false;
 
+                // Aggregates on audit entity seem to transform inner joins to left outer joins, so can't
+                // use FetchXML aggregates here
+                if (fetchXml.Entity.name == "audit" && fetchXml.Entity.GetLinkEntities(true).Any())
+                    canUseFetchXmlAggregate = false;
+
                 var serializer = new XmlSerializer(typeof(FetchXml.FetchType));
 
                 if (canUseFetchXmlAggregate)


### PR DESCRIPTION
Apply not-null filters for hash joins - fixes #491 
Improved not-null column detection with defined columns in outer joins
Removed tautological and contradictory filters
Fixed use of metadata query within loop join - fixes #495, #496
Fixed filtering & aggregation on audit - fixes #488 