### PR TITLE
V10.4.3 fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/AdoProviderTests.cs
@@ -3195,5 +3195,33 @@ SELECT ABS(@i);";
                 }
             }
         }
+
+        [TestMethod]
+        public void InsertMultipleRecordsWithFirstValueNull()
+        {
+            // https://github.com/MarkMpn/Sql4Cds/issues/784
+            using (var con = new Sql4CdsConnection(_localDataSources))
+            using (var cmd = con.CreateCommand())
+            {
+                cmd.CommandTimeout = 0;
+                cmd.CommandText = @"
+INSERT INTO account (name, employees) VALUES (NULL, 10), ('Data8', 20)";
+                cmd.ExecuteNonQuery();
+
+                cmd.CommandText = "SELECT name, employees FROM account ORDER BY employees";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    Assert.IsTrue(reader.Read());
+                    Assert.IsTrue(reader.IsDBNull(0));
+                    Assert.AreEqual(10, reader.GetInt32(1));
+
+                    Assert.IsTrue(reader.Read());
+                    Assert.AreEqual("Data8", reader.GetString(0));
+                    Assert.AreEqual(20, reader.GetInt32(1));
+                    Assert.IsFalse(reader.Read());
+                }
+            }
+        }
     }
 }

--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanNodeTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanNodeTests.cs
@@ -656,8 +656,9 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
                 },
                 Alias = "test"
             };
+            var context = new NodeCompilationContext(new SessionContext(_localDataSources, new StubOptions()), new StubOptions(), null, null);
 
-            var spool = new TableSpoolNode { Source = source };
+            var spool = new TableSpoolNode(source, context);
 
             var results1 = spool.Execute(new NodeExecutionContext(new SessionContext(_localDataSources, new StubOptions()), new StubOptions(), null, null, null))
                 .Select(e => e.GetAttributeValue<SqlInt32>("test.value1").Value)

