### PR TITLE
Large inserts

### DIFF
--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/DeleteNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/DeleteNode.cs
@@ -134,7 +134,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         {
                             InProgressUppercase = "Deleting",
                             InProgressLowercase = "deleting",
-                            CompletedLowercase = "deleted"
+                            CompletedLowercase = "deleted",
+                            CompletedUppercase = "Deleted"
                         },
                         context,
                         out recordsAffected,
@@ -146,6 +147,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 if (ex.Node == null)
                     ex.Node = this;
 
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
                 throw;
             }
             catch (Exception ex)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/DynamicParallel.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/DynamicParallel.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
+{
+    /// <summary>
+    /// Provides similar methods to the <see cref="Parallel"/> class, but allows the loop to indicate that the number of threads
+    /// should change during execution.
+    /// </summary>
+    class DynamicParallel<TSource, TLocal>
+    {
+        class DynamicParallelThreadState
+        {
+            public Task Task { get; set; }
+
+            public DynamicParallelVote? Vote { get; set; }
+
+            public bool IsStopped { get; set; }
+
+            public CancellationToken CancellationToken { get; set; }
+        }
+
+        private readonly ConcurrentQueue<TSource> _queue;
+        private readonly List<DynamicParallelThreadState> _threads;
+        private readonly DynamicParallelLoopState _loopState;
+        private readonly ConcurrentBag<Exception> _exceptions;
+        private readonly ParallelOptions _parallelOptions;
+        private readonly Func<TLocal> _localInit;
+        private readonly Func<TSource, DynamicParallelLoopState, TLocal, Task<DynamicParallelVote?>> _body;
+        private readonly Func<TLocal, Task> _localFinally;
+
+        public DynamicParallel(
+            IEnumerable<TSource> source,
+            ParallelOptions parallelOptions,
+            Func<TLocal> localInit,
+            Func<TSource, DynamicParallelLoopState, TLocal, Task<DynamicParallelVote?>> body,
+            Func<TLocal, Task> localFinally)
+        {
+            _queue = new ConcurrentQueue<TSource>(source);
+            _threads = new List<DynamicParallelThreadState>();
+            _loopState = new DynamicParallelLoopState();
+            _exceptions = new ConcurrentBag<Exception>();
+            _parallelOptions = parallelOptions;
+            _localInit = localInit;
+            _body = body;
+            _localFinally = localFinally;
+        }
+
+        public void ForEach(CancellationToken cancellationToken)
+        {
+            StartThread(cancellationToken);
+
+            var monitor = Task.Factory.StartNew(async () => await MonitorAsync(cancellationToken)).Unwrap();
+            monitor.Wait();
+
+            if (!_exceptions.IsEmpty)
+                throw new AggregateException(_exceptions);
+        }
+
+        private void StartThread(CancellationToken cancellationToken)
+        {
+            var threadState = new DynamicParallelThreadState
+            {
+                CancellationToken = cancellationToken
+            };
+            threadState.Task = Task.Factory.StartNew((state) => RunThread((DynamicParallelThreadState)state), threadState).Unwrap();
+            _threads.Add(threadState);
+        }
+
+        private async Task RunThread(DynamicParallelThreadState threadState)
+        {
+            var local = _localInit();
+
+            try
+            {
+                while (!_loopState.IsStopped &&
+                    !threadState.IsStopped &&
+                    _queue.TryDequeue(out var item))
+                {
+                    threadState.Vote = await _body(item, _loopState, local) ?? threadState.Vote;
+                }
+            }
+            catch (Exception ex)
+            {
+                _exceptions.Add(ex);
+                _loopState.Stop();
+            }
+            finally
+            {
+                await _localFinally(local);
+                threadState.Vote = null;
+            }
+        }
+
+        private async Task MonitorAsync(CancellationToken cancellationToken)
+        {
+            var hasDecreased = false;
+
+            // Periodically check the votes and adjust the number of threads
+            while (!_loopState.IsStopped)
+            {
+                var allTasks = Task.WhenAll(_threads.Select(t => t.Task).ToArray());
+                var timeout = Task.Delay(1000, cancellationToken);
+                var task = await Task.WhenAny(allTasks, timeout);
+
+                if (task == allTasks)
+                    break;
+
+                var votes = _threads.Where(t => t.Vote != null && !t.IsStopped).Select(t => t.Vote.Value).ToList();
+                var increase = votes.Count(v => v == DynamicParallelVote.IncreaseThreads);
+                var decrease = votes.Count(v => v == DynamicParallelVote.DecreaseThreads);
+
+                if (decrease > 0 && _threads.Count(t => !t.IsStopped) > 1)
+                {
+                    var thread = _threads.First(t => !t.IsStopped && t.Vote == DynamicParallelVote.DecreaseThreads);
+                    thread.IsStopped = true;
+                    hasDecreased = true;
+                }
+                else if (increase > 0 && !hasDecreased && _threads.Count(t => !t.IsStopped) < _parallelOptions.MaxDegreeOfParallelism)
+                {
+                    StartThread(cancellationToken);
+                }
+
+                foreach (var thread in _threads)
+                    thread.Vote = null;
+
+            }
+        }
+    }
+
+    class DynamicParallelLoopState
+    {
+        public bool IsStopped { get; private set; }
+
+        public void Stop()
+        {
+            IsStopped = true;
+        }
+    }
+
+    enum DynamicParallelVote
+    {
+        IncreaseThreads,
+        DecreaseThreads,
+    }
+}

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExceptionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExceptionExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xrm.Sdk;
+
+namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
+{
+    static class ExceptionExtensions
+    {
+        public static bool IsThrottlingException(this FaultException<OrganizationServiceFault> ex, out TimeSpan retryDelay)
+        {
+            if (ex == null)
+            {
+                retryDelay = TimeSpan.Zero;
+                return false;
+            }
+
+            if (ex.Detail.ErrorCode == 429 || // Virtual/elastic tables
+                ex.Detail.ErrorCode == -2147015902 || // Number of requests exceeded the limit of 6000 over time window of 300 seconds.
+                ex.Detail.ErrorCode == -2147015903 || // Combined execution time of incoming requests exceeded limit of 1,200,000 milliseconds over time window of 300 seconds. Decrease number of concurrent requests or reduce the duration of requests and try again later.
+                ex.Detail.ErrorCode == -2147015898) // Number of concurrent requests exceeded the limit of 52.
+            {
+                retryDelay = TimeSpan.FromSeconds(2);
+
+                if (ex.Detail.ErrorDetails.TryGetValue("Retry-After", out var retryAfter) && retryAfter is TimeSpan ts)
+                    retryDelay = ts;
+
+                if (retryDelay > TimeSpan.FromMinutes(5))
+                    retryDelay = TimeSpan.FromMinutes(5);
+
+                return true;
+            }
+
+            retryDelay = TimeSpan.Zero;
+            return false;
+        }
+    }
+}

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteAsNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteAsNode.cs
@@ -134,7 +134,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         {
                             var qry = new Microsoft.Xrm.Sdk.Query.QueryExpression("systemuser");
                             qry.Criteria.AddCondition("systemuserid", ConditionOperator.EqualUserId);
-                            var actualUserId = ((RetrieveMultipleResponse)dataSource.Execute(new RetrieveMultipleRequest { Query = qry })).EntityCollection.Entities.Single().Id;
+                            var actualUserId = ((RetrieveMultipleResponse)dataSource.ExecuteWithServiceProtectionLimitLogging(new RetrieveMultipleRequest { Query = qry }, context.Options, "Impersonating user...")).EntityCollection.Entities.Single().Id;
 
                             if (actualUserId != userId)
                                 throw new QueryExecutionException(Sql4CdsError.ImpersonationError(username), new ApplicationException("User was found but the server could not impersonate it"));

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
@@ -286,7 +286,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (!context.Session.DataSources.TryGetValue(DataSource, out var dataSource))
                 throw new NotSupportedQueryFragmentException("Missing datasource " + DataSource);
 
-            context.Options.Progress(0, $"Executing {MessageName}...");
+            var progressMessage = $"Executing {MessageName}...";
+            context.Options.Progress(0, progressMessage);
 
             // Get the first page of results
             if (!context.Options.ContinueRetrieve(0))
@@ -302,7 +303,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (BypassCustomPluginExecution)
                 request.Parameters["BypassCustomPluginExecution"] = true;
 
-            var response = dataSource.Connection.Execute(request);
+            var response = dataSource.ExecuteWithServiceProtectionLimitLogging(request, context.Options, progressMessage);
             var entities = GetEntityCollection(response);
             PagesRetrieved++;
 
@@ -325,7 +326,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 };
 
 
-                response = dataSource.Connection.Execute(request);
+                response = dataSource.ExecuteWithServiceProtectionLimitLogging(request, context.Options, progressMessage);
                 entities = GetEntityCollection(response);
                 PagesRetrieved++;
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/InsertNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/InsertNode.cs
@@ -148,7 +148,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         {
                             InProgressUppercase = "Inserting",
                             InProgressLowercase = "inserting",
-                            CompletedLowercase = "inserted"
+                            CompletedLowercase = "inserted",
+                            CompletedUppercase = "Inserted",
                         },
                         context,
                         out recordsAffected,
