### PR TITLE
V9.6 fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.FetchXml.Tests/Properties/AssemblyInfo.cs
+++ b/MarkMpn.Sql4Cds.Engine.FetchXml.Tests/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("MarkMpn.Sql4Cds.Engine.FetchXml.Tests")]
-[assembly: AssemblyCopyright("Copyright © 2020 - 2024 Mark Carrington")]
+[assembly: AssemblyCopyright("Copyright © 2020 - 2025 Mark Carrington")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/MarkMpn.Sql4Cds.Engine.Tests/Properties/AssemblyInfo.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("MarkMpn.Sql4Cds.Engine.Tests")]
-[assembly: AssemblyCopyright("Copyright © 2020 - 2024 Mark Carrington")]
+[assembly: AssemblyCopyright("Copyright © 2020 - 2025 Mark Carrington")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/MarkMpn.Sql4Cds.Engine.Tests/SqlDateTimeTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/SqlDateTimeTests.cs
@@ -101,6 +101,10 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
         [DataRow("1996 april 15", true)]
         [DataRow("1996 15 apr", true)]
         [DataRow("1996 15 april", true)]
+        [DataRow("15  apr  1996", true)]
+        [DataRow("15-APR-1996", true)]
+        [DataRow("15/ APR/  1996", true)]
+        [DataRow("15-APR/ 1996", true)]
         public void AlphaFormat(string input, bool includesDay)
         {
             Assert.IsTrue(SqlDateParsing.TryParse(input, DateFormat.mdy, out SqlDateTime actual));

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ConcatenateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ConcatenateNode.cs
@@ -247,7 +247,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 clone.Sources.Add(sourceClone);
             }
 
-            clone.ColumnSet.AddRange(ColumnSet);
+            foreach (var col in ColumnSet)
+            {
+                var colClone = new ConcatenateColumn();
+                colClone.OutputColumn = col.OutputColumn;
+                colClone.SourceColumns.AddRange(col.SourceColumns);
+                colClone.SourceExpressions.AddRange(col.SourceExpressions);
+                clone.ColumnSet.Add(colClone);
+            }
 
             return clone;
         }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ConcatenateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ConcatenateNode.cs
@@ -197,7 +197,43 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         protected override RowCountEstimate EstimateRowsOutInternal(NodeCompilationContext context)
         {
-            return new RowCountEstimate(Sources.Sum(s => s.EstimateRowsOut(context).Value));
+            var estimate = 0;
+            var minimum = 0;
+            var maximum = 0;
+            var exact = true;
+
+            foreach (var source in Sources)
+            {
+                var sourceEstimate = source.EstimateRowsOut(context);
+
+                estimate = AddUpToMaxValue(estimate, sourceEstimate.Value);
+
+                if (exact && sourceEstimate is RowCountEstimateDefiniteRange range)
+                {
+                    minimum = AddUpToMaxValue(minimum, range.Minimum);
+                    maximum = AddUpToMaxValue(maximum, range.Maximum);
+                }
+                else
+                {
+                    exact = false;
+                }
+            }
+
+            if (exact)
+                return new RowCountEstimateDefiniteRange(minimum, maximum);
+
+            return new RowCountEstimate(estimate);
+        }
+
+        private int AddUpToMaxValue(int x, int y)
+        {
+            // Avoid overflow error when adding large row count estimates
+            var maxAddition = Int32.MaxValue - x;
+
+            if (y > maxAddition)
+                return Int32.MaxValue;
+
+            return x + y;
         }
 
         public override object Clone()

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/EntityReader.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/EntityReader.cs
@@ -472,6 +472,13 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     errors.Add(Sql4CdsError.InvalidColumnName(col));
                     continue;
                 }