--- a/MarkMpn.Sql4Cds.Engine/BuiltAtAttribute.cs
+++ b/MarkMpn.Sql4Cds.Engine/BuiltAtAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MarkMpn.Sql4Cds.Engine
+{
+    [AttributeUsage(AttributeTargets.Assembly)]
+    class BuiltAtAttribute : Attribute
+    {
+        public BuiltAtAttribute(string buildDate)
+        {
+            BuildDate = buildDate;
+        }
+
+        public string BuildDate { get; }
+
+        public DateTime Date => DateTime.ParseExact(BuildDate, "yyyyMMddHHmmss", null);
+    }
+}

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/AdaptiveIndexSpoolNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/AdaptiveIndexSpoolNode.cs
@@ -11,9 +11,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
     {
         private IndexSpoolNode _indexSpool;
 
-        public AdaptiveIndexSpoolNode()
+        private AdaptiveIndexSpoolNode() { }
+
+        public AdaptiveIndexSpoolNode(IDataExecutionPlanNodeInternal source, NodeCompilationContext context)
         {
-            _indexSpool = new IndexSpoolNode();
+            UnspooledSource = (IDataExecutionPlanNodeInternal)source.Clone();
+            _indexSpool = new IndexSpoolNode(source, context);
         }
 
         [Browsable(false)]

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ConcatenateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ConcatenateNode.cs
@@ -51,10 +51,28 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         {
             var schema = new ColumnList();
 
-            var sourceSchema = Sources[0].GetSchema(context);
+            // Combine types from each source as per FoldQuery
+            var schemas = Sources.Select(s => s.GetSchema(context)).ToArray();
+            var types = GetCombinedTypes(context, out _);
 
-            foreach (var col in ColumnSet)
-                schema[col.OutputColumn] = sourceSchema.Schema[col.SourceColumns[0]];
+            for (var i = 0; i < ColumnSet.Count; i++)
+            {
+                var isNullable = false;
+                var isCalculated = false;
+                var isVisible = false;
+                var isWildcardable = false;
+
+                for (var sourceIndex = 0; sourceIndex < Sources.Count; sourceIndex++)
+                {
+                    var sourceSchema = schemas[sourceIndex].Schema[ColumnSet[i].SourceColumns[sourceIndex]];
+                    isNullable |= sourceSchema.IsNullable;
+                    isCalculated |= sourceSchema.IsCalculated;
+                    isVisible |= sourceSchema.IsVisible;
+                    isWildcardable |= sourceSchema.IsWildcardable;
+                }
+
+                schema[ColumnSet[i].OutputColumn] = new ColumnDefinition(types[i], isNullable, isCalculated, isVisible, isWildcardable);
+            }
 
             return new NodeSchema(
                 primaryKey: null,
@@ -68,17 +86,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             return Sources;
         }
 
-        public override IDataExecutionPlanNodeInternal FoldQuery(NodeCompilationContext context, IList<OptimizerHint> hints)
+        private DataTypeReference[] GetCombinedTypes(NodeCompilationContext context, out DataTypeReference[][] sourceColumnTypes)
         {
-            for (var i = 0; i < Sources.Count; i++)
-            {
-                Sources[i] = Sources[i].FoldQuery(context, hints);
-                Sources[i].Parent = this;
-            }
-
-            // Work out the column types
-            var sourceColumnTypes = Sources.Select((source, index) => GetColumnTypes(index, context)).ToArray();
-            var types = (DataTypeReference[]) sourceColumnTypes[0].Clone();
+            sourceColumnTypes = Sources.Select((source, index) => GetColumnTypes(index, context)).ToArray();
+            var types = (DataTypeReference[])sourceColumnTypes[0].Clone();
 
             for (var i = 1; i < Sources.Count; i++)
             {
@@ -92,6 +103,20 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     types[colIndex] = colType;
                 }
             }
+
+            return types;
+        }
+
+        public override IDataExecutionPlanNodeInternal FoldQuery(NodeCompilationContext context, IList<OptimizerHint> hints)
+        {
+            for (var i = 0; i < Sources.Count; i++)
+            {
+                Sources[i] = Sources[i].FoldQuery(context, hints);
+                Sources[i].Parent = this;
+            }
+
+            // Work out the column types
+            var types = GetCombinedTypes(context, out var sourceColumnTypes);
 
             // Apply any necessary conversions
             for (var i = 0; i < Sources.Count; i++)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -1734,9 +1734,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                     if (rowCount.Value >= 100)
                     {
-                        indexSpool = new IndexSpoolNode
+                        indexSpool = new IndexSpoolNode(this, context)
                         {
-                            Source = this,
                             KeyColumn = (variableCondition.entityname ?? Alias) + "." + variableCondition.attribute,
                             SeekValue = variableCondition.value
                         };
@@ -1754,7 +1753,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         // lots of times. Add an adaptive spool in to avoid excessive calls
                         var clone = (FetchXmlScan)Clone();
 
-                        indexSpool = new AdaptiveIndexSpoolNode
+                        indexSpool = new AdaptiveIndexSpoolNode(this, context)
                         {
                             UnspooledSource = clone,
                             SpooledSource = this,

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FilterNode.cs
@@ -1508,9 +1508,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 };
             }
 
-            Source = new IndexSpoolNode
+            Source = new IndexSpoolNode(spoolSource, context)
             {
-                Source = spoolSource,
                 KeyColumn = indexColumn,
                 SeekValue = seekVariable
             }.FoldQuery(context, hints);

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
@@ -598,14 +598,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 // aggregate processing
                 if (maxResultCount > maxPageSize && !supportsPaging)
                 {
-                    var spoolProducer = new TableSpoolNode
+                    var spoolProducer = new TableSpoolNode(firstTry, context)
                     {
-                        Source = firstTry,
                         SpoolType = SpoolType.Eager
                     };
-                    var spoolConsumer = new TableSpoolNode
+                    var spoolConsumer = new TableSpoolNode(spoolProducer)
                     {
-                        Producer = spoolProducer,
                         SpoolType = SpoolType.Eager
                     };
                     var countCol = context.GetExpressionName();

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/IndexSpoolNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/IndexSpoolNode.cs
@@ -23,7 +23,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         private Stack<Entity> _stack;
         private INodeSchema _workTableSchema;
 
-        private IndexSpoolNode() { }
+        public IndexSpoolNode() { }
 
         public IndexSpoolNode(IDataExecutionPlanNodeInternal source, NodeCompilationContext context)
         {

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/IndexSpoolNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/IndexSpoolNode.cs
@@ -21,6 +21,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         private Func<INullable, ExpressionExecutionContext, INullable> _keySelector;
         private Func<INullable, ExpressionExecutionContext, INullable> _seekSelector;
         private Stack<Entity> _stack;
+        private INodeSchema _workTableSchema;
+
+        private IndexSpoolNode() { }
+
+        public IndexSpoolNode(IDataExecutionPlanNodeInternal source, NodeCompilationContext context)
+        {
+            Source = source;
+            _workTableSchema = source.GetSchema(context);
+        }
 
         [Browsable(false)]
         public IDataExecutionPlanNodeInternal Source { get; set; }
@@ -108,6 +117,13 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 return FoldCTEToFetchXml(context, hints);
 
             return this;
+        }
+
+        public override void FinishedFolding(NodeCompilationContext context)
+        {
+            base.FinishedFolding(context);
+
+            _workTableSchema = Source.GetSchema(context);
         }
 
         private IDataExecutionPlanNodeInternal FoldCTEToFetchXml(NodeCompilationContext context, IList<OptimizerHint> hints)
@@ -403,7 +419,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public INodeSchema GetWorkTableSchema(NodeCompilationContext context)
         {
-            return Source.GetSchema(context);
+            return _workTableSchema;
         }
 
         public override IEnumerable<IExecutionPlanNode> GetSources()
@@ -473,6 +489,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 _keySelector = _keySelector,
                 _seekSelector = _seekSelector,
                 WithStack = WithStack,
+                _workTableSchema = _workTableSchema,
             };
 
             LastClone = clone;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/TableSpoolNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/TableSpoolNode.cs
@@ -84,10 +84,22 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             }
         }
 
