### PR TITLE
Fix JSON serialization of nested Entity/EntityCollection in expando API responses

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/ExpandoMessageExecutor.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExpandoMessageExecutor.cs
@@ -1,0 +1,55 @@
+using System;
+using FakeXrmEasy;
+using FakeXrmEasy.FakeMessageExecutors;
+using Microsoft.Xrm.Sdk;
+
+namespace MarkMpn.Sql4Cds.Engine.Tests
+{
+    internal class ExpandoMessageExecutor : IFakeMessageExecutor
+    {
+        public static string MessageName => "ExpandoMessage";
+
+        public bool CanExecute(OrganizationRequest request)
+        {
+            return request.RequestName == MessageName;
+        }
+
+        public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
+        {
+            var user1 = new Entity
+            {
+                ["OneDriveRoot_Error"] = false,
+                ["OneDriveMSFP_Error"] = false,
+                ["user"] = new Entity("systemuser", new Guid("a81ca1d0-0b4f-ef11-a316-000d3a0cd126"))
+                {
+                    ["__DisplayName__"] = "John Doe"
+                }
+            };
+
+            var user2 = new Entity
+            {
+                ["OneDriveRoot_Error"] = false,
+                ["OneDriveMSFP_Error"] = false,
+                ["user"] = new Entity("systemuser", new Guid("450b303e-ff46-ef11-a317-0022481b5eda"))
+                {
+                    ["__DisplayName__"] = "Jane Doe"
+                }
+            };
+
+            var results = new EntityCollection(new[] { user1, user2 });
+
+            return new OrganizationResponse
+            {
+                Results = new ParameterCollection
+                {
+                    ["Results"] = results
+                }
+            };
+        }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(OrganizationRequest);
+        }
+    }
+}

--- a/MarkMpn.Sql4Cds.Engine.Tests/FakeXrmEasyTestsBase.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/FakeXrmEasyTestsBase.cs
@@ -77,6 +77,7 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             _context.AddFakeMessageExecutor<RetrieveAllOptionSetsRequest>(new RetrieveAllOptionSetsHandler());
             _context.AddGenericFakeMessageExecutor(SampleMessageExecutor.MessageName, new SampleMessageExecutor());
             _context.AddGenericFakeMessageExecutor(SetStateMessageExecutor.MessageName, new SetStateMessageExecutor());
+            _context.AddGenericFakeMessageExecutor(ExpandoMessageExecutor.MessageName, new ExpandoMessageExecutor());
 
             _service = _context.GetOrganizationService();
             _dataSource = new FakeXrmDataSource { Name = "uat", Connection = _service, Metadata = new AttributeMetadataCache(_service), TableSizeCache = new StubTableSizeCache(), MessageCache = new StubMessageCache(), DefaultCollation = Collation.USEnglish };

--- a/MarkMpn.Sql4Cds.Engine.Tests/JsonFunctionTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/JsonFunctionTests.cs
@@ -179,5 +179,45 @@ SELECT JSON_VALUE(@jsonInfo, @path)";
                 Assert.AreEqual(true, cmd.ExecuteScalar());
             }
         }
+
+        [TestMethod]
+        public void ExpandoMessageNestedEntitySerializesAsWebApiJson()
+        {
+            using (var con = new Sql4CdsConnection(_localDataSources))
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandText = "SELECT Results FROM ExpandoMessage()";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    Assert.IsTrue(reader.Read());
+                    var json1 = reader.GetString(0);
+
+                    // Should produce flat WebAPI-style JSON, not verbose .NET format with Attributes[]
+                    Assert.IsFalse(json1.Contains("\"Attributes\""), "Row 1: should not contain verbose .NET Entity serialization");
+
+                    var doc1 = System.Text.Json.JsonDocument.Parse(json1);
+                    Assert.AreEqual(false, doc1.RootElement.GetProperty("OneDriveRoot_Error").GetBoolean());
+
+                    // Nested Entity should appear as a JSON object, not serialized with Attributes[]
+                    var user1 = doc1.RootElement.GetProperty("user");
+                    Assert.AreEqual(System.Text.Json.JsonValueKind.Object, user1.ValueKind);
+                    Assert.AreEqual("systemuser", user1.GetProperty("@odata.type").GetString());
+                    Assert.AreEqual("John Doe", user1.GetProperty("__DisplayName__").GetString());
+
+                    Assert.IsTrue(reader.Read());
+                    var json2 = reader.GetString(0);
+
+                    Assert.IsFalse(json2.Contains("\"Attributes\""), "Row 2: should not contain verbose .NET Entity serialization");
+
+                    var doc2 = System.Text.Json.JsonDocument.Parse(json2);
+                    var user2 = doc2.RootElement.GetProperty("user");
+                    Assert.AreEqual(System.Text.Json.JsonValueKind.Object, user2.ValueKind);
+                    Assert.AreEqual("Jane Doe", user2.GetProperty("__DisplayName__").GetString());
+
+                    Assert.IsFalse(reader.Read());
+                }
+            }
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj
+++ b/MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="RetrieveMetadataChangesHandler.cs" />
     <Compile Include="SetStateMessageExecutor.cs" />
     <Compile Include="SampleMessageExecutor.cs" />