+                else if (operation == DmlOperationDetails.Insert && attr.IsPrimaryId == true)
+                {
+                    // When writing a primary key, treat is as a raw guid instead of an EntityReference
+                    colName = attr.LogicalName;
+                    targetType = DataTypeHelpers.UniqueIdentifier;
+                    targetClrType = typeof(Guid?);
+                }
                 else
                 {
                     colName = attr.LogicalName;
@@ -764,10 +771,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 var pidAccessor =  lookupMapping.Value.Pid?.Accessor;
 
                 // If we're creating an elastic lookup for a fixed type, we still need to know the type
-                if (pidAccessor != null && typeAccessor == null)
+                if (typeAccessor == null && attr is LookupAttributeMetadata lookupAttr)
                 {
-                    var lookupAttr = (LookupAttributeMetadata)attr;
-
                     if (lookupAttr.Targets.Length != 1)
                         throw new NotSupportedException();
 

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/EntityReader.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/EntityReader.cs
@@ -472,7 +472,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     errors.Add(Sql4CdsError.InvalidColumnName(col));
                     continue;
                 }
-                else if (operation == DmlOperationDetails.Insert && attr.IsPrimaryId == true)
+                else if ((operation == DmlOperationDetails.Insert && attr.IsPrimaryId == true) || isIntersect)
                 {
                     // When writing a primary key, treat is as a raw guid instead of an EntityReference
                     colName = attr.LogicalName;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -639,13 +639,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         public void RemoveSorts()
         {
             // Remove any existing sorts
-            if (Entity.Items != null)
-            {
-                Entity.Items = Entity.Items.Where(i => !(i is FetchOrderType)).ToArray();
-
-                foreach (var linkEntity in Entity.GetLinkEntities().Where(le => le.Items != null))
-                    linkEntity.Items = linkEntity.Items.Where(i => !(i is FetchOrderType)).ToArray();
-            }
+            Entity.RemoveSorts();
         }
 
         public void RemoveAttributes()

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -830,7 +830,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                             var partitionIdAttribute = items?.OfType<FetchAttributeType>().SingleOrDefault(a => a.name == "partitionid");
                             var alias = partitionIdAttribute?.alias ?? "partitionid";
                             var colName = parts[0] + "." + alias;
-                            var partitionId = entity.GetAttributeValue<string>(colName);
+                            var partitionId = GetString(entity, colName);
                             sqlValue = new SqlEntityReference(DataSource, dataSource.Metadata[logicalName], guid, partitionId);
                         }
                         else if (logicalName == "activitypointer")
@@ -840,7 +840,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                             var activityTypeCodeAttribute = items?.OfType<FetchAttributeType>().SingleOrDefault(a => a.name == "activitytypecode");
                             var alias = activityTypeCodeAttribute?.alias ?? "activitytypecode";
                             var colName = parts[0] + "." + alias;
-                            var activityTypeCode = entity.GetAttributeValue<string>(colName);
+                            var activityTypeCode = GetString(entity, colName);
                             sqlValue = new SqlEntityReference(DataSource, activityTypeCode ?? logicalName, guid);
                         }
                         else
@@ -882,6 +882,22 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 foreach (var pagingField in _pagingFields)
                     _lastPageValues.Add((INullable)entity[pagingField.Value]);
             }
+        }
+
+        private string GetString(Entity entity, string colName)
+        {
+            if (!entity.TryGetAttributeValue<object>(colName, out var value))
+                return null;
+
+            if (value is string str)
+                return str;
+
+            var sqlStr = (SqlString)value;
+
+            if (sqlStr.IsNull)
+                return null;
+
+            return sqlStr.Value;
         }
 
         private void PrefixAliasedScalarAttributes(Entity entity, object[] items, string alias)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -2402,6 +2402,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             var attributes = items.OfType<FetchAttributeType>().ToList();
 
