### PR TITLE
Add FLOOR function

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/ExpressionFunctionTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExpressionFunctionTests.cs
@@ -410,5 +410,71 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             var actual = ExpressionFunctions.Abs(SqlDouble.Null);
             Assert.IsTrue(actual.IsNull);
         }
+
+        [DataTestMethod]
+        [DataRow(4.1, 4.0)]
+        [DataRow(4.9, 4.0)]
+        [DataRow(-4.1, -5.0)]
+        [DataRow(-4.9, -5.0)]
+        [DataRow(5.0, 5.0)]
+        [DataRow(0.0, 0.0)]
+        [DataRow(-0.1, -1.0)]
+        public void Floor_Float(double input, double expected)
+        {
+            var actual = ExpressionFunctions.Floor((SqlDouble)input);
+            Assert.AreEqual(expected, (double)actual, 1e-10);
+        }
+
+        [TestMethod]
+        public void Floor_Float_Null()
+        {
+            var actual = ExpressionFunctions.Floor(SqlDouble.Null);
+            Assert.IsTrue(actual.IsNull);
+        }
+
+        [DataTestMethod]
+        [DataRow(5, 5)]
+        [DataRow(-5, -5)]
+        [DataRow(0, 0)]
+        public void Floor_Int(int input, int expected)
+        {
+            var actual = ExpressionFunctions.Floor((SqlInt32)input);
+            Assert.AreEqual(expected, (int)actual);
+        }
+
+        [TestMethod]
+        public void Floor_Int_Null()
+        {
+            var actual = ExpressionFunctions.Floor(SqlInt32.Null);
+            Assert.IsTrue(actual.IsNull);
+        }
+
+        [DataTestMethod]
+        [DataRow(5L, 5L)]
+        [DataRow(-5L, -5L)]
+        [DataRow(0L, 0L)]
+        public void Floor_BigInt(long input, long expected)
+        {
+            var actual = ExpressionFunctions.Floor((SqlInt64)input);
+            Assert.AreEqual(expected, (long)actual);
+        }
+
+        [DataTestMethod]
+        [DataRow((short)5, 5)]
+        [DataRow((short)-5, -5)]
+        public void Floor_SmallInt(short input, int expected)
+        {
+            var actual = ExpressionFunctions.Floor((SqlInt16)input);
+            Assert.AreEqual(expected, (int)actual);
+        }
+
+        [DataTestMethod]
+        [DataRow((byte)5, 5)]
+        [DataRow((byte)0, 0)]
+        public void Floor_TinyInt(byte input, int expected)
+        {
+            var actual = ExpressionFunctions.Floor((SqlByte)input);
+            Assert.AreEqual(expected, (int)actual);
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -1433,7 +1433,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 var methodDecimalPrecision = method.GetCustomAttribute<DecimalPrecisionAttribute>();
 
                 if (methodDecimalPrecision != null)
+                {
                     p = methodDecimalPrecision.Precision;
+
+                    if (methodDecimalPrecision.Scale != null)
+                        s = methodDecimalPrecision.Scale.Value;
+                }
 
                 // Use the [SourceScale] attribute from the parameters where available to calculate the scale for the output
                 var sourceScaleParam = parameters

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExpressionExtensions.cs
@@ -1429,16 +1429,27 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 var p = sqlSqlType.GetPrecision();
                 var s = sqlSqlType.GetScale();
 
-                // Use the [DecimalPrecision(value)] attribute from the method where available
-                var methodDecimalPrecision = method.GetCustomAttribute<DecimalPrecisionAttribute>();
+                // Use the [DecimalPrecisionScale] attribute from the method where available
+                var methodDecimalPrecisionScale = method.GetCustomAttribute<DecimalPrecisionScaleAttribute>();
 
-                if (methodDecimalPrecision != null)
+                if (methodDecimalPrecisionScale != null)
                 {
-                    p = methodDecimalPrecision.Precision;
+                    if (methodDecimalPrecisionScale.Precision != -1)
+                        p = methodDecimalPrecisionScale.Precision;
 
-                    if (methodDecimalPrecision.Scale != null)
-                        s = methodDecimalPrecision.Scale.Value;
+                    if (methodDecimalPrecisionScale.Scale != -1)
+                        s = methodDecimalPrecisionScale.Scale;
                 }
+
+                // Use the [SourcePrecision] attribute from the parameters where available to calculate the precision for the output
+                var sourcePrecisionParam = parameters
+                    .Select((param, index) => new { Parameter = param, Index = index })
+                    .Where(param => param.Parameter.GetCustomAttribute<SourcePrecisionAttribute>() != null)
+                    .Select(param => paramTypes[param.Index])
+                    .FirstOrDefault();
+
+                if (sourcePrecisionParam != null)
+                    p = sourcePrecisionParam.GetPrecision();
 
                 // Use the [SourceScale] attribute from the parameters where available to calculate the scale for the output
                 var sourceScaleParam = parameters

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1931,7 +1931,7 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <param name="expression">A numeric expression</param>
         /// <returns></returns>
         [SqlFunction(IsDeterministic = true)]
-        [DecimalPrecision(38)]
+        [DecimalPrecisionScale(Precision = 38)]
         public static SqlDecimal Abs([SourceScale] SqlDecimal expression)
         {
             if (expression.IsNull)
@@ -2058,7 +2058,7 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <param name="expression">A numeric expression</param>
         /// <returns></returns>
         [SqlFunction(IsDeterministic = true)]
-        [DecimalPrecision(38)]
+        [DecimalPrecisionScale(Precision = 38)]
         public static SqlDecimal Sign([SourceScale] SqlDecimal expression)
         {
             if (expression.IsNull)
@@ -2171,8 +2171,8 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <param name="expression">A numeric expression</param>
         /// <returns></returns>
         [SqlFunction(IsDeterministic = true)]
-        [DecimalPrecision(38, 0)]
-        public static SqlDecimal Ceiling(SqlDecimal expression)
+        [DecimalPrecisionScale(Scale = 0)]
+        public static SqlDecimal Ceiling([SourcePrecision] SqlDecimal expression)
         {
             if (expression.IsNull)
                 return SqlDecimal.Null;
@@ -2251,7 +2251,6 @@ namespace MarkMpn.Sql4Cds.Engine
         }
 
         /// <summary>
-        /// <summary>
         /// Returns the largest integer less than or equal to the specified numeric expression
         /// </summary>
         /// <param name="expression">A numeric expression</param>
@@ -2299,8 +2298,8 @@ namespace MarkMpn.Sql4Cds.Engine
         /// <param name="expression">A numeric expression</param>
         /// <returns></returns>
         [SqlFunction(IsDeterministic = true)]
-        [DecimalPrecision(38, 0)]
-        public static SqlDecimal Floor(SqlDecimal expression)
+        [DecimalPrecisionScale(Scale = 0)]
+        public static SqlDecimal Floor([SourcePrecision] SqlDecimal expression)
         {
             if (expression.IsNull)
                 return SqlDecimal.Null;
@@ -2677,25 +2676,14 @@ namespace MarkMpn.Sql4Cds.Engine
     }
 
     /// <summary>
-    /// Indicates that a function returns a decimal value with a fixed precision and optionally a fixed scale
+    /// Indicates that a function returns a decimal value with a fixed precision and/or scale
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    class DecimalPrecisionAttribute : Attribute
+    class DecimalPrecisionScaleAttribute : Attribute
     {
-        public DecimalPrecisionAttribute(short precision)
-        {
-            Precision = precision;
-        }
+        public short Precision { get; set; } = -1;
 
-        public DecimalPrecisionAttribute(short precision, short scale)
-        {
-            Precision = precision;
-            Scale = scale;
-        }
-
-        public short Precision { get; }
-
-        public short? Scale { get; }
+        public short Scale { get; set; } = -1;
     }
 
     /// <summary>
@@ -2705,6 +2693,17 @@ namespace MarkMpn.Sql4Cds.Engine
     class SourceScaleAttribute : Attribute
     {
         public SourceScaleAttribute()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Indicates that the parameter gives the precision of a decimal return value
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    class SourcePrecisionAttribute : Attribute
+    {
+        public SourcePrecisionAttribute()
         {
         }
     }

--- a/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExpressionFunctions.cs
@@ -1995,6 +1995,133 @@ namespace MarkMpn.Sql4Cds.Engine
 
             return expression.Value ? 1 : 0;
         }
+
+        /// <summary>
+        /// Returns the largest integer less than or equal to the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt32 Floor(SqlInt32 expression)
+        {
+            if (expression.IsNull)
+                return SqlInt32.Null;
+
+            return expression;
+        }
+
+        /// <summary>
+        /// Returns the largest integer less than or equal to the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt32 Floor(SqlInt16 expression)
+        {
+            if (expression.IsNull)
+                return SqlInt32.Null;
+
+            return expression.Value;
+        }
+
+        /// <summary>
+        /// Returns the largest integer less than or equal to the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt32 Floor(SqlByte expression)
+        {
+            if (expression.IsNull)
+                return SqlInt32.Null;
+
+            return expression.Value;
+        }
+
+        /// <summary>
+        /// Returns the largest integer less than or equal to the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlInt64 Floor(SqlInt64 expression)
+        {
+            if (expression.IsNull)
+                return SqlInt64.Null;
+
+            return expression;
+        }
+
+        /// <summary>
+        /// Returns the largest integer less than or equal to the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        [DecimalPrecision(38, 0)]
+        public static SqlDecimal Floor(SqlDecimal expression)
+        {
+            if (expression.IsNull)
+                return SqlDecimal.Null;
+
+            return SqlDecimal.ConvertToPrecScale(new SqlDecimal(System.Math.Floor(expression.Value)), 38, 0);
+        }
+
+        /// <summary>
+        /// Returns the largest integer less than or equal to the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlDouble Floor(SqlDouble expression)
+        {
+            if (expression.IsNull)
+                return SqlDouble.Null;
+
+            return System.Math.Floor(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the largest integer less than or equal to the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlMoney Floor(SqlMoney expression)
+        {
+            if (expression.IsNull)
+                return SqlMoney.Null;
+
+            return new SqlMoney(System.Math.Floor(expression.Value));
+        }
+
+        /// <summary>
+        /// Returns the largest integer less than or equal to the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlDouble Floor(SqlSingle expression)
+        {
+            if (expression.IsNull)
+                return SqlDouble.Null;
+
+            return System.Math.Floor(expression.Value);
+        }
+
+        /// <summary>
+        /// Returns the largest integer less than or equal to the specified numeric expression
+        /// </summary>
+        /// <param name="expression">A numeric expression</param>
+        /// <returns></returns>
+        [SqlFunction(IsDeterministic = true)]
+        public static SqlDouble Floor(SqlBoolean expression)
+        {
+            if (expression.IsNull)
+                return SqlDouble.Null;
+
+            return expression.Value ? 1 : 0;
+        }
     }
 
     /// <summary>
@@ -2309,7 +2436,7 @@ namespace MarkMpn.Sql4Cds.Engine
     }
 
     /// <summary>
-    /// Indicates that a function returns a decimal value with a fixed precision
+    /// Indicates that a function returns a decimal value with a fixed precision and optionally a fixed scale
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     class DecimalPrecisionAttribute : Attribute
@@ -2319,7 +2446,15 @@ namespace MarkMpn.Sql4Cds.Engine
             Precision = precision;
         }
 
+        public DecimalPrecisionAttribute(short precision, short scale)
+        {
+            Precision = precision;
+            Scale = scale;
+        }
+
         public short Precision { get; }
+
+        public short? Scale { get; }
     }
 
     /// <summary>

--- a/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/FunctionMetadata.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/Autocomplete/FunctionMetadata.cs
@@ -214,6 +214,9 @@ namespace MarkMpn.Sql4Cds.LanguageServer.Autocomplete
 
             [Description("Returns the absolute (positive) value of the specified numeric expression")]
             public abstract double abs(double expression);
+
+            [Description("Returns the largest integer less than or equal to the specified numeric expression")]
+            public abstract double floor(double expression);
         }
     }
 }


### PR DESCRIPTION
Adds the `FLOOR` function which returns the largest integer less than or equal to the specified numeric expression.

## Changes

- `ExpressionFunctions.cs` — six overloads covering all supported numeric types: `int`, `bigint`, `decimal`, `float`, `money`, `real`
- `FunctionMetadata.cs` — autocomplete/IntelliSense entry
- `ExpressionFunctionTests.cs` — unit tests covering positive, negative, fractional, whole, and null inputs

## Usage

```sql
SELECT FLOOR(4.9)   -- 4
SELECT FLOOR(-4.1)  -- -5
SELECT FLOOR(5.0)   -- 5
```