### PR TITLE
Metadata improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,3 +29,6 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+**Sponsorship**
+If you find this tool useful, please consider [sponsoring its development](https://github.com/sponsors/MarkMpn).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,6 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+**Sponsorship**
+If you find this tool useful, please consider [sponsoring its development](https://github.com/sponsors/MarkMpn).

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/AliasNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/AliasNode.cs
@@ -250,7 +250,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 return;
 
             var mapped = $"{escapedAlias}.{outputColumn}";
-            schema[mapped] = new ColumnDefinition(sourceSchema.Schema[normalized].Type, sourceSchema.Schema[normalized].IsNullable, false);
+            schema[mapped] = sourceSchema.Schema[normalized].NotCalculated();
             mappings[normalized] = mapped;
 
             if (normalized == sourceSchema.PrimaryKey)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseJoinNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/BaseJoinNode.cs
@@ -182,7 +182,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         nullable = false;
                     }
 
-                    schema[column.Key] = new ColumnDefinition(column.Value.Type, nullable, column.Value.IsCalculated, column.Value.IsVisible);
+                    schema[column.Key] = nullable ? column.Value.Null() : column.Value.NotNull();
                 }
 
                 foreach (var alias in subSchema.Aliases)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/EntityReader.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/EntityReader.cs
@@ -396,7 +396,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         continue;
                     }
 
-                    targetType = virtualAttr.DataType;
+                    targetType = virtualAttr.DataType();
                     targetClrType = typeof(string);
 
                     if (!complexLookupAttributes.TryGetValue(attr.LogicalName, out var lookupDetails))

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
@@ -253,6 +253,11 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             Schema[name] = new ColumnDefinition(type, true, false);
         }
 