+            // https://github.com/MarkMpn/Sql4Cds/issues/646
+            // If we've included audit.changedata then we need audit.objectid as well
+            if (entityName == "audit" && attributes.Any(a => a.name == "changedata") && !attributes.Any(a => a.name == "objectid"))
+            {
+                var objectId = new FetchAttributeType { name = "objectid" };
+                attributes.Add(objectId);
+                items = items.Concat(new object[] { objectId }).ToArray();
+            }
+
             // If we've included audit.objectid then we need audit.objecttypecode as well
             if (entityName == "audit" && attributes.Any(a => a.name == "objectid") && !attributes.Any(a => a.name == "objecttypecode"))
             {

--- a/MarkMpn.Sql4Cds.Engine/FetchXmlExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/FetchXmlExtensions.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using MarkMpn.Sql4Cds.Engine.FetchXml;
+using Microsoft.Xrm.Sdk;
 
 namespace MarkMpn.Sql4Cds.Engine
 {
@@ -177,6 +178,31 @@ namespace MarkMpn.Sql4Cds.Engine
                 .Concat(filter.Items
                     .OfType<filter>()
                     .SelectMany(f => f.GetConditions()));
+        }
+
+        public static void RemoveSorts(this FetchEntityType entity)
+        {
+            if (entity.Items != null)
+            {
+                entity.Items = entity.Items.Where(i => !(i is FetchOrderType)).ToArray();
+
+                foreach (var linkEntity in entity.GetLinkEntities())
+                    linkEntity.RemoveSorts();
+            }
+        }
+
+        public static void RemoveSorts(this FetchLinkEntityType linkEntity, bool recurse = false)
+        {
+            if (linkEntity.Items == null)
+                return;
+
+            linkEntity.Items = linkEntity.Items.Where(i => !(i is FetchOrderType)).ToArray();
+
+            if (recurse)
+            {
+                foreach (var child in GetLinkEntities(linkEntity.Items, false))
+                    linkEntity.RemoveSorts(true);
+            }
         }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.csproj
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>MarkMpn.Sql4Cds.Engine</AssemblyName>
     <RootNamespace>MarkMpn.Sql4Cds.Engine</RootNamespace>
-    <Copyright>Copyright © 2020 - 2024 Mark Carrington</Copyright>
+    <Copyright>Copyright © 2020 - 2025 Mark Carrington</Copyright>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/MarkMpn.Sql4Cds.Engine/MetadataExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/MetadataExtensions.cs
@@ -41,6 +41,12 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <returns>The metadata of the underlying attribute, or <see langword="null"/> if no virtual attribute is found</returns>
         public static AttributeMetadata FindBaseAttributeFromVirtualAttribute(this EntityMetadata entity, string virtualAttributeLogicalName, out string suffix)
         {
+            if (entity.Attributes.Any(a => a.LogicalName.Equals(virtualAttributeLogicalName, StringComparison.OrdinalIgnoreCase) && a.AttributeOf == null))
+            {
+                suffix = null;
+                return null;
+            }
+
             var matchingSuffix = VirtualLookupAttributeSuffixes.SingleOrDefault(s => virtualAttributeLogicalName.EndsWith(s, StringComparison.OrdinalIgnoreCase));
             suffix = matchingSuffix;
 

--- a/MarkMpn.Sql4Cds.Engine/Visitors/TDSEndpointCompatibilityVisitor.cs
+++ b/MarkMpn.Sql4Cds.Engine/Visitors/TDSEndpointCompatibilityVisitor.cs
@@ -526,5 +526,17 @@ namespace MarkMpn.Sql4Cds.Engine.Visitors
             // Cursors are not supported
             IsCompatible = false;
         }
+
+        public override void Visit(CreateTableStatement node)
+        {
+            // CREATE TABLE is not supported
+            IsCompatible = false;
+        }
+
+        public override void Visit(DropTableStatement node)
+        {
+            // DROP TABLE is not supported
+            IsCompatible = false;
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.XTB/PluginControl.cs
+++ b/MarkMpn.Sql4Cds.XTB/PluginControl.cs
@@ -919,6 +919,11 @@ in
                             }
                             break;
 
+                        case DialogResult.No:
+                            foreach (var doc in unsavedDocuments.OfType<DocumentWindowBase>())
+                                doc.Modified = false;
+                            break;
+
                         case DialogResult.Cancel:
                             return false;
                     }

--- a/MarkMpn.Sql4Cds.XTB/SettingsForm.Designer.cs
+++ b/MarkMpn.Sql4Cds.XTB/SettingsForm.Designer.cs
@@ -1003,7 +1003,7 @@
             this.rememberSessionConnectionsCheckBox.Name = "rememberSessionConnectionsCheckBox";
             this.rememberSessionConnectionsCheckBox.Size = new System.Drawing.Size(148, 17);
             this.rememberSessionConnectionsCheckBox.TabIndex = 3;
-            this.rememberSessionConnectionsCheckBox.Text = "Remember session details";
+            this.rememberSessionConnectionsCheckBox.Text = "Reopen sessions with the original connection";
             this.rememberSessionConnectionsCheckBox.UseVisualStyleBackColor = true;
             // 
             // SettingsForm

--- a/MarkMpn.Sql4Cds.XTB/SqlQueryControl.cs
+++ b/MarkMpn.Sql4Cds.XTB/SqlQueryControl.cs
@@ -2168,7 +2168,7 @@ namespace MarkMpn.Sql4Cds.XTB
                 // We don't already have this connection - connect to it and add it to the object explorer
                 var savedConnection = ConnectionManager.Instance.ConnectionsList.Connections.SingleOrDefault(c => c.ConnectionId == tab.Connection);
 
-                if (savedConnection != null)
+                if (savedConnection != null && !savedConnection.IsFromSdkLoginCtrl)
                 {
                     var connectionParameterInfoType = System.Type.GetType("XrmToolBox.ConnectionParameterInfo, XrmToolBox");
                     var connectionParameterInfo = Activator.CreateInstance(connectionParameterInfoType);


### PR DESCRIPTION
- Fixed retrieving `audit.changedata` even when `audit.objectid` is not selected - fixes #644, #646
- Fixed inserting a primary key value from an existing lookup value - fixes #643 
- Fixed showing the "Confirm Close" dialog individually for each tab after already selecting "No" on the same dialog for bulk closing tabs
- Fixed label on checkbox to restore sessions with the original connection
- Do not attempt to restore connections using SDK login control - fixes #647 
- Fixed arithmetic overflow error when concatenating large data sets
- Check links to be added for `IN`/`EXISTS` predicates are valid before adding them to the query - fixes #649 
- Added support for more alphanumeric datetime formats - fixes #657
- Do not use TDS Endpoint for temporary tables - fixes #663
- Fixed DML operations on listmember - fixes #655
- Handle real attributes that have a "type" suffix from another attribute - fixes #661
- Fixed retrieving activity and elastic table primary keys - fixes #662
- Fixed cloning Concatenate nodes - fixes #665