### PR TITLE
.NET 8

### DIFF
--- a/AzureDataStudioExtension/CHANGELOG.md
+++ b/AzureDataStudioExtension/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## [v9.5.0](https://github.com/MarkMpn/Sql4Cds/releases/tag/v9.4.1) - 2024-12-07
+
+Updated to .NET 8
+
+Bulk DML improvements
+* Automatically adjust batch size to keep requests within timeout limits
+* Automatically adjust thread count to avoid hitting service protection limits
+* Provide better feedback when queries pause due to service protection limits
+* Automatically retry requests that have failed due to a transient error
+* Added DML support for `solutioncomponent` table
+
+Metadata improvements
+* Expose optionset values via `metadata.globaloptionsetvalue` and `metadata.optionsetvalue` tables
+* Reduced amount of metadata required to execute queries
+
+Bug fixes
+* Use correct scale when displaying numeric results
+* Fixed "Must declare the scalar variable @Cond" error when using nested loop for single-record joins
+* Do not trust `RetrieveTotalRecordCount` for certain metadata-related entities that give incorrect results
+* Avoid errors when using cross-table column comparisons and nested link entities
+* Handle nested primary functions
+
 ## [v9.4.1](https://github.com/MarkMpn/Sql4Cds/releases/tag/v9.4.1) - 2024-11-10
 
 Fixed Intellisense with trailing comments

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.csproj
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>MarkMpn.Sql4Cds.Engine</AssemblyName>
     <RootNamespace>MarkMpn.Sql4Cds.Engine</RootNamespace>
     <Copyright>Copyright © 2020 - 2024 Mark Carrington</Copyright>
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.1.9" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.2" Condition=" '$(TargetFramework)' == 'net8.0' " />
     <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.49" Condition=" '$(TargetFramework)' == 'net462' " />
     <PackageReference Include="Microsoft.CrmSdk.XrmTooling.CoreAssembly" Version="9.1.1.32" Condition=" '$(TargetFramework)' == 'net462' " />
     <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="161.8834.0" />

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -11,9 +11,22 @@
     <iconUrl>https://markcarrington.dev/sql4cds-icon/</iconUrl>
     <description>Convert SQL queries to FetchXml and execute them against Dataverse / D365</description>
     <summary>Convert SQL queries to FetchXml and execute them against Dataverse / D365</summary>
-    <releaseNotes>Include join alias in output column aliases when converting from Fetch XML to SQL
-Improved SQL to Fetch XML conversion of datetime filters
-Fixed use of case-insensitive table names in INSERT statements
+    <releaseNotes>Bulk DML improvements
+* Automatically adjust batch size to keep requests within timeout limits
+* Automatically adjust thread count to avoid hitting service protection limits
+* Provide better feedback when queries pause due to service protection limits
+* Automatically retry requests that have failed due to a transient error
+* Added DML support for `solutioncomponent` table
+
+Metadata improvements
+* Expose optionset values via `metadata.globaloptionsetvalue` and `metadata.optionsetvalue` tables
+* Reduced amount of metadata required to execute queries
+
+Bug fixes
+* Fixed "Must declare the scalar variable @Cond" error when using nested loop for single-record joins
+* Do not trust `RetrieveTotalRecordCount` for certain metadata-related entities that give incorrect results
+* Avoid errors when using cross-table column comparisons and nested link entities
+* Handle nested primary functions
     </releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -11,7 +11,9 @@
     <iconUrl>https://markcarrington.dev/sql4cds-icon/</iconUrl>
     <description>Convert SQL queries to FetchXml and execute them against Dataverse / D365</description>
     <summary>Convert SQL queries to FetchXml and execute them against Dataverse / D365</summary>
-    <releaseNotes>Bulk DML improvements
+    <releaseNotes>Updated to .NET 8
+
+Bulk DML improvements
 * Automatically adjust batch size to keep requests within timeout limits
 * Automatically adjust thread count to avoid hitting service protection limits
 * Provide better feedback when queries pause due to service protection limits
@@ -40,8 +42,8 @@ Bug fixes
         <dependency id="System.Data.SqlClient" version="4.8.6" />
         <dependency id="XPath2.Extensions" version="1.1.3" />
       </group>