+        private void AddSchemaColumn(string name, Func<DataTypeReference> typeLoader)
+        {
+            Schema[name] = new LazyColumnDefinition(typeLoader, true, false);
+        }
+
         private string PrefixWithAlias(string columnName)
         {
             if (String.IsNullOrEmpty(Alias))

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/GlobalOptionSetQueryNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/GlobalOptionSetQueryNode.cs
@@ -76,7 +76,6 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 .Where(p => p != null)
                 .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
 
-
             _valueProps = typeof(OptionMetadata)
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .Where(p => p.Name != nameof(AttributeMetadata.ExtensionData) && p.PropertyType != typeof(int[]))
@@ -143,8 +142,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         /// </summary>
         [Category("Global Optionset Query")]
         [Description("The alias to use for the values dataset")]
-        [DisplayName("Values Alias")]
-        public string ValuesAlias { get; set; }
+        [DisplayName("Value Alias")]
+        public string ValueAlias { get; set; }
 
         public override void AddRequiredColumns(NodeCompilationContext context, IList<string> requiredColumns)
         {
@@ -163,7 +162,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     var prop = _optionsetProps[parts[1]];
                     _optionsetCols[col] = prop;
                 }
-                else if (parts[0].Equals(ValuesAlias, StringComparison.OrdinalIgnoreCase))
+                else if (parts[0].Equals(ValueAlias, StringComparison.OrdinalIgnoreCase))
                 {
                     var prop = _valueProps[parts[1]];
                     _valueCols[col] = prop;
@@ -192,7 +191,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             if (MetadataSource.HasFlag(OptionSetSource.Value))
             {
-                AddSchemaCols(context, schema, aliases, _valueCols ?? _valueProps, ValuesAlias, ref primaryKey);
+                AddSchemaCols(context, schema, aliases, _valueCols ?? _valueProps, ValueAlias, ref primaryKey);
                 primaryKey = null;
             }
 
@@ -313,7 +312,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             {
                 MetadataSource = MetadataSource,
                 OptionSetAlias = OptionSetAlias,
-                ValuesAlias = ValuesAlias,
+                ValueAlias = ValueAlias,
                 DataSource = DataSource,
                 _optionsetCols = _optionsetCols,
                 _valueCols = _valueCols,

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MetadataQueryNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MetadataQueryNode.cs
@@ -49,11 +49,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         private IDictionary<string, MetadataProperty> _manyToOneRelationshipCols;
         private IDictionary<string, MetadataProperty> _manyToManyRelationshipCols;
         private IDictionary<string, MetadataProperty> _keyCols;
+        private IDictionary<string, MetadataProperty> _valueCols;
 
         private static readonly Dictionary<string, MetadataProperty> _entityProps;
         private static readonly Dictionary<string, MetadataProperty> _oneToManyRelationshipProps;
         private static readonly Dictionary<string, MetadataProperty> _manyToManyRelationshipProps;
         private static readonly Dictionary<string, MetadataProperty> _keyProps;
+        private static readonly Dictionary<string, MetadataProperty> _valueProps;
+        private static readonly MetadataProperty _attributeIdProp;
         private static readonly Type[] _attributeTypes;
         private static readonly Dictionary<string, AttributeProperty> _attributeProps;
         private static readonly string[] _entityNotNullProps;
@@ -61,6 +64,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         private static readonly string[] _oneToManyRelationshipNotNullProps;
         private static readonly string[] _manyToManyRelationshipNotNullProps;
         private static readonly string[] _keyNotNullProps;
+        private static readonly string[] _valueNotNullProps;
 
         static MetadataQueryNode()
         {
@@ -168,6 +172,41 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 .Where(p => p != null)
                 .ToDictionary(p => p.SqlName, StringComparer.OrdinalIgnoreCase);
 
+            _valueProps = typeof(OptionMetadata)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.Name != nameof(AttributeMetadata.ExtensionData) && p.PropertyType != typeof(int[]))
+                .Select(p =>
+                {
+                    var type = GetPropertyType(p.PropertyType);
+                    var netType = type.ToNetType(out _);
+
+                    return new MetadataProperty
+                    {
+                        SqlName = p.Name.ToLowerInvariant(),
+                        PropertyName = p.Name,
+                        Type = p.PropertyType,
+                        SqlType = type,
+                        Accessor = GetPropertyAccessor(p, netType),
+                        DataMemberOrder = GetDataMemberOrder(p)
+                    };
+                })
+                .ToDictionary(p => p.SqlName, StringComparer.OrdinalIgnoreCase);
+
+            // Create a fake property to allow joining options to the parent attribute
+            _attributeIdProp = new MetadataProperty
+            {
+                DataMemberOrder = new IComparable[]
+                {
+                    0,
+                    0,
+                    "attributeid"
+                },
+                SqlName = "attributeid",
+                SqlType = DataTypeHelpers.UniqueIdentifier,
+                Type = DataTypeHelpers.UniqueIdentifier.ToNetType(out _),
+            };
+            _valueProps[_attributeIdProp.SqlName] = _attributeIdProp;
+
             _entityNotNullProps = _entityProps.Values
                 .Where(p => !IsNullable(p.Type))
                 .Select(p => p.PropertyName)
@@ -196,6 +235,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 .Where(p => !IsNullable(p.Type))
                 .Select(p => p.PropertyName)
                 .Union(new[] { nameof(EntityKeyMetadata.MetadataId), nameof(EntityKeyMetadata.EntityLogicalName), nameof(EntityKeyMetadata.KeyAttributes) })
+                .ToArray();
+
+            _valueNotNullProps = _valueProps.Values
+                .Where(p => !IsNullable(p.Type))
+                .Select(p => p.PropertyName)
+                .Union(new[] { nameof(OptionMetadata.Value) })
                 .ToArray();
         }
 
@@ -285,6 +330,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         public string KeyAlias { get; set; }
 
         /// <summary>
+        /// The alias for optionset value data
+        /// </summary>
+        [Category("Metadata Query")]
+        [Description("The alias for optionset value data")]
+        [DisplayName("Value Alias")]
+        public string ValueAlias { get; set; }
+
+        /// <summary>
         /// The metadata query to be executed
         /// </summary>
         [Category("Metadata Query")]
@@ -299,6 +352,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             _manyToOneRelationshipCols = new Dictionary<string, MetadataProperty>();
             _manyToManyRelationshipCols = new Dictionary<string, MetadataProperty>();
             _keyCols = new Dictionary<string, MetadataProperty>();
+            _valueCols = new Dictionary<string, MetadataProperty>();
 
             foreach (var col in requiredColumns)
             {
@@ -394,6 +448,21 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                     _keyCols[col] = prop;
                 }
+                else if (parts[0].Equals(ValueAlias, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (Query.AttributeQuery == null)
+                        Query.AttributeQuery = new AttributeQueryExpression();
+
+                    if (Query.AttributeQuery.Properties == null)
+                        Query.AttributeQuery.Properties = new MetadataPropertiesExpression();
+
+                    var prop = nameof(EnumAttributeMetadata.OptionSet);
+
+                    if (!Query.AttributeQuery.Properties.AllProperties && !Query.AttributeQuery.Properties.PropertyNames.Contains(prop))
+                        Query.AttributeQuery.Properties.PropertyNames.Add(prop);
+
+                    _valueCols[col] = _valueProps[parts[1]];
+                }
             }
 
             NormalizeProperties();
@@ -427,6 +496,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             var attributesPerEntity = 1;
             var relationshipsPerEntity = 1;
             var keysPerEntity = 1;
+            var valuesPerAttribute = 1;
 
             if (HasEqualityFilter(Query.Criteria, nameof(EntityMetadata.LogicalName)))
             {
@@ -465,7 +535,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 }
             }
 
-            var count = entityCount * attributesPerEntity * relationshipsPerEntity * keysPerEntity;
+            if (MetadataSource.HasFlag(MetadataSource.Value))
+                valuesPerAttribute = 2;
+
+            var count = entityCount * attributesPerEntity * relationshipsPerEntity * keysPerEntity * valuesPerAttribute;
 
             if (count == 1)
                 return RowCountEstimateDefiniteRange.ZeroOrOne;
@@ -785,6 +858,43 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 childCount++;
             }
 
+            if (MetadataSource.HasFlag(MetadataSource.Value))
+            {
+                var valueProps = (IEnumerable<MetadataProperty>)_valueProps.Values;
+
+                if (_valueCols != null)
+                    valueProps = _valueCols.Values;
+
+                if (context.Options.ColumnOrdering == ColumnOrdering.Alphabetical)
+                    valueProps = valueProps.OrderBy(p => p.SqlName);
+                else
+                    valueProps = valueProps.OrderBy(p => p.DataMemberOrder[0]).ThenBy(p => p.DataMemberOrder[1]).ThenBy(p => p.DataMemberOrder[2]);
+
+                var escapedValueAlias = ValueAlias.EscapeIdentifier();
+
+                foreach (var prop in valueProps)
+                {
+                    var fullName = $"{escapedValueAlias}.{prop.SqlName}";
+                    var nullable = true;
+
+                    if (_valueNotNullProps.Contains(prop.PropertyName))
+                        nullable = false;
+
+                    schema[fullName] = new ColumnDefinition(prop.SqlType, nullable, false);
+
+                    if (!aliases.TryGetValue(prop.SqlName, out var a))
+                    {
+                        a = new List<string>();
+                        aliases[prop.SqlName] = a;
+                    }
+
+                    ((List<string>)a).Add(fullName);
+                }
+
+                primaryKey = null;
+                childCount++;
+            }
+
             if (childCount > 1)
                 primaryKey = null;
 
