### PR TITLE
Remove features not supported in plugin sandbox

### DIFF
--- a/MarkMpn.Sql4Cds.Engine/SessionContext.cs
+++ b/MarkMpn.Sql4Cds.Engine/SessionContext.cs
@@ -61,17 +61,24 @@ namespace MarkMpn.Sql4Cds.Engine
                 if (orgVersion == null)
                     orgVersion = ((RetrieveVersionResponse)dataSource.ExecuteWithServiceProtectionLimitLogging(new RetrieveVersionRequest(), _context._options, "Retrieving server version...")).Version;
 
-                var assembly = typeof(Sql4CdsConnection).Assembly;
-                var assemblyVersion = assembly.GetName().Version;
-                var assemblyCopyright = assembly
-                    .GetCustomAttributes(typeof(AssemblyCopyrightAttribute), false)
-                    .OfType<AssemblyCopyrightAttribute>()
-                    .FirstOrDefault()?
-                    .Copyright;
-                var assemblyFilename = assembly.Location;
-                var assemblyDate = System.IO.File.GetLastWriteTime(assemblyFilename);
+                try
+                {
+                    var assembly = typeof(Sql4CdsConnection).Assembly;
+                    var assemblyVersion = assembly.GetName().Version;
+                    var assemblyCopyright = assembly
+                        .GetCustomAttributes(typeof(AssemblyCopyrightAttribute), false)
+                        .OfType<AssemblyCopyrightAttribute>()
+                        .FirstOrDefault()?
+                        .Copyright;
+                    var assemblyFilename = assembly.Location;
+                    var assemblyDate = System.IO.File.GetLastWriteTime(assemblyFilename);
 
-                return $"Microsoft Dataverse - {orgVersion}\r\n\tSQL 4 CDS - {assemblyVersion}\r\n\t{assemblyDate:MMM dd yyyy HH:mm:ss}\r\n\t{assemblyCopyright}";
+                    return $"Microsoft Dataverse - {orgVersion}\r\n\tSQL 4 CDS - {assemblyVersion}\r\n\t{assemblyCopyright}";
+                }
+                catch
+                {
+                    return $"Microsoft Dataverse - {orgVersion}";
+                }
             }
 
             private SqlString GetServerName()


### PR DESCRIPTION
The version retrieval code, touching the file system, broke the Sql4Cds engine when embedded into a plugin running inside the Dataverse sandbox.
The simplest fix of simply ignoring the error has been applied.
With these changes it now perfectly works inside the plugin sandbox environment and is used in a derivative project I have recently been working on - [Sql4CdsApp](https://github.com/kowgli/Sql4CdsApp).

Thank you so much for this wonderful tool! It's the nr 1 tool in my toolbox and I use it for everything, including bulk data updates and data migrations.