-      <group targetFramework=".NETCoreApp6.0">
-        <dependency id="Microsoft.PowerPlatform.Dataverse.Client" version="1.1.9" />
+      <group targetFramework=".NETCoreApp8.0">
+        <dependency id="Microsoft.PowerPlatform.Dataverse.Client" version="1.2.2" />
         <dependency id="Microsoft.SqlServer.TransactSql.ScriptDom" version="161.8834.0" />
         <dependency id="Microsoft.ApplicationInsights" version="2.21.0" />
         <dependency id="System.Data.SqlClient" version="4.8.6" />
@@ -52,7 +54,7 @@ Bug fixes
   </metadata>
   <files>
     <file src=".\bin\Release\net462\MarkMpn.Sql4Cds.Engine.dll" target="lib\net462\MarkMpn.Sql4Cds.Engine.dll" />
-    <file src=".\bin\Release\net6.0\MarkMpn.Sql4Cds.Engine.dll" target="lib\net6.0\MarkMpn.Sql4Cds.Engine.dll" />
+    <file src=".\bin\Release\net6.0\MarkMpn.Sql4Cds.Engine.dll" target="lib\net8.0\MarkMpn.Sql4Cds.Engine.dll" />
     <file src="..\README.md" target="docs\" />
   </files>
 </package>

--- a/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/Autocomplete.cs
@@ -540,7 +540,7 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
                                         message.IsValidAsTableValuedFunction())
                                     {
                                         if (!Guid.TryParse(table.Key, out _))
-                                            items.Add(new TVFAutocompleteItem(message, table.Key, currentLength));
+                                            items.Add(new TVFAutocompleteItem(message, instance, table.Key, currentLength));
 
                                         attributes.AddRange(GetMessageOutputAttributes(message, instance));
                                     }
@@ -786,7 +786,7 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
 
                     // Show TVF list
                     if (fromClause && ds.Metadata != null)
-                        list.AddRange(ds.MessageCache.GetAllMessages().Where(x => x.IsValidAsTableValuedFunction()).Select(x => new TVFAutocompleteItem(x, _columnOrdering, currentLength)));
+                        list.AddRange(ds.MessageCache.GetAllMessages().Where(x => x.IsValidAsTableValuedFunction()).Select(x => new TVFAutocompleteItem(x, _columnOrdering, ds, currentLength)));
                 }
             }
             else if (TryParseTableName(currentWord, out var instanceName, out var schemaName, out var tableName, out var parts, out var lastPartLength))
@@ -856,7 +856,7 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
                     if (fromClause)
                     {
                         messages = messages.Where(e => e.IsValidAsTableValuedFunction() && e.Name.StartsWith(lastPart, StringComparison.OrdinalIgnoreCase));
-                        list.AddRange(messages.Select(e => new TVFAutocompleteItem(e, _columnOrdering, lastPartLength)));
+                        list.AddRange(messages.Select(e => new TVFAutocompleteItem(e, _columnOrdering, instance, lastPartLength)));
                     }
                 }
             }
@@ -1552,16 +1552,19 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
         {
             private readonly Message _message;
             private readonly ColumnOrdering _columnOrdering;
+            private readonly DataSource _dataSource;
 
-            public TVFAutocompleteItem(Message message, ColumnOrdering columnOrdering, int replaceLength) : base(message.Name, replaceLength, CompletionItemKind.Function)
+            public TVFAutocompleteItem(Message message, ColumnOrdering columnOrdering, DataSource dataSource, int replaceLength) : base(message.Name, replaceLength, CompletionItemKind.Function)
             {
                 _message = message;
                 _columnOrdering = columnOrdering;
+                _dataSource = dataSource;
             }
 
-            public TVFAutocompleteItem(Message message, string alias, int replaceLength) : base(alias, replaceLength, CompletionItemKind.Function)
+            public TVFAutocompleteItem(Message message, DataSource dataSource, string alias, int replaceLength) : base(alias, replaceLength, CompletionItemKind.Function)
             {
                 _message = message;
+                _dataSource = dataSource;
             }
 
             public override string ToolTipTitle
@@ -1582,7 +1585,7 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
                     else
                         parameters = parameters.OrderBy(p => p.Position);
 
-                    return _message.Name + "(" + String.Join(", ", parameters.Select(p => p.Name + " " + p.GetSqlDataType(null).ToSql())) + ")";
+                    return _message.Name + "(" + String.Join(", ", parameters.Select(p => p.Name + " " + p.GetSqlDataType(_dataSource).ToSql())) + ")";
                 }
                 set => base.ToolTipText = value;
             }