@@ -1001,33 +1111,61 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     query.Properties.PropertyNames.Add(nameof(EntityMetadata.Keys));
             }
 
+            if (MetadataSource.HasFlag(MetadataSource.Value))
+            {
+                if (query.Properties == null)
+                    query.Properties = new MetadataPropertiesExpression();
+
+                // Ensure the entity metadata contains the attributes
+                if (!query.Properties.AllProperties && !query.Properties.PropertyNames.Contains(nameof(EntityMetadata.Attributes)))
+                    query.Properties.PropertyNames.Add(nameof(EntityMetadata.Attributes));
+
+                // Ensure the attribute metadata contains the values
+                if (query.AttributeQuery == null)
+                    query.AttributeQuery = new AttributeQueryExpression();
+
+                if (!query.AttributeQuery.Properties.AllProperties && !query.AttributeQuery.Properties.PropertyNames.Contains(nameof(EnumAttributeMetadata.OptionSet)))
+                    query.AttributeQuery.Properties.PropertyNames.Add(nameof(EnumAttributeMetadata.OptionSet));
+            }
+
             if (!context.Session.DataSources.TryGetValue(DataSource, out var dataSource))
                 throw new NotSupportedQueryFragmentException("Missing datasource " + DataSource);
 
             var resp = (RetrieveMetadataChangesResponse)dataSource.Connection.Execute(new RetrieveMetadataChangesRequest { Query = query });
-
-            var entityProps = typeof(EntityMetadata).GetProperties().ToDictionary(p => p.Name);
-            var oneToManyRelationshipProps = typeof(OneToManyRelationshipMetadata).GetProperties().ToDictionary(p => p.Name);
-            var manyToManyRelationshipProps = typeof(ManyToManyRelationshipMetadata).GetProperties().ToDictionary(p => p.Name);
-            var keyProps = typeof(EntityKeyMetadata).GetProperties().ToDictionary(p => p.Name);
             var eec = new ExpressionExecutionContext(context);
 
-            var results = resp.EntityMetadata.Select(e => new { Entity = e, Attribute = (AttributeMetadata)null, Relationship = (RelationshipMetadataBase)null, Key = (EntityKeyMetadata)null });
+            var results = resp.EntityMetadata.Select(e => new { Entity = e, Attribute = (AttributeMetadata)null, Relationship = (RelationshipMetadataBase)null, Key = (EntityKeyMetadata)null, Value = (OptionMetadata)null });
 
-            if (MetadataSource.HasFlag(MetadataSource.Attribute))
-                results = results.SelectMany(r => r.Entity.Attributes.Select(a => new { Entity = r.Entity, Attribute = a, Relationship = r.Relationship, Key = r.Key }));
+            if (MetadataSource.HasFlag(MetadataSource.Attribute) || MetadataSource.HasFlag(MetadataSource.Value))
+                results = results.SelectMany(r => r.Entity.Attributes.Select(a => new { Entity = r.Entity, Attribute = a, Relationship = r.Relationship, Key = r.Key, Value = r.Value }));
 
             if (MetadataSource.HasFlag(MetadataSource.OneToManyRelationship))
-                results = results.SelectMany(r => r.Entity.OneToManyRelationships.Select(om => new { Entity = r.Entity, Attribute = r.Attribute, Relationship = (RelationshipMetadataBase)om, Key = r.Key }));
+                results = results.SelectMany(r => r.Entity.OneToManyRelationships.Select(om => new { Entity = r.Entity, Attribute = r.Attribute, Relationship = (RelationshipMetadataBase)om, Key = r.Key, Value = r.Value }));
 
             if (MetadataSource.HasFlag(MetadataSource.ManyToOneRelationship))
-                results = results.SelectMany(r => r.Entity.ManyToOneRelationships.Select(mo => new { Entity = r.Entity, Attribute = r.Attribute, Relationship = (RelationshipMetadataBase)mo, Key = r.Key }));
+                results = results.SelectMany(r => r.Entity.ManyToOneRelationships.Select(mo => new { Entity = r.Entity, Attribute = r.Attribute, Relationship = (RelationshipMetadataBase)mo, Key = r.Key, Value = r.Value }));
 
             if (MetadataSource.HasFlag(MetadataSource.ManyToManyRelationship))
-                results = results.SelectMany(r => r.Entity.ManyToManyRelationships.Where(mm => ManyToManyRelationshipJoin == null || ((string)typeof(ManyToManyRelationshipMetadata).GetProperty(ManyToManyRelationshipJoin).GetValue(mm)) == r.Entity.LogicalName).Select(mm => new { Entity = r.Entity, Attribute = r.Attribute, Relationship = (RelationshipMetadataBase)mm, Key = r.Key }));
+                results = results.SelectMany(r => r.Entity.ManyToManyRelationships.Where(mm => ManyToManyRelationshipJoin == null || ((string)typeof(ManyToManyRelationshipMetadata).GetProperty(ManyToManyRelationshipJoin).GetValue(mm)) == r.Entity.LogicalName).Select(mm => new { Entity = r.Entity, Attribute = r.Attribute, Relationship = (RelationshipMetadataBase)mm, Key = r.Key, Value = r.Value }));
 
             if (MetadataSource.HasFlag(MetadataSource.Key))