+    <Compile Include="ExpandoMessageExecutor.cs" />
     <Compile Include="Sql2FetchXmlTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlDateTimeTests.cs" />

--- a/MarkMpn.Sql4Cds.Engine.Tests/StubMessageCache.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/StubMessageCache.cs
@@ -43,6 +43,21 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                     }
                 }.AsReadOnly()
             };
+            _cache["ExpandoMessage"] = new Message
+            {
+                Name = "ExpandoMessage",
+                InputParameters = new List<MessageParameter>().AsReadOnly(),
+                OutputParameters = new List<MessageParameter>
+                {
+                    new MessageParameter
+                    {
+                        Name = "Results",
+                        Position = 0,
+                        Type = typeof(EntityCollection),
+                        OTC = null
+                    }
+                }.AsReadOnly()
+            };
             _cache["SetState"] = new Message
             {
                 Name = "SetState",

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
@@ -439,6 +439,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (entity == null)
                 return null;
 
+            return JsonConvert.SerializeObject(BuildAttributeDictionary(entity));
+        }
+
+        private Dictionary<string, object> BuildAttributeDictionary(Entity entity)
+        {
+            if (entity == null)
+                return null;
+
             var values = new Dictionary<string, object>();
 
             if (!String.IsNullOrEmpty(entity.LogicalName))
@@ -465,6 +473,18 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         values[attribute.Key + "name"] = er.Name;
                         values[attribute.Key + "type"] = er.LogicalName;
                     }
+                    else if (attribute.Value is Entity nestedEntity)
+                    {
+                        values[attribute.Key] = BuildAttributeDictionary(nestedEntity);
+                        continue;
+                    }
+                    else if (attribute.Value is EntityCollection nestedCollection)
+                    {
+                        values[attribute.Key] = nestedCollection.Entities
+                            .Select(e => BuildAttributeDictionary(e))
+                            .ToList();
+                        continue;
+                    }
                     else
                     {
                         values[attribute.Key] = attribute.Value;
@@ -476,7 +496,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 }
             }
 
-            return JsonConvert.SerializeObject(values);
+            return values;
         }
 
         private Entity DeserializeAttributeValues(string s)


### PR DESCRIPTION
## Problem

Fixes #743

When a custom API returns an expando `EntityCollection` whose entities contain nested `Entity` or `EntityCollection` attribute values, the serialization produced verbose .NET-style JSON instead of the flat WebAPI-style JSON:

**Before (broken):**
```json
{
  "user": {
    "Attributes": [{"Key": "systemuser", "Value": "a81ca1d0-..."}],
    "LogicalName": null,
    "Id": "00000000-..."
  }
}
```

**After (fixed):**
```json
{
  "user": {
    "@odata.type": "systemuser",
    "@odata.id": "a81ca1d0-...",
    "__DisplayName__": "John Doe"
  }
}
```

## Root Cause

In `ExecuteMessageNode.SerializeAttributeValues()`, the `else` branch passed `Entity` and `EntityCollection` attribute values directly to `JsonConvert.SerializeObject()` which used default .NET reflection serialization, producing the `Attributes[]` / `Entities[]` verbose format.

## Fix

Refactored `SerializeAttributeValues` into a `BuildAttributeDictionary()` helper that returns a `Dictionary<string, object>`, adding recursive handling for:
- **`Entity` attribute values** → nested JSON object via recursion into `BuildAttributeDictionary`
- **`EntityCollection` attribute values** → JSON array of recursively serialized entity dictionaries

All existing type handling (`OptionSetValue`, `Money`, `EntityReference`, `@odata.type` annotations) is preserved unchanged.

## Changes

- `MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs` — Core fix: refactored `SerializeAttributeValues` with a recursive `BuildAttributeDictionary` helper
- `MarkMpn.Sql4Cds.Engine.Tests/ExpandoMessageExecutor.cs` — New fake executor returning entities with nested `Entity` attributes
- `MarkMpn.Sql4Cds.Engine.Tests/StubMessageCache.cs` — Added `ExpandoMessage` entry for testing
- `MarkMpn.Sql4Cds.Engine.Tests/FakeXrmEasyTestsBase.cs` — Registered `ExpandoMessageExecutor`
- `MarkMpn.Sql4Cds.Engine.Tests/JsonFunctionTests.cs` — New test verifying flat WebAPI-style JSON output
- `MarkMpn.Sql4Cds.Engine.Tests/MarkMpn.Sql4Cds.Engine.Tests.csproj` — Added new executor file to project