--- a/MarkMpn.Sql4Cds.LanguageServer/MarkMpn.Sql4Cds.LanguageServer.csproj
+++ b/MarkMpn.Sql4Cds.LanguageServer/MarkMpn.Sql4Cds.LanguageServer.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Copyright>Copyright © 2022 - 2024 Mark Carrington</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Data8.PowerPlatform.Dataverse.Client" Version="2.3.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.1.9" />
+    <PackageReference Include="Data8.PowerPlatform.Dataverse.Client" Version="2.4.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.2" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
-    <PackageReference Include="StreamJsonRpc" Version="2.14.24" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
+    <PackageReference Include="StreamJsonRpc" Version="2.20.20" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MarkMpn.Sql4Cds.LanguageServer/QueryExecution/QueryExecutionHandler.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/QueryExecution/QueryExecutionHandler.cs
@@ -349,7 +349,7 @@ namespace MarkMpn.Sql4Cds.LanguageServer.QueryExecution
                                 var schemaTable = reader.GetSchemaTable();
 
                                 for (var i = 0; i < reader.FieldCount; i++)
-                                    resultSet.ColumnInfo[i] = new DbColumnWrapper((string)schemaTable.Rows[i]["ColumnName"], (string)schemaTable.Rows[i]["DataTypeName"], (short?)schemaTable.Rows[i]["NumericScale"]);
+                                    resultSet.ColumnInfo[i] = new DbColumnWrapper(schemaTable.Rows[i]["ColumnName"] as string, (string)schemaTable.Rows[i]["DataTypeName"], (short?)schemaTable.Rows[i]["NumericScale"]);
 
                                 resultSetInProgress = resultSet;
                                 resultSets.Add(resultSet);

--- a/MarkMpn.Sql4Cds.XTB/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds.XTB/Autocomplete.cs
@@ -539,7 +539,7 @@ namespace MarkMpn.Sql4Cds.XTB
                                         message.IsValidAsTableValuedFunction())
                                     {
                                         if (!Guid.TryParse(table.Key, out _))
-                                            items.Add(new TVFAutocompleteItem(message, table.Key, currentLength));
+                                            items.Add(new TVFAutocompleteItem(message, instance, table.Key, currentLength));
 
                                         attributes.AddRange(GetMessageOutputAttributes(message, instance));
                                     }
@@ -785,7 +785,7 @@ namespace MarkMpn.Sql4Cds.XTB
 
                     // Show TVF list
                     if (fromClause && ds.MessageCache != null)
-                        list.AddRange(ds.MessageCache.GetAllMessages().Where(x => x.IsValidAsTableValuedFunction()).Select(x => new TVFAutocompleteItem(x, _columnOrdering, currentLength)));
+                        list.AddRange(ds.MessageCache.GetAllMessages().Where(x => x.IsValidAsTableValuedFunction()).Select(x => new TVFAutocompleteItem(x, _columnOrdering, ds, currentLength)));
                 }
             }
             else if (TryParseTableName(currentWord, out var instanceName, out var schemaName, out var tableName, out var parts, out var lastPartLength))
@@ -855,7 +855,7 @@ namespace MarkMpn.Sql4Cds.XTB
                     if (fromClause)
                     {
                         messages = messages.Where(e => e.IsValidAsTableValuedFunction() && e.Name.StartsWith(lastPart, StringComparison.OrdinalIgnoreCase));
-                        list.AddRange(messages.Select(e => new TVFAutocompleteItem(e, _columnOrdering, lastPartLength)));
+                        list.AddRange(messages.Select(e => new TVFAutocompleteItem(e, _columnOrdering, instance, lastPartLength)));
                     }
                 }
             }