-                results = results.SelectMany(r => r.Entity.Keys.Select(k => new { Entity = r.Entity, Attribute = r.Attribute, Relationship = r.Relationship, Key = k }));
+                results = results.SelectMany(r => r.Entity.Keys.Select(k => new { Entity = r.Entity, Attribute = r.Attribute, Relationship = r.Relationship, Key = k, Value = r.Value }));
+
+            if (MetadataSource.HasFlag(MetadataSource.Value))
+            {
+                results = results
+                    .Where(r => r.Attribute is EnumAttributeMetadata)
+                    .SelectMany(r => ((EnumAttributeMetadata)r.Attribute).OptionSet.Options.Select(o => new { Entity = r.Entity, Attribute = r.Attribute, Relationship = r.Relationship, Key = r.Key, Value = o }))
+                    .Concat(
+                        results
+                            .Where(r => r.Attribute is BooleanAttributeMetadata)
+                            .SelectMany(r => new[]
+                            {
+                                new { Entity = r.Entity, Attribute = r.Attribute, Relationship = r.Relationship, Key = r.Key, Value = ((BooleanAttributeMetadata)r.Attribute).OptionSet.FalseOption },
+                                new { Entity = r.Entity, Attribute = r.Attribute, Relationship = r.Relationship, Key = r.Key, Value = ((BooleanAttributeMetadata)r.Attribute).OptionSet.TrueOption },
+                            })
+                    );
+            }
 
             foreach (var result in results)
             {
@@ -1093,6 +1231,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                     foreach (var prop in _keyCols)
                         converted[prop.Key] = prop.Value.Accessor(result.Key, eec);
+                }
+
+                if (MetadataSource.HasFlag(MetadataSource.Value))
+                {
+                    converted.LogicalName = "value";
+                    converted.Id = result.Value.MetadataId ?? Guid.Empty;
+
+                    foreach (var prop in _valueCols)
+                        converted[prop.Key] = prop.Value.Accessor(result.Value, eec);
                 }
 
                 foreach (var attr in converted.Attributes.ToList())
@@ -1214,20 +1361,22 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             {
                 AttributeAlias = AttributeAlias,
                 DataSource = DataSource,
-                EntityAlias= EntityAlias,
+                EntityAlias = EntityAlias,
                 ManyToManyRelationshipAlias = ManyToManyRelationshipAlias,
                 ManyToManyRelationshipJoin = ManyToManyRelationshipJoin,
                 ManyToOneRelationshipAlias = ManyToOneRelationshipAlias,
                 KeyAlias = KeyAlias,
-                MetadataSource = MetadataSource,
+                ValueAlias = ValueAlias,
                 OneToManyRelationshipAlias = OneToManyRelationshipAlias,
+                MetadataSource = MetadataSource,
                 Query = Query.Clone(),
                 _attributeCols = _attributeCols,
                 _entityCols = _entityCols,
                 _manyToManyRelationshipCols = _manyToManyRelationshipCols,
                 _manyToOneRelationshipCols = _manyToOneRelationshipCols,
                 _oneToManyRelationshipCols = _oneToManyRelationshipCols,
-                _keyCols = _keyCols
+                _keyCols = _keyCols,
+                _valueCols = _valueCols,
             };
         }
     }
@@ -1240,6 +1389,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         OneToManyRelationship = 4,
         ManyToOneRelationship = 8,
         ManyToManyRelationship = 16,
-        Key = 32
+        Key = 32,
+        Value = 64,
     }
 }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MetadataQueryNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/MetadataQueryNode.cs
@@ -827,7 +827,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         internal static DataTypeReference GetPropertyType(Type propType)
         {
             if (propType == typeof(OptionMetadata))
-                propType = typeof(SqlInt32);
+                propType = typeof(int);
 
             if (propType.BaseType != null && propType.BaseType.IsGenericType && propType.BaseType.GetGenericTypeDefinition() == typeof(ManagedProperty<>))
                 propType = propType.BaseType.GetGenericArguments()[0];

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -4303,6 +4303,16 @@ namespace MarkMpn.Sql4Cds.Engine
                         };
                     }
 
