### PR TITLE
V9.6 fixes

### DIFF
--- a/AzureDataStudioExtension/CHANGELOG.md
+++ b/AzureDataStudioExtension/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## [v9.6.1](https://github.com/MarkMpn/Sql4Cds/releases/tag/v9.6.1) - 2025-04-30
+
+Bug fixes
+* Fixed retrieving `audit.changedata` even when `audit.objectid`
+* Fixed inserting a primary key value from an existing lookup value
+* Fixed arithmetic overflow error when concatenating large data sets
+* Check links to be added for `IN`/`EXISTS` predicates are valid before adding them to the query
+* Added support for more alphanumeric datetime formats
+* Do not use TDS Endpoint for temporary tables
+* Fixed DML operations on `listmember`
+* Handle real attributes that have a `type` suffix from another attribute
+* Fixed retrieving activity and elastic table primary keys
+* Fixed cloning Concatenate nodes
+
+* Fixed showing the "Confirm Close" dialog individually for each tab after already selecting "No" on the same dialog for bulk closing tabs
+* Fixed label on checkbox to restore sessions with the original connection
+* Do not attempt to restore connections using SDK login control
+
 ## [v9.6.0](https://github.com/MarkMpn/Sql4Cds/releases/tag/v9.6.0) - 2025-02-22
 
 New SQL support

--- a/AzureDataStudioExtension/CHANGELOG.md
+++ b/AzureDataStudioExtension/CHANGELOG.md
@@ -13,10 +13,8 @@ Bug fixes
 * Handle real attributes that have a `type` suffix from another attribute
 * Fixed retrieving activity and elastic table primary keys
 * Fixed cloning Concatenate nodes
-
-* Fixed showing the "Confirm Close" dialog individually for each tab after already selecting "No" on the same dialog for bulk closing tabs
-* Fixed label on checkbox to restore sessions with the original connection
-* Do not attempt to restore connections using SDK login control
+* Do not fold `TOP` clause to FetchXML for virtual tables
+* Improved null handling when converting "not" conditions from FetchXML to SQL
 
 ## [v9.6.0](https://github.com/MarkMpn/Sql4Cds/releases/tag/v9.6.0) - 2025-02-22
 

--- a/MarkMpn.Sql4Cds.Engine.FetchXml.Tests/FetchXml2SqlTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.FetchXml.Tests/FetchXml2SqlTests.cs
@@ -51,6 +51,26 @@ namespace MarkMpn.Sql4Cds.Engine.FetchXml.Tests
         }
 
         [TestMethod]
+        public void NeAllowsNull()
+        {
+            var metadata = new AttributeMetadataCache(_service);
+            var fetch = @"
+                <fetch>
+                    <entity name='contact'>
+                        <attribute name='firstname' />
+                        <attribute name='lastname' />
+                        <filter>
+                            <condition attribute='firstname' operator='ne' value='Mark' />
+                        </filter>
+                    </entity>
+                </fetch>";
+
+            var converted = FetchXml2Sql.Convert(_service, metadata, fetch, new FetchXml2SqlOptions(), out _);
+
+            Assert.AreEqual("SELECT firstname, lastname FROM contact WHERE (firstname <> 'Mark' OR firstname IS NULL)", NormalizeWhitespace(converted));
+        }
+
+        [TestMethod]
         public void Joins()
         {
             var metadata = new AttributeMetadataCache(_service);

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -23,6 +23,8 @@ Bug fixes
 * Handle real attributes that have a `type` suffix from another attribute
 * Fixed retrieving activity and elastic table primary keys
 * Fixed cloning Concatenate nodes
+* Do not fold `TOP` clause to FetchXML for virtual tables
+* Improved null handling when converting "not" conditions from FetchXML to SQL
     </releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -11,15 +11,18 @@
     <iconUrl>https://markcarrington.dev/sql4cds-icon/</iconUrl>
     <description>Convert SQL queries to FetchXml and execute them against Dataverse / D365</description>
     <summary>Convert SQL queries to FetchXml and execute them against Dataverse / D365</summary>
-    <releaseNotes>New SQL support
-* Window functions
-* Temporary tables
-* Cursors
-
+    <releaseNotes>
 Bug fixes
-* Fixed "An item with the same key has already been added" error when using multiple nested loops
-* Fixed "Index was out of range" error when using `INTERSECT` or `EXCEPT`
-* Fixed "The specified key does not exist in the dictionary" error when using XML query functions in an `OUTER APPLY`
+* Fixed retrieving `audit.changedata` even when `audit.objectid`
+* Fixed inserting a primary key value from an existing lookup value
+* Fixed arithmetic overflow error when concatenating large data sets
+* Check links to be added for `IN`/`EXISTS` predicates are valid before adding them to the query
+* Added support for more alphanumeric datetime formats
+* Do not use TDS Endpoint for temporary tables
+* Fixed DML operations on `listmember`
+* Handle real attributes that have a `type` suffix from another attribute
+* Fixed retrieving activity and elastic table primary keys
+* Fixed cloning Concatenate nodes
     </releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -23,19 +23,23 @@ plugins or integrations by writing familiar SQL and converting it.
 Queries can also run using the preview TDS Endpoint. A wide range of SQL functionality is also built
 in to allow running queries that aren't directly supported by either FetchXML or the TDS Endpoint.</description>
     <summary>Convert SQL queries to FetchXML and execute them against Dataverse / D365</summary>
-    <releaseNotes>New SQL support
-* Window functions
-* Temporary tables
-* Cursors
-
-User experience
-* Saved queries are reopened with the original connection
-* Environment color highlighting is applied to query tab and object explorer icons
-
+    <releaseNotes>
 Bug fixes
-* Fixed "An item with the same key has already been added" error when using multiple nested loops
-* Fixed "Index was out of range" error when using `INTERSECT` or `EXCEPT`
-* Fixed "The specified key does not exist in the dictionary" error when using XML query functions in an `OUTER APPLY`
+* Fixed retrieving `audit.changedata` even when `audit.objectid`
+* Fixed inserting a primary key value from an existing lookup value
+* Fixed arithmetic overflow error when concatenating large data sets
+* Check links to be added for `IN`/`EXISTS` predicates are valid before adding them to the query
+* Added support for more alphanumeric datetime formats
+* Do not use TDS Endpoint for temporary tables
+* Fixed DML operations on `listmember`
+* Handle real attributes that have a `type` suffix from another attribute
+* Fixed retrieving activity and elastic table primary keys
+* Fixed cloning Concatenate nodes
+
+User Experience
+* Fixed showing the "Confirm Close" dialog individually for each tab after already selecting "No" on the same dialog for bulk closing tabs
+* Fixed label on checkbox to restore sessions with the original connection
+* Do not attempt to restore connections using SDK login control
     </releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -35,6 +35,8 @@ Bug fixes
 * Handle real attributes that have a `type` suffix from another attribute
 * Fixed retrieving activity and elastic table primary keys
 * Fixed cloning Concatenate nodes
+* Do not fold `TOP` clause to FetchXML for virtual tables
+* Improved null handling when converting "not" conditions from FetchXML to SQL
 
 User Experience
 * Fixed showing the "Confirm Close" dialog individually for each tab after already selecting "No" on the same dialog for bulk closing tabs


### PR DESCRIPTION
Do not fold `TOP` clause to FetchXML for virtual tables - possible fix for #656?
Improved null handling when converting "not" comparisons from FetchXML to SQL