@@ -1534,16 +1534,19 @@ namespace MarkMpn.Sql4Cds.XTB
         {
             private readonly Message _message;
             private readonly ColumnOrdering _columnOrdering;
+            private readonly DataSource _dataSource;
 
-            public TVFAutocompleteItem(Message message, ColumnOrdering columnOrdering, int replaceLength) : base(message.Name, replaceLength, 25)
+            public TVFAutocompleteItem(Message message, ColumnOrdering columnOrdering, DataSource dataSource, int replaceLength) : base(message.Name, replaceLength, 25)
             {
                 _message = message;
                 _columnOrdering = columnOrdering;
+                _dataSource = dataSource;
             }
 
-            public TVFAutocompleteItem(Message message, string alias, int replaceLength) : base(alias, replaceLength, 25)
+            public TVFAutocompleteItem(Message message, DataSource dataSource, string alias, int replaceLength) : base(alias, replaceLength, 25)
             {
                 _message = message;
+                _dataSource = dataSource;
             }
 
             public override string ToolTipTitle
@@ -1564,7 +1567,7 @@ namespace MarkMpn.Sql4Cds.XTB
                     else
                         parameters = parameters.OrderBy(p => p.Position);
 
-                    return _message.Name + "(" + String.Join(", ", parameters.Select(p => p.Name + " " + p.GetSqlDataType(null).ToSql())) + ")";
+                    return _message.Name + "(" + String.Join(", ", parameters.Select(p => p.Name + " " + p.GetSqlDataType(_dataSource).ToSql())) + ")";
                 }
                 set => base.ToolTipText = value;
             }

--- a/MarkMpn.Sql4Cds.XTB/Autocomplete.cs
+++ b/MarkMpn.Sql4Cds.XTB/Autocomplete.cs
@@ -313,7 +313,7 @@ namespace MarkMpn.Sql4Cds.XTB
                             var availableParameters = message.InputParameters
                                 .Concat(message.OutputParameters)
                                 .OrderBy(p => p.Name)
-                                .Select(p => new SprocParameterAutocompleteItem(message, p, currentLength));
+                                .Select(p => new SprocParameterAutocompleteItem(message, p, instance, currentLength));
 
                             return FilterList(availableParameters, currentWord);
                         }
@@ -876,7 +876,7 @@ namespace MarkMpn.Sql4Cds.XTB
                     list.AddRange(_dataSources.Values.Select(x => new InstanceAutocompleteItem(x, currentLength)));
 
                 if (_dataSources.TryGetValue(_primaryDataSource, out var ds) && ds.MessageCache != null)
-                    list.AddRange(ds.MessageCache.GetAllMessages().Where(x => x.IsValidAsStoredProcedure()).Select(x => new SprocAutocompleteItem(x, _columnOrdering, currentLength)));
+                    list.AddRange(ds.MessageCache.GetAllMessages().Where(x => x.IsValidAsStoredProcedure()).Select(x => new SprocAutocompleteItem(x, _columnOrdering, ds, currentLength)));
             }
             else if (TryParseTableName(currentWord, out var instanceName, out var schemaName, out var tableName, out var parts, out var lastPartLength))
             {
@@ -904,7 +904,7 @@ namespace MarkMpn.Sql4Cds.XTB
 
                 // Could be a sproc name
                 if (schemaName.Equals("dbo", StringComparison.OrdinalIgnoreCase) && instance?.MessageCache != null)
-                    list.AddRange(instance.MessageCache.GetAllMessages().Where(x => x.IsValidAsStoredProcedure()).Select(e => new SprocAutocompleteItem(e, _columnOrdering, lastPartLength)));
+                    list.AddRange(instance.MessageCache.GetAllMessages().Where(x => x.IsValidAsStoredProcedure()).Select(e => new SprocAutocompleteItem(e, _columnOrdering, instance, lastPartLength)));
             }
 
             list.Sort();