+                    if (entityName.Equals("optionsetvalue", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new MetadataQueryNode
+                        {
+                            DataSource = dataSource.Name,
+                            MetadataSource = MetadataSource.Value,
+                            ValueAlias = table.Alias?.Value ?? entityName
+                        };
+                    }
+
                     if (entityName.Equals("globaloptionset", StringComparison.OrdinalIgnoreCase))
                     {
                         return new GlobalOptionSetQueryNode
@@ -4319,7 +4329,7 @@ namespace MarkMpn.Sql4Cds.Engine
                         {
                             DataSource = dataSource.Name,
                             MetadataSource = OptionSetSource.Value,
-                            ValuesAlias = table.Alias?.Value ?? entityName
+                            ValueAlias = table.Alias?.Value ?? entityName
                         };
                     }
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -4308,7 +4308,18 @@ namespace MarkMpn.Sql4Cds.Engine
                         return new GlobalOptionSetQueryNode
                         {
                             DataSource = dataSource.Name,
-                            Alias = table.Alias?.Value ?? entityName
+                            MetadataSource = OptionSetSource.OptionSet,
+                            OptionSetAlias = table.Alias?.Value ?? entityName
+                        };
+                    }
+
+                    if (entityName.Equals("globaloptionsetvalue", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new GlobalOptionSetQueryNode
+                        {
+                            DataSource = dataSource.Name,
+                            MetadataSource = OptionSetSource.Value,
+                            ValuesAlias = table.Alias?.Value ?? entityName
                         };
                     }
 

--- a/MarkMpn.Sql4Cds.Engine/MetaMetadataCache.cs
+++ b/MarkMpn.Sql4Cds.Engine/MetaMetadataCache.cs
@@ -107,11 +107,13 @@ namespace MarkMpn.Sql4Cds.Engine
             _customMetadata["metadata." + metadataNode.KeyAlias] = SchemaToMetadata(metadataSchema, metadataNode.KeyAlias);
 
             var optionsetNode = new GlobalOptionSetQueryNode();
-            optionsetNode.Alias = "globaloptionset";
+            optionsetNode.OptionSetAlias = "globaloptionset";
+            optionsetNode.ValuesAlias = "globaloptionsetvalue";
 
             var optionsetSchema = optionsetNode.GetSchema(new NodeCompilationContext(null, new StubOptions(), null, null));
 
-            _customMetadata["metadata." + optionsetNode.Alias] = SchemaToMetadata(optionsetSchema, optionsetNode.Alias);
+            _customMetadata["metadata." + optionsetNode.OptionSetAlias] = SchemaToMetadata(optionsetSchema, optionsetNode.OptionSetAlias);
+            _customMetadata["metadata." + optionsetNode.ValuesAlias] = SchemaToMetadata(optionsetSchema, optionsetNode.ValuesAlias);
         }
 
         private static EntityMetadata SchemaToMetadata(INodeSchema schema, string alias)

--- a/MarkMpn.Sql4Cds.Engine/MetaMetadataCache.cs
+++ b/MarkMpn.Sql4Cds.Engine/MetaMetadataCache.cs
@@ -96,6 +96,7 @@ namespace MarkMpn.Sql4Cds.Engine
             metadataNode.ManyToOneRelationshipAlias = "relationship_n_1";
             metadataNode.ManyToManyRelationshipAlias = "relationship_n_n";
             metadataNode.KeyAlias = "alternate_key";
+            metadataNode.ValueAlias = "optionsetvalue";
 
             var metadataSchema = metadataNode.GetSchema(new NodeCompilationContext(null, new StubOptions(), null, null));
 
@@ -105,15 +106,16 @@ namespace MarkMpn.Sql4Cds.Engine
             _customMetadata["metadata." + metadataNode.ManyToOneRelationshipAlias] = SchemaToMetadata(metadataSchema, metadataNode.ManyToOneRelationshipAlias);
             _customMetadata["metadata." + metadataNode.ManyToManyRelationshipAlias] = SchemaToMetadata(metadataSchema, metadataNode.ManyToManyRelationshipAlias);
             _customMetadata["metadata." + metadataNode.KeyAlias] = SchemaToMetadata(metadataSchema, metadataNode.KeyAlias);
+            _customMetadata["metadata." + metadataNode.ValueAlias] = SchemaToMetadata(metadataSchema, metadataNode.ValueAlias);
 
             var optionsetNode = new GlobalOptionSetQueryNode();
             optionsetNode.OptionSetAlias = "globaloptionset";
-            optionsetNode.ValuesAlias = "globaloptionsetvalue";
+            optionsetNode.ValueAlias = "globaloptionsetvalue";
 
             var optionsetSchema = optionsetNode.GetSchema(new NodeCompilationContext(null, new StubOptions(), null, null));
 
             _customMetadata["metadata." + optionsetNode.OptionSetAlias] = SchemaToMetadata(optionsetSchema, optionsetNode.OptionSetAlias);
-            _customMetadata["metadata." + optionsetNode.ValuesAlias] = SchemaToMetadata(optionsetSchema, optionsetNode.ValuesAlias);
+            _customMetadata["metadata." + optionsetNode.ValueAlias] = SchemaToMetadata(optionsetSchema, optionsetNode.ValueAlias);
         }
 
         private static EntityMetadata SchemaToMetadata(INodeSchema schema, string alias)
