### PR TITLE
Add ABS function

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
@@ -3171,5 +3171,29 @@ SELECT ABS(@f), ABS(@r), ABS(@d), ABS(@i), ABS(@si), ABS(@ti), ABS(@bi), ABS(@m)
                 }
             }
         }
+
+        [TestMethod]
+        public void AbsOverflow()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSources))
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandTimeout = 0;
+                cmd.CommandText = @"
+DECLARE @i INT;  
+SET @i = -2147483648;  
+SELECT ABS(@i);";
+
+                try
+                {
+                    cmd.ExecuteNonQuery();
+                    Assert.Fail();
+                }
+                catch (Sql4CdsException ex)
+                {
+                    Assert.AreEqual(8115, ex.Number);
+                }
+            }
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
@@ -3130,5 +3130,46 @@ FROM (SELECT name, '' FROM account) AS a";
                 }
             }
         }
+
+        [TestMethod]
+        public void OverloadedFunctionResolution()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSources))
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandTimeout = 0;
+                cmd.CommandText = @"
+DECLARE @f float = -1
+DECLARE @r real = -1
+DECLARE @d decimal(10, 2) = -1.23
+DECLARE @i int = -1
+DECLARE @si smallint = -1
+DECLARE @ti tinyint = 1
+DECLARE @bi bigint = -1
+DECLARE @m money = -1
+DECLARE @sm smallmoney = -1
+DECLARE @b bit = 1
+
+SELECT ABS(@f), ABS(@r), ABS(@d), ABS(@i), ABS(@si), ABS(@ti), ABS(@bi), ABS(@m), ABS(@sm), ABS(@b)";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    Assert.AreEqual("float", reader.GetDataTypeName(0));
+                    Assert.AreEqual("float", reader.GetDataTypeName(1));
+                    Assert.AreEqual("decimal", reader.GetDataTypeName(2));
+                    Assert.AreEqual("int", reader.GetDataTypeName(3));
+                    Assert.AreEqual("int", reader.GetDataTypeName(4));
+                    Assert.AreEqual("int", reader.GetDataTypeName(5));
+                    Assert.AreEqual("bigint", reader.GetDataTypeName(6));
+                    Assert.AreEqual("money", reader.GetDataTypeName(7));
+                    Assert.AreEqual("money", reader.GetDataTypeName(8));
+                    Assert.AreEqual("float", reader.GetDataTypeName(9));
+
+                    var schema = reader.GetSchemaTable();
+                    Assert.AreEqual((short)38, schema.Rows[2]["NumericPrecision"]);
+                    Assert.AreEqual((short)2, schema.Rows[2]["NumericScale"]);
+                }
+            }
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExpressionFunctionTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExpressionFunctionTests.cs
@@ -358,5 +358,57 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             var actual = ExpressionFunctions.DateDiff("hour", new SqlDateTime(dateTime), new SqlDateTimeOffset(offset), DataTypeHelpers.DateTime, DataTypeHelpers.DateTimeOffset(7));
             Assert.AreEqual(-1, actual);
         }
+
+        [DataTestMethod]
+        [DataRow(5, 5)]
+        [DataRow(-5, 5)]
+        [DataRow(0, 0)]
+        [DataRow(int.MinValue + 1, int.MaxValue)]
+        public void Abs_Int(int input, int expected)
+        {
+            var actual = ExpressionFunctions.Abs((SqlInt32)input);
+            Assert.AreEqual(expected, (int)actual);
+        }
+
+        [TestMethod]
+        public void Abs_Int_Null()
+        {
+            var actual = ExpressionFunctions.Abs(SqlInt32.Null);
+            Assert.IsTrue(actual.IsNull);
+        }
+
+        [DataTestMethod]
+        [DataRow(5L, 5L)]
+        [DataRow(-5L, 5L)]
+        [DataRow(0L, 0L)]
+        public void Abs_BigInt(long input, long expected)
+        {
+            var actual = ExpressionFunctions.Abs((SqlInt64)input);
+            Assert.AreEqual(expected, (long)actual);
+        }
+
+        [TestMethod]
+        public void Abs_BigInt_Null()
+        {
+            var actual = ExpressionFunctions.Abs(SqlInt64.Null);
+            Assert.IsTrue(actual.IsNull);
+        }
+
+        [DataTestMethod]
+        [DataRow(5.5, 5.5)]
+        [DataRow(-5.5, 5.5)]
+        [DataRow(0.0, 0.0)]
+        public void Abs_Float(double input, double expected)
+        {
+            var actual = ExpressionFunctions.Abs((SqlDouble)input);
+            Assert.AreEqual(expected, (double)actual, 1e-10);
+        }
+
+        [TestMethod]
+        public void Abs_Float_Null()
+        {
+            var actual = ExpressionFunctions.Abs(SqlDouble.Null);
+            Assert.IsTrue(actual.IsNull);
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsError.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsError.cs
@@ -145,6 +145,11 @@ namespace MarkMpn.Sql4Cds.Engine
             return Create(8115, fragment, GetTypeName(sourceType), GetTypeName(targetType));
         }
 
