### PR TITLE
Fix possible crash in MiniChartEditor when painting empty arrays

### DIFF
--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanNodeTypeDescriptor.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanNodeTypeDescriptor.cs
@@ -443,6 +443,10 @@ namespace MarkMpn.Sql4Cds.Engine
         public override void PaintValue(PaintValueEventArgs e)
         {
             var values = (float[])((ExecutionPlanNodeTypeDescriptor)e.Value).GetPropertyOwner(null);
+
+            if (values.Length == 0)
+            return;
+            
             var brush = Brushes.DarkBlue;
             var barWidth = (float)e.Bounds.Width / values.Length;
             var maxValue = values.Max();


### PR DESCRIPTION
Fixes DivideByZeroException and InvalidOperationException in MiniChartEditor.PaintValue() when values array is empty
Add early return for empty arrays before division and Max() operations