@@ -145,81 +147,104 @@ namespace MarkMpn.Sql4Cds.Engine
 
         private static OneToManyRelationshipMetadata[] CreateOneToManyRelationships(string alias)
         {
-            if (alias == "metadata.entity")
-            {
-                var attrRelationship = new OneToManyRelationshipMetadata
-                {
-                    SchemaName = "entity_attributes",
-                    ReferencedEntity = "metadata.entity",
-                    ReferencedAttribute = "logicalname",
-                    ReferencingEntity = "metadata.attribute",
-                    ReferencingAttribute = "entitylogicalname"
-                };
-
-                var rel1nRelationship = new OneToManyRelationshipMetadata
-                {
-                    SchemaName = "entity_one_to_many_relationships",
-                    ReferencedEntity = "metadata.entity",
-                    ReferencedAttribute = "logicalname",
-                    ReferencingEntity = "metadata.relationship_1_n",
-                    ReferencingAttribute = "referencedentity"
-                };
-
-                var reln1Relationship = new OneToManyRelationshipMetadata
-                {
-                    SchemaName = "entity_many_to_one_relationships",
-                    ReferencedEntity = "metadata.entity",
-                    ReferencedAttribute = "logicalname",
-                    ReferencingEntity = "metadata.relationship_n_1",
-                    ReferencingAttribute = "referencingentity"
-                };
-
-                var relnnRelationship1 = new OneToManyRelationshipMetadata
-                {
-                    SchemaName = "entity_many_to_many_relationships_entity1",
-                    ReferencedEntity = "metadata.entity",
-                    ReferencedAttribute = "logicalname",
-                    ReferencingEntity = "metadata.relationship_n_n",
-                    ReferencingAttribute = "entity1logicalname"
-                };
-
-                var relnnRelationship2 = new OneToManyRelationshipMetadata
-                {
-                    SchemaName = "entity_many_to_many_relationships_entity2",
-                    ReferencedEntity = "metadata.entity",
-                    ReferencedAttribute = "logicalname",
-                    ReferencingEntity = "metadata.relationship_n_n",
-                    ReferencingAttribute = "entity2logicalname"
-                };
-
-                var relnnRelationshipIntersect = new OneToManyRelationshipMetadata
-                {
-                    SchemaName = "entity_many_to_many_relationships_intersect",
-                    ReferencedEntity = "metadata.entity",
-                    ReferencedAttribute = "logicalname",
-                    ReferencingEntity = "metadata.relationship_n_n",
-                    ReferencingAttribute = "intersectentityname"
-                };
-
-                return new[]
-                {
-                    attrRelationship,
-                    rel1nRelationship,
-                    reln1Relationship,
-                    relnnRelationship1,
-                    relnnRelationship2,
-                    relnnRelationshipIntersect
-                };
-            }
-
-            return Array.Empty<OneToManyRelationshipMetadata>();
+            return GetAllRelationships()
+                .Where(r => r.ReferencedEntity == alias)
+                .ToArray();
         }
 
         private static OneToManyRelationshipMetadata[] CreateManyToOneRelationships(string alias)
         {
-            var relationships = CreateOneToManyRelationships("metadata.entity");
+            return GetAllRelationships()
+                .Where(r => r.ReferencingEntity == alias)
+                .ToArray();
+        }
 
-            return relationships.Where(r => r.ReferencingEntity == alias).ToArray();
+        private static OneToManyRelationshipMetadata[] GetAllRelationships()
+        {
+
+            var attrRelationship = new OneToManyRelationshipMetadata
+            {
+                SchemaName = "entity_attributes",
+                ReferencedEntity = "metadata.entity",
+                ReferencedAttribute = "logicalname",
+                ReferencingEntity = "metadata.attribute",
+                ReferencingAttribute = "entitylogicalname"
+            };
+
+            var rel1nRelationship = new OneToManyRelationshipMetadata
+            {
+                SchemaName = "entity_one_to_many_relationships",
+                ReferencedEntity = "metadata.entity",
+                ReferencedAttribute = "logicalname",
+                ReferencingEntity = "metadata.relationship_1_n",
+                ReferencingAttribute = "referencedentity"
+            };
+
+            var reln1Relationship = new OneToManyRelationshipMetadata
+            {
+                SchemaName = "entity_many_to_one_relationships",
+                ReferencedEntity = "metadata.entity",
+                ReferencedAttribute = "logicalname",
+                ReferencingEntity = "metadata.relationship_n_1",
+                ReferencingAttribute = "referencingentity"
+            };
+
+            var relnnRelationship1 = new OneToManyRelationshipMetadata
+            {
+                SchemaName = "entity_many_to_many_relationships_entity1",
+                ReferencedEntity = "metadata.entity",
+                ReferencedAttribute = "logicalname",
+                ReferencingEntity = "metadata.relationship_n_n",
+                ReferencingAttribute = "entity1logicalname"
+            };
+
+            var relnnRelationship2 = new OneToManyRelationshipMetadata
+            {
+                SchemaName = "entity_many_to_many_relationships_entity2",
+                ReferencedEntity = "metadata.entity",
+                ReferencedAttribute = "logicalname",
+                ReferencingEntity = "metadata.relationship_n_n",
+                ReferencingAttribute = "entity2logicalname"
+            };
+
+            var relnnRelationshipIntersect = new OneToManyRelationshipMetadata
+            {
+                SchemaName = "entity_many_to_many_relationships_intersect",
+                ReferencedEntity = "metadata.entity",
+                ReferencedAttribute = "logicalname",
+                ReferencingEntity = "metadata.relationship_n_n",
+                ReferencingAttribute = "intersectentityname"
+            };
+
+            var attributeValuesRelationship = new OneToManyRelationshipMetadata
+            {
+                SchemaName = "attribute_optionsetvalues",
+                ReferencedEntity = "metadata.attribute",
+                ReferencedAttribute = "metadataid",
+                ReferencingEntity = "metadata.optionsetvalue",
+                ReferencingAttribute = "attributeid"
+            };
+
+            var globalOptionsetValuesRelationship = new OneToManyRelationshipMetadata
+            {
+                SchemaName = "globaloptionset_optionsetvalues",
+                ReferencedEntity = "metadata.globaloptionset",
+                ReferencedAttribute = "metadataid",
+                ReferencingEntity = "metadata.globaloptionsetvalue",
+                ReferencingAttribute = "optionsetid"
+            };
+
+            return new[]
+            {
+                attrRelationship,
+                rel1nRelationship,
+                reln1Relationship,
+                relnnRelationship1,
+                relnnRelationship2,
+                relnnRelationshipIntersect,
+                attributeValuesRelationship,
+                globalOptionsetValuesRelationship
+            };
         }
 
         private static void SetSealedProperty(object target, string prop, object value)

--- a/MarkMpn.Sql4Cds.Engine/Visitors/ReplacePrimaryFunctionsVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/ReplacePrimaryFunctionsVisitor.cs
@@ -31,6 +31,7 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
                         ThenExpression = expr
                     });
 