+        internal static Sql4CdsError ArithmeticOverflow(string source, DataTypeReference targetType, TSqlFragment fragment)
+        {
+            return Create(8115, fragment, source, GetTypeName(targetType));
+        }
+
         internal static Sql4CdsError ArithmeticOverflow(DataTypeReference targetType, SqlInt32 value)
         {
             return Create(220, targetType, Collation.USEnglish.ToSqlString(GetTypeName(targetType)), value);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -1190,21 +1190,49 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (correctParameterCount.Count == 0)
                 throw new NotSupportedQueryFragmentException(Sql4CdsError.InvalidFunctionParameterCount(func.FunctionName, methods[0].GetParameters().Length));
 
-            if (correctParameterCount.Count > 1)
-                throw new NotSupportedQueryFragmentException("Ambiguous method", func);
+            var overloadCheckRequired = correctParameterCount.Count > 1;
 
-            var method = correctParameterCount[0].Method;
-            var parameters = correctParameterCount[0].Parameters;
+            foreach (var candidate in correctParameterCount)
+            {
+                var method = candidate.Method;
+                var parameters = candidate.Parameters;
+                BindParameters(context, targetType, primaryDataSource, func, paramTypes, paramCacheKeys, contextParam, createExpression || overloadCheckRequired, ref paramExpressions, out sqlType, out cacheKey, ref method, ref parameters);
+
+                if (overloadCheckRequired)
+                {
+                    var requiresConversion = false;
+
+                    for (var i = 0; i < parameters.Length; i++)
+                    {
+                        if (parameters[i].ParameterType != paramExpressions[i].Type)
+                        {
+                            requiresConversion = true;
+                            break;
+                    }
+                    }
+
+                    if (requiresConversion)
+                        continue;
+                }
+
+                return method;
+            }
+
+                throw new NotSupportedQueryFragmentException("Ambiguous method", func);
+        }
+
+        private static void BindParameters(ExpressionCompilationContext context, Type targetType, DataSource primaryDataSource, FunctionCall func, DataTypeReference[] paramTypes, string[] paramCacheKeys, ParameterExpression contextParam, bool createExpression, ref Expression[] paramExpressions, out DataTypeReference sqlType, out string cacheKey, ref MethodInfo method, ref ParameterInfo[] parameters)
+        {
             var parameterTypes = new Dictionary<string, DataTypeReference>();
             cacheKey = method.Name;
 
-            if (correctParameterCount[0].Method.IsGenericMethodDefinition)
+            if (method.IsGenericMethodDefinition)
             {
                 // Create the generic method based on the type of the generic arguments
-                var genericArguments = correctParameterCount[0].Method.GetGenericArguments();
+                var genericArguments = method.GetGenericArguments();
                 var genericArgumentValues = new Type[genericArguments.Length];
 
-                foreach (var param in correctParameterCount[0].Parameters)
+                foreach (var param in parameters)
                 {
                     for (var i = 0; i < genericArguments.Length; i++)
                     {
@@ -1329,7 +1357,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         if (!DataTypeHelpers.TryParse(context, typeLiteral.Value, out var parsedType))
                             throw new NotSupportedQueryFragmentException(Sql4CdsError.InvalidDataTypeForXmlValueMethod(typeLiteral));
 
-                        cacheKey +=$"(TYPE:{parsedType.ToSql()})";
+                        cacheKey += $"(TYPE:{parsedType.ToSql()})";
 
                         if (createExpression)
                             paramExpressions[i] = Expression.Constant(parsedType);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -1208,7 +1208,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         {
                             requiresConversion = true;
                             break;
-                    }
+                        }
                     }
 
                     if (requiresConversion)
@@ -1218,7 +1218,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 return method;
             }
 
-                throw new NotSupportedQueryFragmentException("Ambiguous method", func);
+            throw new NotSupportedQueryFragmentException("Ambiguous method", func);
         }
 
         private static void BindParameters(ExpressionCompilationContext context, Type targetType, DataSource primaryDataSource, FunctionCall func, DataTypeReference[] paramTypes, string[] paramCacheKeys, ParameterExpression contextParam, bool createExpression, ref Expression[] paramExpressions, out DataTypeReference sqlType, out string cacheKey, ref MethodInfo method, ref ParameterInfo[] parameters)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -1424,6 +1424,30 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (sqlType == null)
                 sqlType = method.ReturnType.ToSqlType(primaryDataSource);
 
