### PR TITLE
V9.3 fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
@@ -2292,6 +2292,11 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 prop.Name == nameof(AttributeMetadata.SourceType))
                 return false;
 
+            // Filtering on types that the KnownTypesResolver can't handle is not supported
+            // https://github.com/MarkMpn/Sql4Cds/issues/534
+            if (!new KnownTypesResolver().ResolvedTypes.ContainsKey(targetValueType.Name))
+                return false;
+
             // String comparisons will be executed case-sensitively, but all other comparisons are case-insensitive. For consistency, don't allow
             // comparisons on string properties except those where we know the expected case.
             if (targetValueType == typeof(string))

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1374,6 +1374,12 @@ namespace MarkMpn.Sql4Cds.Engine
 
             return (context?.PrimaryDataSource.DefaultCollation ?? Collation.USEnglish).ToSqlString(msg);
         }
+
+        [SqlFunction(IsDeterministic = false)]
+        public static SqlGuid NewId()
+        {
+            return Guid.NewGuid();
+        }
     }
 
     /// <summary>

--- a/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/FunctionMetadata.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/FunctionMetadata.cs
@@ -202,6 +202,9 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
 
             [Description("Generates an error message and initiates error processing for the session")]
             public abstract void raiserror(string msg_str, int severity, int state, object[] parameters);
+
+            [Description("Creates a unique value of type uniqueidentifier")]
+            public abstract Guid newid();
         }
     }
 }

--- a/MarkMpn.Sql4Cds.LanguageServer/QueryExecution/QueryExecutionHandler.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/QueryExecution/QueryExecutionHandler.cs
@@ -208,7 +208,7 @@ namespace MarkMpn.Sql4Cds.LanguageServer.QueryExecution
 
                 if ((e.Count > threshold || e.BypassCustomPluginExecution) && !bypassWarnings)
                 {
-                    var msg = $"{operation} will affect {e.Count:N0} {GetDisplayName(e.Count, e.Metadata)}.";
+                    var msg = $"{operation} will affect {(e.Count == Int32.MaxValue ? "an unknown number of" : e.Count.ToString("N0"))} {GetDisplayName(e.Count, e.Metadata)}.";
                     if (e.BypassCustomPluginExecution)
                         msg += " This operation will bypass any custom plugins.";
                     msg += " Do you want to proceed?";

--- a/MarkMpn.Sql4Cds.XTB/FunctionMetadata.cs
+++ b/MarkMpn.Sql4Cds.XTB/FunctionMetadata.cs
@@ -202,6 +202,9 @@ namespace MarkMpn.Sql4Cds.XTB
 
             [Description("Generates an error message and initiates error processing for the session")]
             public abstract void raiserror(string msg_str, int severity, int state, object[] parameters);
+
+            [Description("Creates a unique value of type uniqueidentifier")]
+            public abstract Guid newid();
         }
     }
 }

--- a/MarkMpn.Sql4Cds.XTB/QueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds.XTB/QueryExecutionOptions.cs
@@ -63,7 +63,7 @@ namespace MarkMpn.Sql4Cds.XTB
         {
             if ((e.Count > Settings.Instance.InsertWarnThreshold || e.BypassCustomPluginExecution) && !_suppressWarnings)
             {
-                var msg = $"Insert will affect {e.Count:N0} {GetDisplayName(e.Count, e.Metadata)}.";
+                var msg = $"Insert will affect {(e.Count == Int32.MaxValue ? "an unknown number of" : e.Count.ToString("N0"))} {GetDisplayName(e.Count, e.Metadata)}.";
                 if (e.BypassCustomPluginExecution)
                     msg += "\r\n\r\nThis operation will bypass any custom plugins.";
 
@@ -85,7 +85,7 @@ namespace MarkMpn.Sql4Cds.XTB
         {
             if ((e.Count > Settings.Instance.UpdateWarnThreshold || e.BypassCustomPluginExecution) && !_suppressWarnings)
             {
-                var msg = $"Update will affect {e.Count:N0} {GetDisplayName(e.Count, e.Metadata)}.";
+                var msg = $"Update will affect {(e.Count == Int32.MaxValue ? "an unknown number of" : e.Count.ToString("N0"))} {GetDisplayName(e.Count, e.Metadata)}.";
                 if (e.BypassCustomPluginExecution)
                     msg += "\r\n\r\nThis operation will bypass any custom plugins.";
 
@@ -107,7 +107,7 @@ namespace MarkMpn.Sql4Cds.XTB
         {
             if ((e.Count > Settings.Instance.DeleteWarnThreshold || e.BypassCustomPluginExecution) && !_suppressWarnings)
             {
-                var msg = $"Delete will affect {e.Count:N0} {GetDisplayName(e.Count, e.Metadata)}.";
+                var msg = $"Delete will affect {(e.Count == Int32.MaxValue ? "an unknown number of" : e.Count.ToString("N0"))} {GetDisplayName(e.Count, e.Metadata)}.";
                 if (e.BypassCustomPluginExecution)
                     msg += "\r\n\r\nThis operation will bypass any custom plugins.";
 


### PR DESCRIPTION
Fixed filtering on `metadata.alternate_key.entitykeyindexstatus` - fixes #534 
Extended support for executing messages with more parameter types - fixes #369, #442, #494
Show confirmation message before executing bulk delete job - fixes #536 
Implemented `NEWID()` function - fixes #537 