+                caseExpr.Accept(this);
                 return caseExpr;
             }
 
@@ -42,13 +43,14 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
                     {
                         new SearchedWhenClause
                         {
-                            WhenExpression = iif.Predicate,
-                            ThenExpression = iif.ThenExpression
+                            WhenExpression = iif.Predicate.Clone(),
+                            ThenExpression = iif.ThenExpression.Clone()
                         }
                     },
-                    ElseExpression = iif.ElseExpression
+                    ElseExpression = iif.ElseExpression.Clone()
                 };
 
+                caseExpr.Accept(this);
                 return caseExpr;
             }
 
@@ -60,8 +62,9 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
                 };
 
                 foreach (var param in left.Parameters)
-                    leftFunc.Parameters.Add(param);
+                    leftFunc.Parameters.Add(param.Clone());
 
+                leftFunc.Accept(this);
                 return leftFunc;
             }
 
@@ -75,16 +78,17 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
                         {
                             WhenExpression = new BooleanComparisonExpression
                             {
-                                ComparisonType = BooleanComparisonType.Equals,
                                 FirstExpression = nullif.FirstExpression.Clone(),
-                                SecondExpression = nullif.SecondExpression
+                                ComparisonType = BooleanComparisonType.Equals,
+                                SecondExpression = nullif.SecondExpression.Clone()
                             },
                             ThenExpression = new NullLiteral()
                         }
                     },
-                    ElseExpression = nullif.FirstExpression
+                    ElseExpression = nullif.FirstExpression.Clone()
                 };
 
+                caseExpr.Accept(this);
                 return caseExpr;
             }
 
@@ -96,8 +100,9 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
                 };
 
                 foreach (var param in right.Parameters)
-                    rightFunc.Parameters.Add(param);
+                    rightFunc.Parameters.Add(param.Clone());
 
+                rightFunc.Accept(this);
                 return rightFunc;
             }
 
