### PR TITLE
Add SIGN function

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/ExpressionFunctionTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExpressionFunctionTests.cs
@@ -410,5 +410,77 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             var actual = ExpressionFunctions.Abs(SqlDouble.Null);
             Assert.IsTrue(actual.IsNull);
         }
+
+        [DataTestMethod]
+        [DataRow(5, 1)]
+        [DataRow(-5, -1)]
+        [DataRow(0, 0)]
+        [DataRow(int.MaxValue, 1)]
+        [DataRow(int.MinValue, -1)]
+        public void Sign_Int(int input, int expected)
+        {
+            var actual = ExpressionFunctions.Sign((SqlInt32)input);
+            Assert.AreEqual(expected, (int)actual);
+        }
+
+        [TestMethod]
+        public void Sign_Int_Null()
+        {
+            var actual = ExpressionFunctions.Sign(SqlInt32.Null);
+            Assert.IsTrue(actual.IsNull);
+        }
+
+        [DataTestMethod]
+        [DataRow(5L, 1L)]
+        [DataRow(-5L, -1L)]
+        [DataRow(0L, 0L)]
+        public void Sign_BigInt(long input, long expected)
+        {
+            var actual = ExpressionFunctions.Sign((SqlInt64)input);
+            Assert.AreEqual(expected, (long)actual);
+        }
+
+        [TestMethod]
+        public void Sign_BigInt_Null()
+        {
+            var actual = ExpressionFunctions.Sign(SqlInt64.Null);
+            Assert.IsTrue(actual.IsNull);
+        }
+
+        [DataTestMethod]
+        [DataRow(3.14, 1.0)]
+        [DataRow(-3.14, -1.0)]
+        [DataRow(0.0, 0.0)]
+        public void Sign_Float(double input, double expected)
+        {
+            var actual = ExpressionFunctions.Sign((SqlDouble)input);
+            Assert.AreEqual(expected, (double)actual, 1e-10);
+        }
+
+        [TestMethod]
+        public void Sign_Float_Null()
+        {
+            var actual = ExpressionFunctions.Sign(SqlDouble.Null);
+            Assert.IsTrue(actual.IsNull);
+        }
+
+        [DataTestMethod]
+        [DataRow((short)5, 1)]
+        [DataRow((short)-5, -1)]
+        [DataRow((short)0, 0)]
+        public void Sign_SmallInt(short input, int expected)
+        {
+            var actual = ExpressionFunctions.Sign((SqlInt16)input);
+            Assert.AreEqual(expected, (int)actual);
+        }
+
+        [DataTestMethod]
+        [DataRow((byte)5, 1)]
+        [DataRow((byte)0, 0)]
+        public void Sign_TinyInt(byte input, int expected)
+        {
+            var actual = ExpressionFunctions.Sign((SqlByte)input);
+            Assert.AreEqual(expected, (int)actual);
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1995,6 +1995,119 @@ namespace MarkMpn.Sql4Cds.Engine
 
             return expression.Value ? 1 : 0;
         }
+
+        /// <summary>
+        /// Returns the positive (+1), zero (0), or negative (-1) sign of the specified expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt32 Sign(SqlInt32 expression)
+        {
+            if (expression.IsNull)
+                return SqlInt32.Null;
+
+            return System.Math.Sign(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the positive (+1), zero (0), or negative (-1) sign of the specified expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt32 Sign(SqlInt16 expression)
+        {
+            if (expression.IsNull)
+                return SqlInt32.Null;
+
+            return System.Math.Sign(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the positive (+1), zero (0), or negative (-1) sign of the specified expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt32 Sign(SqlByte expression)
+        {
+            if (expression.IsNull)
+                return SqlInt32.Null;
+
+            return expression.Value == 0 ? 0 : 1;
+        }
+
+        /// <summary>
+        /// Returns the positive (+1), zero (0), or negative (-1) sign of the specified expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt64 Sign(SqlInt64 expression)
+        {
+            if (expression.IsNull)
+                return SqlInt64.Null;
+
+            return (long)System.Math.Sign(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the positive (+1), zero (0), or negative (-1) sign of the specified expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        [DecimalPrecision(38)]
+        public static SqlDecimal Sign([SourceScale] SqlDecimal expression)
+        {
+            if (expression.IsNull)
+                return SqlDecimal.Null;
+
+            return SqlDecimal.ConvertToPrecScale(new SqlDecimal(System.Math.Sign(expression.Value)), 38, expression.Scale);
+        }
+
+        /// <summary>
+        /// Returns the positive (+1), zero (0), or negative (-1) sign of the specified expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlDouble Sign(SqlDouble expression)
+        {
+            if (expression.IsNull)
+                return SqlDouble.Null;
+
+            return (double)System.Math.Sign(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the positive (+1), zero (0), or negative (-1) sign of the specified expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlMoney Sign(SqlMoney expression)
+        {
+            if (expression.IsNull)
+                return SqlMoney.Null;
+
+            return new SqlMoney(System.Math.Sign(expression.Value));
+        }
+
+        /// <summary>
+        /// Returns the positive (+1), zero (0), or negative (-1) sign of the specified expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlDouble Sign(SqlSingle expression)
+        {
+            if (expression.IsNull)
+                return SqlDouble.Null;
+
+            return (double)System.Math.Sign(expression.Value);
+        }
     }
 
     /// <summary>

--- a/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/FunctionMetadata.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/FunctionMetadata.cs
@@ -214,6 +214,9 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
 
             [Description("Returns the absolute (positive) value of the specified numeric expression")]
             public abstract double abs(double expression);
+
+            [Description("Returns the positive (+1), zero (0), or negative (-1) sign of the specified numeric expression")]
+            public abstract double sign(double expression);
         }
     }
 }


### PR DESCRIPTION
Adds the `SIGN` function which returns the positive (+1), zero (0), or negative (-1) sign of a numeric expression.

## Changes

- `ExpressionFunctions.cs` — six overloads covering all supported numeric types: `int`, `bigint`, `decimal`, `float`, `money`, `real`
- `FunctionMetadata.cs` — autocomplete/IntelliSense entry
- `ExpressionFunctionTests.cs` — unit tests for `int`, `bigint`, and `float` overloads covering positive, negative, zero, and null inputs

## Usage

```sql
SELECT SIGN(-42)     -- -1
SELECT SIGN(0)       -- 0
SELECT SIGN(3.14)    -- 1
SELECT SIGN(amount)  -- works on any numeric column
```