-        public TableSpoolNode() { }
+        private TableSpoolNode() { }
+
+        public TableSpoolNode(ISpoolProducerNode producer)
+        {
+            Producer = producer;
+        }
+
+        public TableSpoolNode(IDataExecutionPlanNodeInternal source, NodeCompilationContext context)
+        {
+            Source = source;
+            _workTableSchema = source.GetSchema(context);
+        }
 
         private IEnumerable<Entity> _workTable;
         private HashSet<string> _addedColumns;
+        private INodeSchema _workTableSchema;
 
         /// <summary>
         /// The data source to cache
@@ -211,7 +223,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
         public INodeSchema GetWorkTableSchema(NodeCompilationContext context)
         {
-            return Source.GetSchema(context);
+            return _workTableSchema;
         }
 
         public override IDataExecutionPlanNodeInternal FoldQuery(NodeCompilationContext context, IList<OptimizerHint> hints)
@@ -229,6 +241,14 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
             Source.Parent = this;
             return this;
+        }
+
+        public override void FinishedFolding(NodeCompilationContext context)
+        {
+            base.FinishedFolding(context);
+
+            if (Producer == null)
+                _workTableSchema = Source.GetSchema(context);
         }
 
         public override void AddRequiredColumns(NodeCompilationContext context, IList<string> requiredColumns)
@@ -295,6 +315,8 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 Producer = Producer?.LastClone,
                 SpoolType = SpoolType,
                 SegmentColumn = SegmentColumn,
+                IsPerformanceSpool = IsPerformanceSpool,
+                _workTableSchema = _workTableSchema
             };
 
             LastClone = clone;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/TableSpoolNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/TableSpoolNode.cs
@@ -84,7 +84,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             }
         }
 
-        private TableSpoolNode() { }
+        public TableSpoolNode() { }
 
         public TableSpoolNode(ISpoolProducerNode producer)
         {

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlanBuilder.cs
@@ -448,9 +448,9 @@ namespace MarkMpn.Sql4Cds.Engine
                     {
                         Source = ctePlan,
                         Columns =
-                                {
-                                    [recursionDepthField] = new IntegerLiteral { Value = "0" }
-                                }
+                        {
+                            [recursionDepthField] = new IntegerLiteral { Value = "0" }
+                        }
                     };
 
                     // Add a ConcatenateNode to combine the anchor results with the recursion results
@@ -479,16 +479,14 @@ namespace MarkMpn.Sql4Cds.Engine
                     });
 
                     // Add an IndexSpool node in stack mode to enable the recursion
-                    var recurseIndexStack = new IndexSpoolNode
+                    var recurseIndexStack = new IndexSpoolNode(recurseConcat, _nodeContext)
                     {
-                        Source = recurseConcat,
                         WithStack = true
                     };
 
                     // Pull the same records into the recursive loop