@@ -126,9 +131,9 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
                     {
                         FirstExpression = new BooleanComparisonExpression
                         {
-                            FirstExpression = between.FirstExpression,
+                            FirstExpression = between.FirstExpression.Clone(),
                             ComparisonType = between.TernaryExpressionType == BooleanTernaryExpressionType.Between ? BooleanComparisonType.GreaterThanOrEqualTo : BooleanComparisonType.LessThan,
-                            SecondExpression = between.SecondExpression,
+                            SecondExpression = between.SecondExpression.Clone(),
 
                             FirstTokenIndex = between.FirstTokenIndex,
                             LastTokenIndex = between.LastTokenIndex,
@@ -137,9 +142,9 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
                         BinaryExpressionType = between.TernaryExpressionType == BooleanTernaryExpressionType.Between ? BooleanBinaryExpressionType.And : BooleanBinaryExpressionType.Or,
                         SecondExpression = new BooleanComparisonExpression
                         {
-                            FirstExpression = between.FirstExpression,
+                            FirstExpression = between.FirstExpression.Clone(),
                             ComparisonType = between.TernaryExpressionType == BooleanTernaryExpressionType.Between ? BooleanComparisonType.LessThanOrEqualTo : BooleanComparisonType.GreaterThan,
-                            SecondExpression = between.ThirdExpression,
+                            SecondExpression = between.ThirdExpression.Clone(),
 
                             FirstTokenIndex = between.FirstTokenIndex,
                             LastTokenIndex = between.LastTokenIndex,
@@ -156,6 +161,7 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
                     ScriptTokenStream = between.ScriptTokenStream
                 };
 
+                converted.Accept(this);
                 return converted;
             }
 

--- a/MarkMpn.Sql4Cds.Tests/FormatterTests.cs
+++ b/MarkMpn.Sql4Cds.Tests/FormatterTests.cs
@@ -119,5 +119,37 @@ FROM   (SELECT sc.solutionidname AS uniquename,
 
             Assert.AreEqual(expected, Formatter.Format(original));
         }
+
+        [TestMethod]
+        public void Issue599()
+        {
+            var original = @"SELECT *
+FROM businessunit
+	--aaa
+	--bbb";
+
+            var expected = @"SELECT *
+FROM   businessunit;
+	--aaa
+	--bbb";
+
+            Assert.AreEqual(expected, Formatter.Format(original));
+        }
+
+        [TestMethod]
+        public void Issue600()
+        {
+            var original = @"SELECT
+	-- b.name,
+	b.*
+FROM businessunit as b";
+
+            var expected = @"SELECT
+	-- b.name,
+	 b.*
+FROM   businessunit AS b;";
+
+            Assert.AreEqual(expected, Formatter.Format(original));
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.XTB/DocumentWindowBase.cs
+++ b/MarkMpn.Sql4Cds.XTB/DocumentWindowBase.cs
@@ -148,7 +148,7 @@ namespace MarkMpn.Sql4Cds.XTB
         {
             base.OnClosing(e);
 
-            if (Modified && !Settings.Instance.RememberSession && this is ISaveableDocumentWindow saveable)
+            if (Modified && this is ISaveableDocumentWindow saveable)
             {
                 using (var form = new ConfirmCloseForm(new[] { DisplayName }, true))
                 {

--- a/MarkMpn.Sql4Cds.XTB/ObjectExplorer.cs
+++ b/MarkMpn.Sql4Cds.XTB/ObjectExplorer.cs
@@ -259,9 +259,9 @@ namespace MarkMpn.Sql4Cds.XTB
                 {
                     var node = new TreeNode(msg.Name);
                     node.Tag = msg;
-                    node.ImageIndex = 25;
-                    node.SelectedImageIndex = 25;
-                    node.ContextMenuStrip = functionContextMenuStrip;
+                    node.ImageIndex = imageIndex;
+                    node.SelectedImageIndex = imageIndex;
+                    node.ContextMenuStrip = menu;
                     return node;
                 })
                 .ToArray();
@@ -777,7 +777,15 @@ INNER JOIN {manyToMany.Entity2LogicalName}
                 TableReferences = { tvfReference }
             };
 
-            foreach (var param in tvf.InputParameters)
+            var parameters = tvf.InputParameters
+                .Where(p => p.Type != typeof(PagingInfo));
+
+            if (Settings.Instance.ColumnOrdering == ColumnOrdering.Alphabetical)
+                parameters = parameters.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase);
+            else
+                parameters = parameters.OrderBy(p => p.Position);
+
+            foreach (var param in parameters)
             {
                 tvfReference.Parameters.Add(new VariableReference
                 {
@@ -805,7 +813,15 @@ INNER JOIN {manyToMany.Entity2LogicalName}
                 DataType = new SqlDataTypeReference { SqlDataTypeOption = SqlDataTypeOption.Int }
             });
 
-            foreach (var param in sproc.InputParameters.Concat(sproc.OutputParameters))
+            var parameters = sproc.InputParameters
+                .Where(p => p.Type != typeof(PagingInfo));
+
+            if (Settings.Instance.ColumnOrdering == ColumnOrdering.Alphabetical)
+                parameters = parameters.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase);
+            else
+                parameters = parameters.OrderBy(p => p.Position);
+
+            foreach (var param in parameters.Concat(sproc.OutputParameters))
             {
                 declare.Declarations.Add(new DeclareVariableElement
                 {
@@ -839,7 +855,7 @@ INNER JOIN {manyToMany.Entity2LogicalName}
                 }
             };
 
-            foreach (var param in sproc.InputParameters)
+            foreach (var param in parameters)
             {
                 exec.ExecuteSpecification.ExecutableEntity.Parameters.Add(new ExecuteParameter
                 {

--- a/MarkMpn.Sql4Cds.XTB/ObjectExplorer.cs
+++ b/MarkMpn.Sql4Cds.XTB/ObjectExplorer.cs
@@ -965,7 +965,7 @@ INNER JOIN {manyToMany.Entity2LogicalName}
                     names.Add(new KeyValuePair<string, DataTypeReference>(a.LogicalName, type));
 
                     foreach (var virtualAttr in a.GetVirtualAttributes(dataSource, true))
-                        names.Add(new KeyValuePair<string, DataTypeReference>(a.LogicalName + virtualAttr.Suffix, virtualAttr.DataType));
+                        names.Add(new KeyValuePair<string, DataTypeReference>(a.LogicalName + virtualAttr.Suffix, virtualAttr.DataType()));
 
                     return names;
                 })
@@ -1056,7 +1056,7 @@ INNER JOIN {manyToMany.Entity2LogicalName}
                     names.Add(new KeyValuePair<string, DataTypeReference>(a.LogicalName, type));
 
                     foreach (var virtualAttr in a.GetVirtualAttributes(dataSource, true))
-                        names.Add(new KeyValuePair<string, DataTypeReference>(a.LogicalName + virtualAttr.Suffix, virtualAttr.DataType));
+                        names.Add(new KeyValuePair<string, DataTypeReference>(a.LogicalName + virtualAttr.Suffix, virtualAttr.DataType()));
 
                     return names;
                 })

--- a/MarkMpn.Sql4Cds.XTB/PluginControl.cs
+++ b/MarkMpn.Sql4Cds.XTB/PluginControl.cs
@@ -664,14 +664,15 @@ namespace MarkMpn.Sql4Cds.XTB
 
         public override void ClosingPlugin(PluginCloseInfo info)
         {
-            if (!ConfirmBulkClose(dockPanel.Contents.OfType<IDocumentWindow>().Cast<IDockContent>().ToArray(), info.Silent))
+            if (Settings.Instance.RememberSession)
+            {
+                SaveSettings();
+            }
+            else if (!ConfirmBulkClose(dockPanel.Contents.OfType<IDocumentWindow>().Cast<IDockContent>().ToArray(), info.Silent))
             {
                 info.Cancel = true;
                 return;
             }
-
-            if (Settings.Instance.RememberSession)
-                SaveSettings();
 
             base.ClosingPlugin(info);
         }
@@ -898,7 +899,7 @@ in
                 .Where(query => query.Modified)
                 .ToArray();
 
-            if (unsavedDocuments.Length > 0 && !Settings.Instance.RememberSession)
+            if (unsavedDocuments.Length > 0)
             {
                 using (var form = new ConfirmCloseForm(unsavedDocuments.Select(query => query.DisplayName).ToArray(), !silent))
                 {


### PR DESCRIPTION
- Reduced amount of metadata required - fixes #593 
- Expose optionset values via `metadata.globaloptionsetvalue` and `metadata.optionsetvalue` - fixes #543 
- Avoid errors with cross-table comparisons and nested link entities - fixes #595 
- Handle nested primary functions - fixes #598 
- Improved handling of comments and whitespace when reformatting queries - fixes #599, #600
- Fixed generating TVF and sproc scripts - fixes #601 
- Show confirmation dialog when closing unsaved scripts even when session persistence is enabled