@@ -162,6 +163,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 if (ex.Node == null)
                     ex.Node = this;
 
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
                 throw;
             }
             catch (Exception ex)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/PartitionedAggregateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/PartitionedAggregateNode.cs
@@ -53,6 +53,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         [Description("The maximum number of partitions that will be executed in parallel")]
         public int MaxDOP { get; set; }
 
+        [Browsable(false)]
+        internal string ProgressMessage { get; set; }
+
         public override IDataExecutionPlanNodeInternal FoldQuery(NodeCompilationContext context, IList<OptimizerHint> hints)
         {
             Source = Source.FoldQuery(context, hints);
@@ -213,7 +216,9 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                             lock (_lock)
                             {
                                 _progress += partition.Percentage;
-                                context.Options.Progress(0, $"Partitioning {GetDisplayName(0, meta)} ({_progress:P0})...");
+                                ProgressMessage = $"Partitioning {GetDisplayName(0, meta)} ({_progress:P0})...";
+
+                                context.Options.Progress(0, ProgressMessage);
                             }
 
                             if (Interlocked.Decrement(ref _pendingPartitions) == 0)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/UpdateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/UpdateNode.cs
@@ -459,7 +459,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         {
                             InProgressUppercase = "Updating",
                             InProgressLowercase = "updating",
-                            CompletedLowercase = "updated"
+                            CompletedLowercase = "updated",
+                            CompletedUppercase = "Updated"
                         },
                         context,
                         out recordsAffected,
@@ -471,6 +472,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 if (ex.Node == null)
                     ex.Node = this;
 
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
                 throw;
             }
             catch (Exception ex)

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1435,7 +1435,7 @@ namespace MarkMpn.Sql4Cds.Engine
 #endif
 
                     if (orgVersion == null)