+            if (sqlType is SqlDataTypeReference sqlSqlType && sqlSqlType.SqlDataTypeOption == SqlDataTypeOption.Decimal)
+            {
+                var p = sqlSqlType.GetPrecision();
+                var s = sqlSqlType.GetScale();
+
+                // Use the [DecimalPrecision(value)] attribute from the method where available
+                var methodDecimalPrecision = method.GetCustomAttribute<DecimalPrecisionAttribute>();
+
+                if (methodDecimalPrecision != null)
+                    p = methodDecimalPrecision.Precision;
+
+                // Use the [SourceScale] attribute from the parameters where available to calculate the scale for the output
+                var sourceScaleParam = parameters
+                    .Select((param, index) => new { Parameter = param, Index = index })
+                    .Where(param => param.Parameter.GetCustomAttribute<SourceScaleAttribute>() != null)
+                    .Select(param => paramTypes[param.Index])
+                    .FirstOrDefault();
+
+                if (sourceScaleParam != null)
+                    s = sourceScaleParam.GetScale();
+
+                sqlType = DataTypeHelpers.Decimal(p, s);
+            }
+
             if (method.GetCustomAttribute(typeof(CollationSensitiveAttribute)) != null)
             {
                 // If method is collation sensitive:

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -1522,8 +1522,6 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     outputCollation.CollationLabel = collation.CollationLabel;
                 }
             }
-
-            return method;
         }
 
         private static Expression ToExpression(this FunctionCall func, ExpressionCompilationContext context, ParameterExpression contextParam, ParameterExpression exprParam, bool createExpression, out DataTypeReference sqlType, out string cacheKey)

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1852,7 +1852,14 @@ namespace MarkMpn.Sql4Cds.Engine
             if (expression.IsNull)
                 return SqlInt32.Null;
 
-            return System.Math.Abs(expression.Value);
+            try
+            {
+                return System.Math.Abs(expression.Value);
+            }
+            catch (OverflowException)
+            {
+                throw new QueryExecutionException(Sql4CdsError.ArithmeticOverflow("expression", DataTypeHelpers.Int, null));
+            }
         }
 
         /// <summary>
@@ -1866,7 +1873,14 @@ namespace MarkMpn.Sql4Cds.Engine
             if (expression.IsNull)
                 return SqlInt32.Null;
 
-            return System.Math.Abs(expression.Value);
+            try
+            {
+                return System.Math.Abs((int)expression.Value);
+            }
+            catch (OverflowException)
+            {
+                throw new QueryExecutionException(Sql4CdsError.ArithmeticOverflow("expression", DataTypeHelpers.Int, null));
+            }
         }
 
         /// <summary>
@@ -1880,7 +1894,14 @@ namespace MarkMpn.Sql4Cds.Engine
             if (expression.IsNull)
                 return SqlInt32.Null;
 
-            return System.Math.Abs(expression.Value);
+            try
+            {
+                return System.Math.Abs((int)expression.Value);
+            }
+            catch (OverflowException)
+            {
+                throw new QueryExecutionException(Sql4CdsError.ArithmeticOverflow("expression", DataTypeHelpers.Int, null));
+            }
         }
 
         /// <summary>
@@ -1894,7 +1915,14 @@ namespace MarkMpn.Sql4Cds.Engine
             if (expression.IsNull)
                 return SqlInt64.Null;
 
-            return System.Math.Abs(expression.Value);
+            try
+            {
+                return System.Math.Abs(expression.Value);
+            }
+            catch (OverflowException)
+            {
+                throw new QueryExecutionException(Sql4CdsError.ArithmeticOverflow("expression", DataTypeHelpers.BigInt, null));
+            }
         }
 
         /// <summary>

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1875,12 +1875,13 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <param name="expression">A numeric expression</param>
         /// <returns></returns>
         [SqlFunction(IsDeterministic = true)]
-        public static SqlDecimal Abs(SqlDecimal expression)
+        [DecimalPrecision(38)]
+        public static SqlDecimal Abs([SourceScale] SqlDecimal expression)
         {
             if (expression.IsNull)
                 return SqlDecimal.Null;
 
-            return SqlDecimal.Abs(expression);
+            return SqlDecimal.ConvertToPrecScale(SqlDecimal.Abs(expression), 38, expression.Scale);
         }
 
         /// <summary>
