### PR TITLE
Update TelemetryClient to use ConnectionString config

### DIFF
--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
@@ -62,7 +62,10 @@ namespace MarkMpn.Sql4Cds.Engine
             _options = new DefaultQueryExecutionOptions(this, dataSources.First().Value, CancellationToken.None);
             _session = new SessionContext(dataSources, _options);
 
-            _ai = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration("79761278-a908-4575-afbf-2f4d82560da6"));
+            _ai = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
+            {
+                ConnectionString = "InstrumentationKey=79761278-a908-4575-afbf-2f4d82560da6"
+            });
 
             var app = System.Reflection.Assembly.GetEntryAssembly();
 

--- a/MarkMpn.Sql4Cds.SSMS/CommandBase.cs
+++ b/MarkMpn.Sql4Cds.SSMS/CommandBase.cs
@@ -28,7 +28,10 @@ namespace MarkMpn.Sql4Cds.SSMS
 
         static CommandBase()
         {
-            _ai = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration("79761278-a908-4575-afbf-2f4d82560da6"));
+            _ai = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
+            {
+                ConnectionString = "InstrumentationKey=79761278-a908-4575-afbf-2f4d82560da6"
+            });
         }
 
         protected CommandBase(Sql4CdsPackage package, DTE2 dte)

--- a/MarkMpn.Sql4Cds.XTB/PluginControl.cs
+++ b/MarkMpn.Sql4Cds.XTB/PluginControl.cs
@@ -43,7 +43,10 @@ namespace MarkMpn.Sql4Cds.XTB
             _objectExplorer.CloseButtonVisible = false;
             _properties = new PropertiesWindow();
             _properties.SelectedObjectChanged += OnSelectedObjectChanged;
-            _ai = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration("79761278-a908-4575-afbf-2f4d82560da6"));
+            _ai = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
+            {
+                ConnectionString = "InstrumentationKey=79761278-a908-4575-afbf-2f4d82560da6"
+            });
             tscbConnection.Items.Add("Add Connection...");
             
             TabIcon = Properties.Resources.SQL4CDS_Icon_16;


### PR DESCRIPTION
Fixes: #771 

Modernised Application Insights setup by initialising TelemetryClient with a TelemetryConfiguration object using the ConnectionString property, replacing direct instrumentation key usage in three files.