-                    var recurseTableSpool = new TableSpoolNode
+                    var recurseTableSpool = new TableSpoolNode(recurseIndexStack)
                     {
-                        Producer = recurseIndexStack,
                         SpoolType = SpoolType.Lazy
                     };
 
@@ -3561,16 +3559,14 @@ namespace MarkMpn.Sql4Cds.Engine
                                 // fed into a nested loop. That loop calls another loop which combines the aggregate with the individual
                                 // row values
                                 // https://sqlserverfast.com/blog/hugo/2018/06/plansplaining-part-6-aggregates-with-over/
-                                var spoolProducer = new TableSpoolNode
+                                var spoolProducer = new TableSpoolNode(segment, _nodeContext)
                                 {
-                                    Source = segment,
                                     SpoolType = SpoolType.Lazy,
                                     SegmentColumn = segmentCol
                                 };
 
-                                var spoolConsumerAggregate = new TableSpoolNode
+                                var spoolConsumerAggregate = new TableSpoolNode(spoolProducer)
                                 {
-                                    Producer = spoolProducer,
                                     SpoolType = spoolProducer.SpoolType
                                 };
                                 var aggregate = new StreamAggregateNode
@@ -3581,9 +3577,8 @@ namespace MarkMpn.Sql4Cds.Engine
                                         [functionCol] = converted
                                     }
                                 };
-                                var spoolConsumer = new TableSpoolNode
+                                var spoolConsumer = new TableSpoolNode(spoolProducer)
                                 {
-                                    Producer = spoolProducer,
                                     SpoolType = spoolProducer.SpoolType
                                 };
                                 var loop1 = new NestedLoopNode
@@ -3919,9 +3914,8 @@ namespace MarkMpn.Sql4Cds.Engine
                 }
 
                 // We can spool the results for reuse each time
-                innerQuery.Source = new TableSpoolNode
+                innerQuery.Source = new TableSpoolNode(innerQuery.Source, context)
                 {
-                    Source = innerQuery.Source,
                     SpoolType = SpoolType.Lazy
                 };
 
@@ -4441,7 +4435,7 @@ namespace MarkMpn.Sql4Cds.Engine
             // TOP x PERCENT requires evaluating the source twice - once to get the total count and again to get the top
             // records. Cache the results in a table spool node.
             if (topRowFilter.Percent)