@@ -2235,6 +2236,31 @@ namespace MarkMpn.Sql4Cds.Engine
     [AttributeUsage(AttributeTargets.Method)]
     class CollationSensitiveAttribute : Attribute
     {
+    }
+
+    /// <summary>
+    /// Indicates that a function returns a decimal value with a fixed precision
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    class DecimalPrecisionAttribute : Attribute
+    {
+        public DecimalPrecisionAttribute(short precision)
+        {
+            Precision = precision;
+        }
+
+        public short Precision { get; }
+    }
+
+    /// <summary>
+    /// Indicates that the parameter gives the scale of a decimal return value
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    class SourceScaleAttribute : Attribute
+    {
+        public SourceScaleAttribute()
+        {
+    }
     }
 
     /// <summary>

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1953,6 +1953,20 @@ namespace MarkMpn.Sql4Cds.Engine
 
             return System.Math.Abs(expression.Value);
         }
+
+        /// <summary>
+        /// Returns the absolute (positive) value of the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlDouble Abs(SqlBoolean expression)
+        {
+            if (expression.IsNull)
+                return SqlDouble.Null;
+
+            return expression.Value ? 1 : 0;
+        }
     }
 
     /// <summary>

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1861,6 +1861,34 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <param name="expression">A numeric expression</param>
         /// <returns></returns>
         [SqlFunction(IsDeterministic = true)]
+        public static SqlInt32 Abs(SqlInt16 expression)
+        {
+            if (expression.IsNull)
+                return SqlInt32.Null;
+
+            return System.Math.Abs(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the absolute (positive) value of the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt32 Abs(SqlByte expression)
+        {
+            if (expression.IsNull)
+                return SqlInt32.Null;
+
+            return System.Math.Abs(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the absolute (positive) value of the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
         public static SqlInt64 Abs(SqlInt64 expression)
         {
             if (expression.IsNull)
@@ -1918,10 +1946,10 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <param name="expression">A numeric expression</param>
         /// <returns></returns>
         [SqlFunction(IsDeterministic = true)]
-        public static SqlSingle Abs(SqlSingle expression)
+        public static SqlDouble Abs(SqlSingle expression)
         {
             if (expression.IsNull)
-                return SqlSingle.Null;
+                return SqlDouble.Null;
 
             return System.Math.Abs(expression.Value);
         }
@@ -2260,7 +2288,7 @@ namespace MarkMpn.Sql4Cds.Engine
     {
         public SourceScaleAttribute()
         {
-    }
+        }
     }
 
     /// <summary>

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1840,6 +1840,90 @@ namespace MarkMpn.Sql4Cds.Engine
         {
             return Guid.NewGuid();
         }
+
+        /// <summary>
+        /// Returns the absolute (positive) value of the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt32 Abs(SqlInt32 expression)
+        {
+            if (expression.IsNull)
+                return SqlInt32.Null;
+
+            return System.Math.Abs(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the absolute (positive) value of the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt64 Abs(SqlInt64 expression)
+        {
+            if (expression.IsNull)
+                return SqlInt64.Null;
+
+            return System.Math.Abs(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the absolute (positive) value of the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlDecimal Abs(SqlDecimal expression)
+        {
+            if (expression.IsNull)
+                return SqlDecimal.Null;
+
+            return SqlDecimal.Abs(expression);
+        }
+
+        /// <summary>
+        /// Returns the absolute (positive) value of the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlDouble Abs(SqlDouble expression)
+        {
+            if (expression.IsNull)
+                return SqlDouble.Null;
+
+            return System.Math.Abs(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the absolute (positive) value of the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlMoney Abs(SqlMoney expression)
+        {
+            if (expression.IsNull)
+                return SqlMoney.Null;
+
+            return new SqlMoney(System.Math.Abs(expression.Value));
+        }
+
+        /// <summary>
+        /// Returns the absolute (positive) value of the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlSingle Abs(SqlSingle expression)
+        {
+            if (expression.IsNull)
+                return SqlSingle.Null;
+
+            return System.Math.Abs(expression.Value);
+        }
     }
 
     /// <summary>

--- a/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/FunctionMetadata.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/FunctionMetadata.cs
@@ -211,6 +211,9 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
 
             [Description("Creates a unique value of type uniqueidentifier")]
             public abstract Guid newid();
+
+            [Description("Returns the absolute (positive) value of the specified numeric expression")]
+            public abstract double abs(double expression);
         }
     }
 }


### PR DESCRIPTION
Adds the `ABS` function which returns the absolute (positive) value of a numeric expression.

## Changes

- `ExpressionFunctions.cs` — six overloads covering all supported numeric types: `int`, `bigint`, `decimal`, `float`, `money`, `real`
- `FunctionMetadata.cs` — autocomplete/IntelliSense entry
- `ExpressionFunctionTests.cs` — unit tests for `int`, `bigint`, and `float` overloads covering positive, negative, zero, and null inputs

## Usage

```sql
SELECT ABS(-42)         -- 42
SELECT ABS(-3.14)       -- 3.14
SELECT ABS(amount)      -- works on any numeric column
```