-                        orgVersion = ((RetrieveVersionResponse)dataSource.Execute(new RetrieveVersionRequest())).Version;
+                        orgVersion = ((RetrieveVersionResponse)dataSource.ExecuteWithServiceProtectionLimitLogging(new RetrieveVersionRequest(), context.Options, "Retrieving server version...")).Version;
 
                     return new SqlVariant(DataTypeHelpers.NVarChar(128, dataSource.DefaultCollation, CollationLabel.CoercibleDefault), dataSource.DefaultCollation.ToSqlString(orgVersion), context);
             }

--- a/MarkMpn.Sql4Cds.Engine/SessionContext.cs
+++ b/MarkMpn.Sql4Cds.Engine/SessionContext.cs
@@ -56,7 +56,7 @@ namespace MarkMpn.Sql4Cds.Engine
 #endif
 
                 if (orgVersion == null)
-                    orgVersion = ((RetrieveVersionResponse)dataSource.Execute(new RetrieveVersionRequest())).Version;
+                    orgVersion = ((RetrieveVersionResponse)dataSource.ExecuteWithServiceProtectionLimitLogging(new RetrieveVersionRequest(), _context._options, "Retrieving server version...")).Version;
 
                 var assembly = typeof(Sql4CdsConnection).Assembly;
                 var assemblyVersion = assembly.GetName().Version;


### PR DESCRIPTION
Automatically adjust batch size to keep requests within timeout limit
Automatically adjust thread count to avoid hitting service protection limits
Use explicit retries for service protection limits to provide better user feedback on why their query pauses
Automatically retry requests that have failed due to a transient error