@@ -1582,11 +1582,13 @@ namespace MarkMpn.Sql4Cds.XTB
         {
             private readonly Message _message;
             private readonly ColumnOrdering _columnOrdering;
+            private readonly DataSource _dataSource;
 
-            public SprocAutocompleteItem(Message message, ColumnOrdering columnOrdering, int replaceLength) : base(message.Name, replaceLength, 26)
+            public SprocAutocompleteItem(Message message, ColumnOrdering columnOrdering, DataSource dataSource, int replaceLength) : base(message.Name, replaceLength, 26)
             {
                 _message = message;
                 _columnOrdering = columnOrdering;
+                _dataSource = dataSource;
             }
 
             public override string ToolTipTitle
@@ -1607,7 +1609,7 @@ namespace MarkMpn.Sql4Cds.XTB
                     else
                         parameters = parameters.OrderBy(p => p.Position);
 
-                    return _message.Name + " " + String.Join(", ", parameters.Select(p => (p.Optional ? "[" : "") + "@" + p.Name + " = " + p.GetSqlDataType(null).ToSql() + (p.Optional ? "]" : ""))) + (_message.OutputParameters.Count == 0 ? "" : ((_message.InputParameters.Count == 0 ? "" : ",") + " " + String.Join(", ", _message.OutputParameters.Select(p => "[@" + p.Name + " = " + p.GetSqlDataType(null).ToSql() + " OUTPUT]"))));
+                    return _message.Name + " " + String.Join(", ", parameters.Select(p => (p.Optional ? "[" : "") + "@" + p.Name + " = " + p.GetSqlDataType(_dataSource).ToSql() + (p.Optional ? "]" : ""))) + (_message.OutputParameters.Count == 0 ? "" : ((_message.InputParameters.Count == 0 ? "" : ",") + " " + String.Join(", ", _message.OutputParameters.Select(p => "[@" + p.Name + " = " + p.GetSqlDataType(_dataSource).ToSql() + " OUTPUT]"))));
                 }
                 set => base.ToolTipText = value;
             }
@@ -1617,22 +1619,24 @@ namespace MarkMpn.Sql4Cds.XTB
         {
             private readonly Message _message;
             private readonly MessageParameter _parameter;
+            private readonly DataSource _dataSource;
 
-            public SprocParameterAutocompleteItem(Message message, MessageParameter parameter, int replaceLength) : base("@" + parameter.Name, replaceLength, 26)
+            public SprocParameterAutocompleteItem(Message message, MessageParameter parameter, DataSource dataSource, int replaceLength) : base("@" + parameter.Name, replaceLength, 26)
             {
                 _message = message;
                 _parameter = parameter;
+                _dataSource = dataSource;
             }
 
             public override string ToolTipTitle
             {
-                get => _parameter.Name + (_message.OutputParameters.Contains(_parameter) ? " output" : " input") + " parameter (" + _parameter.GetSqlDataType(null).ToSql() + ")";
+                get => _parameter.Name + (_message.OutputParameters.Contains(_parameter) ? " output" : " input") + " parameter (" + _parameter.GetSqlDataType(_dataSource).ToSql() + ")";
                 set => base.ToolTipTitle = value;
             }
 
             public override string ToolTipText
             {
-                get => _message.Name + " " + String.Join(", ", _message.InputParameters.Select(p => (p.Optional ? "[" : "") + "@" + p.Name + " = " + p.GetSqlDataType(null).ToSql() + (p.Optional ? "]" : ""))) + (_message.OutputParameters.Count == 0 ? "" : ((_message.InputParameters.Count == 0 ? "" : ",") + " " + String.Join(", ", _message.OutputParameters.Select(p => "[@" + p.Name + " = " + p.GetSqlDataType(null).ToSql() + " OUTPUT]"))));
+                get => _message.Name + " " + String.Join(", ", _message.InputParameters.Select(p => (p.Optional ? "[" : "") + "@" + p.Name + " = " + p.GetSqlDataType(_dataSource).ToSql() + (p.Optional ? "]" : ""))) + (_message.OutputParameters.Count == 0 ? "" : ((_message.InputParameters.Count == 0 ? "" : ",") + " " + String.Join(", ", _message.OutputParameters.Select(p => "[@" + p.Name + " = " + p.GetSqlDataType(_dataSource).ToSql() + " OUTPUT]"))));
                 set => base.ToolTipText = value;
             }
         }

--- a/MarkMpn.Sql4Cds.XTB/ObjectExplorer.cs
+++ b/MarkMpn.Sql4Cds.XTB/ObjectExplorer.cs
@@ -737,7 +737,10 @@ INNER JOIN {manyToMany.Entity2LogicalName}
         private void functionContextMenuStrip_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
             var tvf = (Engine.Message)treeView.SelectedNode.Tag;
-            selectToToolStripMenuItem.Tag = (Func<string>)(() => GenerateSelectQuery(tvf));
+            var connection = GetService(treeView.SelectedNode);
+            var dataSource = _dataSources[connection.ConnectionName];
+            
+            selectToToolStripMenuItem.Tag = (Func<string>)(() => GenerateSelectQuery(tvf, dataSource));
 
             selectToToolStripMenuItem.Enabled = true;
             insertToToolStripMenuItem.Enabled = false;