-                source = new TableSpoolNode { Source = source, SpoolType = SpoolType.Eager };
+                source = new TableSpoolNode(source, context) { SpoolType = SpoolType.Eager };
 
             return new TopNode
             {
@@ -4894,7 +4888,7 @@ namespace MarkMpn.Sql4Cds.Engine
                     {
                         if (EstimateRowsOut(node, context) > 1)
                         {
-                            var spool = new TableSpoolNode { Source = loopRightSource, SpoolType = SpoolType.Lazy, IsPerformanceSpool = true };
+                            var spool = new TableSpoolNode(loopRightSource, context) { SpoolType = SpoolType.Lazy, IsPerformanceSpool = true };
                             loopRightSource = spool;
                         }
                     }
@@ -5169,9 +5163,8 @@ namespace MarkMpn.Sql4Cds.Engine
 
             if (outerCount >= 100 || innerCount <= 5000)
             {
-                var spool = new TableSpoolNode
+                var spool = new TableSpoolNode(lastCorrelatedStep.Source, context)
                 {
-                    Source = lastCorrelatedStep.Source,
                     SpoolType = SpoolType.Lazy,
                     IsPerformanceSpool = true
                 };
@@ -5240,7 +5233,7 @@ namespace MarkMpn.Sql4Cds.Engine
 
                 // Join predicates will be lifted from the WHERE clause during folding later. For now, just add a table spool
                 // to cache the results of the second table and use a nested loop to join them.
-                nextTable = new TableSpoolNode { Source = nextTable, SpoolType = SpoolType.Lazy };
+                nextTable = new TableSpoolNode(nextTable, context) { SpoolType = SpoolType.Lazy };
 
                 node = new NestedLoopNode { LeftSource = node, RightSource = nextTable };
             }
@@ -5576,7 +5569,7 @@ namespace MarkMpn.Sql4Cds.Engine
                 else
                 {
                     // Spool the inner table so the results can be reused by the nested loop
-                    rhs = new TableSpoolNode { Source = rhs, SpoolType = SpoolType.Eager, IsPerformanceSpool = true };
+                    rhs = new TableSpoolNode(rhs, context) { SpoolType = SpoolType.Eager, IsPerformanceSpool = true };
 
                     joinNode = new NestedLoopNode
                     {
@@ -5670,7 +5663,7 @@ namespace MarkMpn.Sql4Cds.Engine
                             joinNode = new NestedLoopNode
                             {
                                 LeftSource = foldable.LeftSource,
-                                RightSource = new TableSpoolNode { Source = foldable.RightSource },
+                                RightSource = new TableSpoolNode(foldable.RightSource, context),
                                 JoinType = foldable.JoinType
                             };
 
@@ -5773,7 +5766,7 @@ namespace MarkMpn.Sql4Cds.Engine
                     // If it is correlated, add a spool where possible closer to the data source
                     if (lhsReferences.Count == 0)
                     {
-                        var spool = new TableSpoolNode { Source = rhs, SpoolType = SpoolType.Lazy };
+                        var spool = new TableSpoolNode(rhs, context) { SpoolType = SpoolType.Lazy };
                         rhs = spool;
                     }
                     else if (UseMergeJoin(lhs, subqueryPlan, context, lhsReferences, null, null, false, true, out _, out var merge))
@@ -5791,7 +5784,7 @@ namespace MarkMpn.Sql4Cds.Engine
 
                 // For cross joins there is no outer reference so the entire result can be spooled for reuse
                 if (unqualifiedJoin.UnqualifiedJoinType == UnqualifiedJoinType.CrossJoin)
-                    rhs = new TableSpoolNode { Source = rhs, SpoolType = SpoolType.Lazy };
+                    rhs = new TableSpoolNode(rhs, context) { SpoolType = SpoolType.Lazy };
                 
                 return new NestedLoopNode
                 {

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.csproj
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.csproj
@@ -10,6 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="MarkMpn.Sql4Cds.Engine.BuiltAtAttribute">
+      <_Parameter1>$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  
+  <ItemGroup>
     <Compile Remove="ScriptDom.cs" />
   </ItemGroup>
 

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -12,7 +12,8 @@
     <description>Convert SQL queries to FetchXml and execute them against Dataverse / D365</description>
     <summary>Convert SQL queries to FetchXml and execute them against Dataverse / D365</summary>
     <releaseNotes>Bug fixes:
-* Fixed compatibility with client applications that use Application Insights v3
+* Fixed using INSERT with multiple values when implicit type conversion is required between the rows
+* Fixed using @@VERSION when local file system is not available
     </releaseNotes>
     <copyright>Copyright © 2020 Mark Carrington</copyright>
     <language>en-GB</language>

--- a/MarkMpn.Sql4Cds.Engine/SessionContext.cs
+++ b/MarkMpn.Sql4Cds.Engine/SessionContext.cs
@@ -64,12 +64,11 @@ namespace MarkMpn.Sql4Cds.Engine
                 var assembly = typeof(Sql4CdsConnection).Assembly;
                 var assemblyVersion = assembly.GetName().Version;
                 var assemblyCopyright = assembly
-                    .GetCustomAttributes(typeof(AssemblyCopyrightAttribute), false)
-                    .OfType<AssemblyCopyrightAttribute>()
-                    .FirstOrDefault()?
+                    .GetCustomAttribute<AssemblyCopyrightAttribute>()
                     .Copyright;
-                var assemblyFilename = assembly.Location;
-                var assemblyDate = System.IO.File.GetLastWriteTime(assemblyFilename);
+                var assemblyDate = assembly
+                    .GetCustomAttribute<BuiltAtAttribute>()
+                    .Date;
 
                 return $"Microsoft Dataverse - {orgVersion}\r\n\tSQL 4 CDS - {assemblyVersion}\r\n\t{assemblyDate:MMM dd yyyy HH:mm:ss}\r\n\t{assemblyCopyright}";
             }

--- a/MarkMpn.Sql4Cds.XTB/SqlQueryControl.cs
+++ b/MarkMpn.Sql4Cds.XTB/SqlQueryControl.cs
@@ -75,7 +75,7 @@ namespace MarkMpn.Sql4Cds.XTB
 
         abstract class ExportParams
         {
-            public DataTable DataTable { get; set; }
+            public GridResults Results { get; set; }
 
             public string Filename { get; set; }
 
@@ -85,23 +85,22 @@ namespace MarkMpn.Sql4Cds.XTB
             {
                 var cols = new List<DbColumnWrapper>();
 
-                for (var i = 0; i < DataTable.Columns.Count; i++)
+                foreach (DataRow schema in Results.Schema.Rows)
                 {
-                    var col = DataTable.Columns[i];
-                    var schema = (DataRow)col.ExtendedProperties["Schema"];
+                    var name = (string)schema["ColumnName"];
                     var type = (string)schema["DataTypeName"];
                     var scale = (short)schema["NumericScale"];
-                    cols.Add(new DbColumnWrapper(col.Caption, type, scale));
+                    cols.Add(new DbColumnWrapper(name, type, scale));
                 }
 
                 using (var stream = GetFileStreamFactory().GetWriter(Filename, cols))
                 {
                     var cells = new DbCellValue[cols.Count];
 
-                    for (var row = 0; row < DataTable.Rows.Count; row++)
+                    for (var row = 0; row < Results.Rows.Count; row++)
                     {
                         for (var col = 0; col < cols.Count; col++)
-                            cells[col] = ValueFormatter.Format(DataTable.Rows[row][col], cols[col].DataTypeName, cols[col].NumericScale, Settings.Instance.LocalFormatDates);
+                            cells[col] = ValueFormatter.Format(Results.Rows[row].Values[col], cols[col].DataTypeName, cols[col].NumericScale, Settings.Instance.LocalFormatDates);
 
                         stream.WriteRow(cells, cols);
 
@@ -109,7 +108,7 @@ namespace MarkMpn.Sql4Cds.XTB
                             progress(row + 1);
                     }
 
-                    progress(DataTable.Rows.Count);
+                    progress(Results.Rows.Count);
                 }
             }
         }
@@ -1231,6 +1230,19 @@ namespace MarkMpn.Sql4Cds.XTB
             }
         }
 
+        class GridResults
+        {
+            public GridResults(DataTable schema)
+            {
+                Schema = schema;
+                Rows = new List<GridRow>();
+            }
+
+            public DataTable Schema { get; }
+
+            public List<GridRow> Rows { get; }
+        }
+
         class GridRow
         {
             public object[] Values { get; set; }
@@ -1248,7 +1260,8 @@ namespace MarkMpn.Sql4Cds.XTB
             public DataGridViewResultOutput(SqlQueryControl query, DataTable schema)
             {
                 _query = query;
-                _values = new List<GridRow>();
+                var results = new GridResults(schema);
+                _values = results.Rows;
                 _grid = query.Execute(() =>
                 {
                     var grid = new DataGridView();
@@ -1270,7 +1283,7 @@ namespace MarkMpn.Sql4Cds.XTB
                     grid.ShowEditingIcon = false;
                     grid.ContextMenuStrip = query.gridContextMenuStrip;
                     grid.VirtualMode = true;
-                    grid.Tag = _values;
+                    grid.Tag = results;
 
                     if (Settings.Instance.ResultGridFontSize != null)
                         grid.Font = new Font(grid.Font.FontFamily, Settings.Instance.ResultGridFontSize.Value);
@@ -2130,7 +2143,7 @@ namespace MarkMpn.Sql4Cds.XTB
                 firstRow = false;
             }
 
-            var values = (List<object[]>)grid.Tag;
+            var values = ((GridResults)grid.Tag).Rows;
 
             for (var i = minRow; i <= maxRow; i++)
             {
@@ -2160,7 +2173,7 @@ namespace MarkMpn.Sql4Cds.XTB
 
                     if (isSelected)
                     {
-                        var args = new DataGridViewCellFormattingEventArgs(j, i, row[j], typeof(string), null);
+                        var args = new DataGridViewCellFormattingEventArgs(j, i, row.Values[j], typeof(string), null);
                         FormatCell(grid, args);
 
                         var str = args.Value.ToString();
@@ -2186,7 +2199,7 @@ namespace MarkMpn.Sql4Cds.XTB
 
                         var isLink = false;
 
-                        if (row[j] is SqlEntityReference entityReference && !entityReference.IsNull)
+                        if (row.Values[j] is SqlEntityReference entityReference && !entityReference.IsNull)
                         {
                             var url = GetRecordUrl(entityReference, out _);
                             html.Append($"<A HREF=\"{url}\">");
@@ -2246,7 +2259,7 @@ namespace MarkMpn.Sql4Cds.XTB
         private void saveAsCSVToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var grid = (DataGridView)gridContextMenuStrip.SourceControl;
-            var table = (DataTable)grid.DataSource;
+            var results = (GridResults)grid.Tag;
 
             using (var saveDialog = new SaveFileDialog())
             {
@@ -2254,16 +2267,16 @@ namespace MarkMpn.Sql4Cds.XTB
 
                 if (saveDialog.ShowDialog() == DialogResult.OK)
                 {
-                    _exportBackgroundWorker.RunWorkerAsync(new ExportToCsv(table, saveDialog.FileName));
+                    _exportBackgroundWorker.RunWorkerAsync(new ExportToCsv(results, saveDialog.FileName));
                 }
             }
         }
 
         class ExportToCsv : ExportParams
         {
-            public ExportToCsv(DataTable table, string filename)
+            public ExportToCsv(GridResults results, string filename)
             {
-                DataTable = table;
+                Results = results;
                 Filename = filename;
             }
 
@@ -2283,7 +2296,7 @@ namespace MarkMpn.Sql4Cds.XTB
         private void saveAsExcelToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var grid = (DataGridView)gridContextMenuStrip.SourceControl;
-            var table = (DataTable)grid.DataSource;
+            var results = (GridResults)grid.Tag;
 
             using (var saveDialog = new SaveFileDialog())
             {
@@ -2291,7 +2304,7 @@ namespace MarkMpn.Sql4Cds.XTB
 
                 if (saveDialog.ShowDialog() == DialogResult.OK)
                 {
-                    _exportBackgroundWorker.RunWorkerAsync(new ExportToExcel(table, saveDialog.FileName, er => GetRecordUrl(er, out _)));
+                    _exportBackgroundWorker.RunWorkerAsync(new ExportToExcel(results, saveDialog.FileName, er => GetRecordUrl(er, out _)));
                 }
             }
         }
@@ -2300,9 +2313,9 @@ namespace MarkMpn.Sql4Cds.XTB
         {
             private readonly Func<SqlEntityReference, string> _urlGenerator;
 
-            public ExportToExcel(DataTable table, string filename, Func<SqlEntityReference, string> urlGenerator)
+            public ExportToExcel(GridResults results, string filename, Func<SqlEntityReference, string> urlGenerator)
             {
-                DataTable = table;
+                Results = results;
                 Filename = filename;
                 _urlGenerator = urlGenerator;
             }

--- a/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
+++ b/MarkMpn.Sql4Cds/MarkMpn.SQL4CDS.nuspec
@@ -23,12 +23,10 @@ plugins or integrations by writing familiar SQL and converting it.
 Queries can also run using the preview TDS Endpoint. A wide range of SQL functionality is also built
 in to allow running queries that aren't directly supported by either FetchXML or the TDS Endpoint.</description>
     <summary>Convert SQL queries to FetchXML and execute them against Dataverse / D365</summary>
-    <releaseNotes>Enhancements:
-* Sort results in grid by clicking on column headers - sort order uses SQL ordering rules
-
-Bug fixes:
-* Fixed "Operation is not valid due to the current state of the object" when running queries that return no results 
-* Fixed compatibility with client applications that use Application Insights v3
+    <releaseNotes>Bug fixes:
+* Fixed using INSERT with multiple values when implicit type conversion is required between the rows
+* Fixed using @@VERSION when local file system is not available
+* Fixed copying and exporting results from the grid view
     </releaseNotes>
     <copyright>Copyright © 2019 Mark Carrington</copyright>
     <language>en-GB</language>


### PR DESCRIPTION
- Fixed copying and exporting grid results - fixes #781
- Fixed using multiple rows for INSERT statements when implicit type conversion is required between the rows, e.g. null literal - fixes #784
- Use timestamp embedded in assembly metadata rather than last write time of file when determining results of `@@VERSION` - supersedes #780