@@ -749,7 +752,10 @@ INNER JOIN {manyToMany.Entity2LogicalName}
         private void procedureContextMenuStrip_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
             var sproc = (Engine.Message)treeView.SelectedNode.Tag;
-            executeToToolStripMenuItem.Tag = (Func<string>)(() => GenerateExecuteQuery(sproc));
+            var connection = GetService(treeView.SelectedNode);
+            var dataSource = _dataSources[connection.ConnectionName];
+
+            executeToToolStripMenuItem.Tag = (Func<string>)(() => GenerateExecuteQuery(sproc, dataSource));
 
             selectToToolStripMenuItem.Enabled = false;
             insertToToolStripMenuItem.Enabled = false;
@@ -758,7 +764,7 @@ INNER JOIN {manyToMany.Entity2LogicalName}
             executeToToolStripMenuItem.Enabled = true;
         }
 
-        private string GenerateSelectQuery(Engine.Message tvf)
+        private string GenerateSelectQuery(Engine.Message tvf, DataSource dataSource)
         {
             var querySpec = new QuerySpecification();
             querySpec.SelectElements.Add(new SelectScalarExpression { Expression = new ColumnReferenceExpression { ColumnType = ColumnType.Wildcard } });
@@ -789,7 +795,7 @@ INNER JOIN {manyToMany.Entity2LogicalName}
             {
                 tvfReference.Parameters.Add(new VariableReference
                 {
-                    Name = $"<@{param.Name}, {param.GetSqlDataType(null).ToSql()}>"
+                    Name = $"<@{param.Name}, {param.GetSqlDataType(dataSource).ToSql()}>"
                 });
             }
 
@@ -801,7 +807,7 @@ INNER JOIN {manyToMany.Entity2LogicalName}
             return querySpec.ToSql();
         }
 
-        private string GenerateExecuteQuery(Engine.Message sproc)
+        private string GenerateExecuteQuery(Engine.Message sproc, DataSource dataSource)
         {
             var batch = new TSqlBatch();
             var declare = new DeclareVariableStatement();
@@ -826,7 +832,7 @@ INNER JOIN {manyToMany.Entity2LogicalName}
                 declare.Declarations.Add(new DeclareVariableElement
                 {
                     VariableName = new Identifier { Value = $"@{param.Name}" },
-                    DataType = param.GetSqlDataType(null)
+                    DataType = param.GetSqlDataType(dataSource)
                 });
             }
 

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -23,10 +23,25 @@ plugins or integrations by writing familiar SQL and converting it.
 Queries can also run using the preview TDS Endpoint. A wide range of SQL functionality is also built
 in to allow running queries that aren't directly supported by either FetchXML or the TDS Endpoint.</description>
     <summary>Convert SQL queries to FetchXML and execute them against Dataverse / D365</summary>
-    <releaseNotes>Fixed Intellisense with trailing comments
-Include join alias in output column aliases when converting from Fetch XML to SQL
-Improved SQL to Fetch XML conversion of datetime filters
-Fixed use of case-insensitive table names in INSERT statements
+    <releaseNotes>Bulk DML improvements
+* Automatically adjust batch size to keep requests within timeout limits
+* Automatically adjust thread count to avoid hitting service protection limits
+* Provide better feedback when queries pause due to service protection limits
+* Automatically retry requests that have failed due to a transient error
+* Added DML support for `solutioncomponent` table
+
+Metadata improvements
+* Expose optionset values via `metadata.globaloptionsetvalue` and `metadata.optionsetvalue` tables
+* Reduced amount of metadata required to execute queries
+
+Bug fixes
+* Fixed "Must declare the scalar variable @Cond" error when using nested loop for single-record joins
+* Do not trust `RetrieveTotalRecordCount` for certain metadata-related entities that give incorrect results
+* Avoid errors when using cross-table column comparisons and nested link entities
+* Handle nested primary functions
+* Improved handling of comments and whitespace when reformatting queries
+* Fixed generating TVF and sproc scripts
+* Show confirmation dialog when closing unsaved scripts
     </releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>


### PR DESCRIPTION
Updated to .NET 8 for Azure Data Studio extension and MarkMpn.Sql4Cds.Engine library (library still dual-targets .NET Framework 4.6.2)
Autocomplete fixes for TVF and sprocs containing parameters with a fixed entityreference type
Fixed showing results in ADS with anonymous columns