### PR TITLE
Message invocation with complex response types

### DIFF
--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/DataverseMessageResponseConverter.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/DataverseMessageResponseConverter.cs
@@ -1,0 +1,335 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xrm.Sdk;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
+{
+    /// <summary>
+    /// Custom JSON converters for Dataverse message response types
+    /// </summary>
+    public static class DataverseMessageResponseConverters
+    {
+        /// <summary>
+        /// Gets the set of converters for serializing Dataverse types
+        /// </summary>
+        public static IList<JsonConverter> GetConverters()
+        {
+            return new JsonConverter[]
+            {
+                new OptionSetValueConverter(),
+                new MoneyConverter(),
+                new EntityReferenceConverter(),
+                new EntityConverter(),
+                new EntityCollectionConverter()
+            };
+        }
+
+        private class OptionSetValueConverter : JsonConverter<OptionSetValue>
+        {
+            public override OptionSetValue ReadJson(JsonReader reader, Type objectType, OptionSetValue existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                if (reader.TokenType == JsonToken.Null)
+                    return null;
+
+                return new OptionSetValue((int)serializer.Deserialize(reader, typeof(int)));
+            }
+
+            public override void WriteJson(JsonWriter writer, OptionSetValue value, JsonSerializer serializer)
+            {
+                if (value == null)
+                {
+                    writer.WriteNull();
+                    return;
+                }
+
+                writer.WriteValue(value.Value);
+            }
+        }
+
+        private class MoneyConverter : JsonConverter<Money>
+        {
+            public override Money ReadJson(JsonReader reader, Type objectType, Money existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                if (reader.TokenType == JsonToken.Null)
+                    return null;
+
+                return new Money((decimal)serializer.Deserialize(reader, typeof(decimal)));
+            }
+
+            public override void WriteJson(JsonWriter writer, Money value, JsonSerializer serializer)
+            {
+                if (value == null)
+                {
+                    writer.WriteNull();
+                    return;
+                }
+
+                writer.WriteValue(value.Value);
+            }
+        }
+
+        private class EntityReferenceConverter : JsonConverter<EntityReference>
+        {
+            public override EntityReference ReadJson(JsonReader reader, Type objectType, EntityReference existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                if (reader.TokenType == JsonToken.Null)
+                    return null;
+
+                var obj = JObject.Load(reader);
+                var er = new EntityReference();
+
+                if (obj.TryGetValue("@odata.id", StringComparison.OrdinalIgnoreCase, out var idToken))
+                    er.Id = Guid.Parse(idToken.Value<string>());
+
+                if (obj.TryGetValue("@odata.type", StringComparison.OrdinalIgnoreCase, out var typeToken))
+                    er.LogicalName = typeToken.Value<string>();
+
+                if (obj.TryGetValue("name", StringComparison.OrdinalIgnoreCase, out var nameToken))
+                    er.Name = nameToken.Value<string>();
+
+                return er;
+            }
+
+            public override void WriteJson(JsonWriter writer, EntityReference value, JsonSerializer serializer)
+            {
+                if (value == null)
+                {
+                    writer.WriteNull();
+                    return;
+                }
+
+                writer.WriteStartObject();
+
+                if (value.Id != Guid.Empty)
+                {
+                    writer.WritePropertyName("@odata.id");
+                    writer.WriteValue(value.Id.ToString());
+                }
+
+                if (!string.IsNullOrEmpty(value.LogicalName))
+                {
+                    writer.WritePropertyName("@odata.type");
+                    writer.WriteValue(value.LogicalName);
+                }
+
+                if (!string.IsNullOrEmpty(value.Name))
+                {
+                    writer.WritePropertyName("name");
+                    writer.WriteValue(value.Name);
+                }
+
+                writer.WriteEndObject();
+            }
+        }
+
+        private class EntityConverter : JsonConverter<Entity>
+        {
+            public override Entity ReadJson(JsonReader reader, Type objectType, Entity existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                if (reader.TokenType == JsonToken.Null)
+                    return null;
+
+                var obj = JObject.Load(reader);
+                var entity = new Entity();
+
+                // Extract the type and ID from known fields
+                if (obj.TryGetValue("@odata.type", StringComparison.OrdinalIgnoreCase, out var typeToken))
+                    entity.LogicalName = typeToken.Value<string>();
+
+                if (obj.TryGetValue("@odata.id", StringComparison.OrdinalIgnoreCase, out var idToken))
+                    entity.Id = Guid.Parse(idToken.Value<string>());
+
+                // Process all other attributes
+                foreach (var prop in obj.Properties())
+                {
+                    if (prop.Name.StartsWith("@odata.", StringComparison.OrdinalIgnoreCase) || prop.Name.EndsWith("@odata.type", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    // Skip virtual attributes that are derived from other attributes
+                    if ((prop.Name.EndsWith("name", StringComparison.OrdinalIgnoreCase) || prop.Name.EndsWith("type", StringComparison.OrdinalIgnoreCase)) &&
+                        obj.ContainsKey(prop.Name.Substring(0, prop.Name.Length - (prop.Name.EndsWith("type", StringComparison.OrdinalIgnoreCase) ? 4 : 4)) + "@odata.type"))
+                        continue;
+
+                    var typeAnnotationKey = prop.Name + "@odata.type";
+                    if (obj.TryGetValue(typeAnnotationKey, StringComparison.OrdinalIgnoreCase, out var typeAnnotation))
+                    {
+                        var typeName = typeAnnotation.Value<string>();
+                        entity[prop.Name] = DeserializeTypedValue(prop.Value, typeName, serializer);
+                    }
+                    else
+                    {
+                        entity[prop.Name] = prop.Value.ToObject(typeof(object), serializer);
+                    }
+                }
+
+                return entity;
+            }
+
+            public override void WriteJson(JsonWriter writer, Entity value, JsonSerializer serializer)
+            {
+                if (value == null)
+                {
+                    writer.WriteNull();
+                    return;
+                }
+
+                writer.WriteStartObject();
+
+                if (!string.IsNullOrEmpty(value.LogicalName))
+                {
+                    writer.WritePropertyName("@odata.type");
+                    writer.WriteValue(value.LogicalName);
+                }
+
+                if (value.Id != Guid.Empty)
+                {
+                    writer.WritePropertyName("@odata.id");
+                    writer.WriteValue(value.Id.ToString());
+                }
+
+                if (value.Attributes != null)
+                {
+                    foreach (var attribute in value.Attributes)
+                    {
+                        writer.WritePropertyName(attribute.Key);
+                        SerializeAttribute(writer, attribute.Value, serializer);
+
+                        // Add type annotation for types that need special deserialization
+                        if (attribute.Value != null && !(attribute.Value is string) && !(attribute.Value is bool) && !(attribute.Value is int))
+                        {
+                            writer.WritePropertyName(attribute.Key + "@odata.type");
+                            writer.WriteValue(attribute.Value.GetType().Name);
+                        }
+                    }
+                }
+
+                writer.WriteEndObject();
+            }
+
+            private void SerializeAttribute(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                if (value == null)
+                {
+                    writer.WriteNull();
+                }
+                else if (value is OptionSetValue osv)
+                {
+                    writer.WriteValue(osv.Value);
+                }
+                else if (value is Money money)
+                {
+                    writer.WriteValue(money.Value);
+                }
+                else if (value is EntityReference er)
+                {
+                    serializer.Serialize(writer, er);
+                }
+                else if (value is Entity nestedEntity)
+                {
+                    serializer.Serialize(writer, nestedEntity);
+                }
+                else if (value is EntityCollection nestedCollection)
+                {
+                    serializer.Serialize(writer, nestedCollection);
+                }
+                else
+                {
+                    serializer.Serialize(writer, value);
+                }
+            }
+
+            private object DeserializeTypedValue(JToken token, string typeName, JsonSerializer serializer)
+            {
+                switch (typeName)
+                {
+                    case "OptionSetValue": return new OptionSetValue((int)token);
+                    case "Money": return new Money((decimal)token);
+                    case "EntityReference": return token.ToObject<EntityReference>(serializer);
+                    case "Entity": return token.ToObject<Entity>(serializer);
+                    case "EntityCollection": return token.ToObject<EntityCollection>(serializer);
+                    default: return token.ToObject(typeof(object), serializer);
+                }
+            }
+        }
+
+        private class EntityCollectionConverter : JsonConverter<EntityCollection>
+        {
+            public override EntityCollection ReadJson(JsonReader reader, Type objectType, EntityCollection existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                if (reader.TokenType == JsonToken.Null)
+                    return null;
+
+                var obj = JObject.Load(reader);
+                var collection = new EntityCollection();
+
+                if (obj.TryGetValue("entityName", StringComparison.OrdinalIgnoreCase, out var entityNameToken))
+                    collection.EntityName = entityNameToken.Value<string>();
+
+                if (obj.TryGetValue("entities", StringComparison.OrdinalIgnoreCase, out var entitiesToken) && entitiesToken.Type == JTokenType.Array)
+                {
+                    foreach (var entityToken in entitiesToken)
+                        collection.Entities.Add(entityToken.ToObject<Entity>(serializer));
+                }
+
+                if (obj.TryGetValue("moreRecords", StringComparison.OrdinalIgnoreCase, out var moreRecordsToken))
+                    collection.MoreRecords = moreRecordsToken.Value<bool>();
+
+                if (obj.TryGetValue("pagingCookie", StringComparison.OrdinalIgnoreCase, out var pagingCookieToken))
+                    collection.PagingCookie = pagingCookieToken.Value<string>();
+
+                if (obj.TryGetValue("totalRecordCount", StringComparison.OrdinalIgnoreCase, out var totalRecordCountToken))
+                    collection.TotalRecordCount = totalRecordCountToken.Value<int>();
+
+                return collection;
+            }
+
+            public override void WriteJson(JsonWriter writer, EntityCollection value, JsonSerializer serializer)
+            {
+                if (value == null)
+                {
+                    writer.WriteNull();
+                    return;
+                }
+
+                writer.WriteStartObject();
+
+                if (!string.IsNullOrEmpty(value.EntityName))
+                {
+                    writer.WritePropertyName("entityName");
+                    writer.WriteValue(value.EntityName);
+                }
+
+                writer.WritePropertyName("entities");
+                writer.WriteStartArray();
+
+                foreach (var entity in value.Entities)
+                    serializer.Serialize(writer, entity);
+
+                writer.WriteEndArray();
+
+                if (value.MoreRecords)
+                {
+                    writer.WritePropertyName("moreRecords");
+                    writer.WriteValue(true);
+                }
+
+                if (!string.IsNullOrEmpty(value.PagingCookie))
+                {
+                    writer.WritePropertyName("pagingCookie");
+                    writer.WriteValue(value.PagingCookie);
+                }
+
+                if (value.TotalRecordCount > 0)
+                {
+                    writer.WritePropertyName("totalRecordCount");
+                    writer.WriteValue(value.TotalRecordCount);
+                }
+
+                writer.WriteEndObject();
+            }
+        }
+    }
+}

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
@@ -96,6 +96,12 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         public string PagingParameter { get; set; }
 
         /// <summary>
+        /// Indicates if the response will be a single JSON-serialized value
+        /// </summary>
+        [Browsable(false)]
+        public bool IsJsonSerialiedValueResponse { get; set; }
+
+        /// <summary>
         /// The types of values to be returned
         /// </summary>
         [Browsable(false)]
@@ -184,7 +190,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         private void SetOutputSchema(DataSource dataSource, Message message, TSqlFragment source)
         {
             // Add the response fields to the node schema
-            if (message.OutputParameters.Count == 1 && (message.OutputParameters[0].Type == typeof(Entity) || !message.OutputParameters[0].IsScalarType()))
+            if (message.OutputParameters.Count == 1 && (message.OutputParameters[0].Type == typeof(Entity) || message.OutputParameters[0].Type == typeof(AuditDetail) || message.OutputParameters[0].Type == typeof(EntityCollection) || message.OutputParameters[0].Type == typeof(AuditDetailCollection) || (message.OutputParameters[0].Type.IsArray && MessageParameter.IsScalarType(message.OutputParameters[0].Type.GetElementType()))))
             {
                 var firstValue = message.OutputParameters.Single();
                 var audit = false;
@@ -238,10 +244,18 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                     _primaryKeyColumn = PrefixWithAlias(dataSource.Metadata[otc.Value].PrimaryIdAttribute);
                 }
             }
-            else
+            else if (message.OutputParameters.Count > 0)
             {
-                foreach (var value in message.OutputParameters)
-                    AddSchemaColumn(value.Name, value.GetSqlDataType(dataSource));
+                if (message.OutputParameters.All(p => p.IsScalarType()))
+                {
+                    foreach (var value in message.OutputParameters)
+                        AddSchemaColumn(value.Name, value.GetSqlDataType(dataSource));
+                }
+                else
+                {
+                    AddSchemaColumn("Value", DataTypeHelpers.NVarChar(Int32.MaxValue, dataSource.DefaultCollation, CollationLabel.Implicit));
+                    IsJsonSerialiedValueResponse = true;
+                }
             }
 
             if (!String.IsNullOrEmpty(PagingParameter) && EntityCollectionResponseParameter == null)
@@ -402,6 +416,15 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
 
                 if (entity != null)
                     entities.Entities.Add(entity);
+            }
+            else if (IsJsonSerialiedValueResponse)
+            {
+                entities = new EntityCollection();
+                var entity = new Entity
+                {
+                    ["Value"] = JsonConvert.SerializeObject(response.Results.ToDictionary(kvp => kvp.Key, kvp => kvp.Value))
+                };
+                entities.Entities.Add(entity);
             }
             else
             {
@@ -648,6 +671,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 _primaryKeyColumn = _primaryKeyColumn,
                 PagingParameter = PagingParameter,
                 _isExpando = _isExpando,
+                IsJsonSerialiedValueResponse = IsJsonSerialiedValueResponse,
             };
 
             foreach (var value in Values)
@@ -669,7 +693,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (!message.IsValidAsTableValuedFunction())
                 throw new NotSupportedQueryFragmentException(Sql4CdsError.InvalidObjectName(tvf.SchemaObject))
                 {
-                    Suggestion = "Messages must only have scalar type inputs and must produce either one or more scalar type outputs or a single Entity or EntityCollection output"
+                    Suggestion = "Messages must only have scalar type inputs and must produce an output"
                 };
 
             var node = new ExecuteMessageNode
@@ -753,7 +777,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (!message.IsValidAsStoredProcedure())
                 throw new NotSupportedQueryFragmentException(Sql4CdsError.InvalidSprocName(sproc.ProcedureReference.ProcedureReference.Name))
                 {
-                    Suggestion = "Message is not valid to be called as a stored procedure\r\nMessages must only have scalar type inputs and must produce no more than one Entity or EntityCollection output or any number of scalar type outputs"
+                    Suggestion = "Message is not valid to be called as a stored procedure\r\nMessages must only have scalar type inputs"
                 };
 
             var node = new ExecuteMessageNode

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/ExecuteMessageNode.cs
@@ -18,6 +18,11 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
         private Dictionary<string, Func<ExpressionExecutionContext, object>> _inputParameters;
         private string _primaryKeyColumn;
         private bool _isExpando;
+        private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
+        {
+            Converters = DataverseMessageResponseConverters.GetConverters(),
+            NullValueHandling = NullValueHandling.Ignore
+        };
 
         /// <summary>
         /// The SQL string that the query was converted from
@@ -149,7 +154,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         conversion = (ExpressionExecutionContext ctx) =>
                         {
                             var s = (string)conversionToString(ctx);
-                            return DeserializeAttributeValues(s);
+                            return DeserializeEntity(s);
                         };
                     }
                     return conversion;
@@ -381,7 +386,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                         // Convert entity to JSON
                         for (var i = 0; i < entities.Entities.Count; i++)
                         {
-                            var json = SerializeAttributeValues(entities.Entities[i]);
+                            var json = SerializeEntity(entities.Entities[i]);
                             var entity = new Entity
                             {
                                 [EntityCollectionResponseParameter] = json
@@ -410,7 +415,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 if (response[EntityResponseParameter] is AuditDetail audit)
                     entity = GetAuditEntity(audit);
                 else if (_isExpando)
-                    entity = new Entity { [EntityResponseParameter] = SerializeAttributeValues((Entity)response[EntityResponseParameter]) };
+                    entity = new Entity { [EntityResponseParameter] = SerializeEntity((Entity)response[EntityResponseParameter]) };
                 else
                     entity = (Entity)response[EntityResponseParameter];
 
@@ -422,7 +427,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 entities = new EntityCollection();
                 var entity = new Entity
                 {
-                    ["Value"] = JsonConvert.SerializeObject(response.Results.ToDictionary(kvp => kvp.Key, kvp => kvp.Value))
+                    ["Value"] = JsonConvert.SerializeObject(response.Results.ToDictionary(kvp => kvp.Key, kvp => kvp.Value), _jsonSettings)
                 };
                 entities.Entities.Add(entity);
             }
@@ -450,142 +455,27 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 // Attribute list could vary from record to record depending on the entity type being audited,
                 // so can't expose this as a definite list of columns. Instead, serialize them as a string and
                 // allow the values to be accessed later using some custom functions.
-                entity["newvalues"] = SerializeAttributeValues(attributeAudit.NewValue);
-                entity["oldvalues"] = SerializeAttributeValues(attributeAudit.OldValue);
+                entity["newvalues"] = SerializeEntity(attributeAudit.NewValue);
+                entity["oldvalues"] = SerializeEntity(attributeAudit.OldValue);
             }
 
             return entity;
         }
 
-        private string SerializeAttributeValues(Entity entity)
+        private string SerializeEntity(Entity entity)
         {
             if (entity == null)
                 return null;
 
-            return JsonConvert.SerializeObject(BuildAttributeDictionary(entity));
+            return JsonConvert.SerializeObject(entity, _jsonSettings);
         }
 
-        private Dictionary<string, object> BuildAttributeDictionary(Entity entity)
-        {
-            if (entity == null)
-                return null;
-
-            var values = new Dictionary<string, object>();
-
-            if (!String.IsNullOrEmpty(entity.LogicalName))
-                values["@odata.type"] = entity.LogicalName;
-
-            if (entity.Id != Guid.Empty)
-                values["@odata.id"] = entity.Id;
-
-            if (entity.Attributes != null)
-            {
-                foreach (var attribute in entity.Attributes)
-                {
-                    if (attribute.Value is OptionSetValue osv)
-                    {
-                        values[attribute.Key] = osv.Value;
-                    }
-                    else if (attribute.Value is Money money)
-                    {
-                        values[attribute.Key] = money.Value;
-                    }
-                    else if (attribute.Value is EntityReference er)
-                    {
-                        values[attribute.Key] = er.Id;
-                        values[attribute.Key + "name"] = er.Name;
-                        values[attribute.Key + "type"] = er.LogicalName;
-                    }
-                    else if (attribute.Value is Entity nestedEntity)
-                    {
-                        values[attribute.Key] = BuildAttributeDictionary(nestedEntity);
-                        continue;
-                    }
-                    else if (attribute.Value is EntityCollection nestedCollection)
-                    {
-                        values[attribute.Key] = nestedCollection.Entities
-                            .Select(e => BuildAttributeDictionary(e))
-                            .ToList();
-                        continue;
-                    }
-                    else
-                    {
-                        values[attribute.Key] = attribute.Value;
-                    }
-
-                    // Add type annotation for any types that aren't going to be natively deserialized to the same type
-                    if (attribute.Value != null && !(attribute.Value is string) && !(attribute.Value is bool) && !(attribute.Value is int))
-                        values[attribute.Key + "@odata.type"] = attribute.Value.GetType().Name;
-                }
-            }
-
-            return values;
-        }
-
-        private Entity DeserializeAttributeValues(string s)
+        private Entity DeserializeEntity(string s)
         {
             if (String.IsNullOrEmpty(s))
                 return null;
 
-            var values = JsonConvert.DeserializeObject<Dictionary<string, object>>(s);
-            var entity = new Entity();
-
-            // Extrac the type and ID from known fields
-            if (values.TryGetValue("@odata.type", out var type))
-                entity.LogicalName = (string)type;
-
-            if (values.TryGetValue("@odata.id", out var id))
-                entity.Id = Guid.Parse((string)id);
-
-            // Look for any other typed values
-            foreach (var value in values)
-            {
-                if (value.Key.StartsWith("@odata.") || value.Key.EndsWith("@odata.type"))
-                    continue;
-
-                if ((value.Key.EndsWith("name") || value.Key.EndsWith("type")) && values.ContainsKey(value.Key.Substring(0, value.Key.Length - 4) + "@odata.type"))
-                    continue;
-
-                if (!values.TryGetValue(value.Key + "@odata.type", out var valueType))
-                {
-                    // Pass through the value as-is
-                    entity[value.Key] = value.Value;
-                }
-                else
-                {
-                    // Convert the value to the requested XRM type
-                    switch ((string)valueType)
-                    {
-
-                       case "OptionSetValue":
-                            entity[value.Key] = new OptionSetValue((int)value.Value);
-                            break;
-
-                        case "Money":
-                            entity[value.Key] = new Money((decimal)value.Value);
-                            break;
-
-                        case "EntityReference":
-                            var er = new EntityReference();
-                            er.Id = Guid.Parse((string)value.Value);
-
-                            if (values.TryGetValue(value.Key + "type", out var erType))
-                                er.LogicalName = (string)erType;
-
-                            if (values.TryGetValue(value.Key + "name", out var erName))
-                                er.Name = (string)erName;
-
-                            entity[value.Key] = er;
-                            break;
-
-                        default:
-                            entity[value.Key] = value.Value;
-                            break;
-                    }
-                }
-            }
-
-            return entity;
+            return JsonConvert.DeserializeObject<Entity>(s, _jsonSettings);
         }
 
         private void OnRetrievedEntity(Entity entity, IQueryExecutionOptions options, DataSource dataSource)

--- a/MarkMpn.Sql4Cds.Engine/MessageCache.cs
+++ b/MarkMpn.Sql4Cds.Engine/MessageCache.cs
@@ -367,7 +367,9 @@ namespace MarkMpn.Sql4Cds.Engine
             //    a. A single field of an entity-derived type, OR
             //    b. A single field of an entity collection, OR
             //    c. A single field of an array of a scalar type, OR
-            //    d. one or more fields of a scalar type
+            //    d. one or more fields of a scalar type, OR
+            //    e. any other fields that can be serialized as a single JSON blob
+            //    f. No response fields at all (if the message is allowed to be called as a stored procedure)
 
             if (InputParameters.Any(p => p.Type == null))
                 return false;
@@ -394,22 +396,7 @@ namespace MarkMpn.Sql4Cds.Engine
             if (OutputParameters.Count == 0)
                 return !requireOutput;
 
-            if (OutputParameters.All(p => p.IsScalarType()))
-                return true;
-
-            if (OutputParameters.Count > 1)
-                return false;
-
-            if (OutputParameters[0].Type == typeof(Entity) || OutputParameters[0].Type == typeof(AuditDetail))
-                return true;
-
-            if (OutputParameters[0].Type == typeof(EntityCollection) || OutputParameters[0].Type == typeof(AuditDetailCollection))
-                return true;
-
-            if (OutputParameters[0].Type.IsArray && MessageParameter.IsScalarType(OutputParameters[0].Type.GetElementType()))
-                return true;
-
-            return false;
+            return true;
         }
     }
 

--- a/MarkMpn.Sql4Cds.Tests/MarkMpn.Sql4Cds.Tests.csproj
+++ b/MarkMpn.Sql4Cds.Tests/MarkMpn.Sql4Cds.Tests.csproj
@@ -105,7 +105,7 @@
       <Version>4.3.1</Version>
     </PackageReference>
     <PackageReference Include="XrmToolBoxPackage">
-      <Version>1.2025.7.71</Version>
+      <Version>1.2025.10.74</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />

--- a/MarkMpn.Sql4Cds.sln
+++ b/MarkMpn.Sql4Cds.sln
@@ -37,8 +37,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MarkMpn.Sql4Cds.Export", "M
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MarkMpn.Sql4Cds.Engine", "MarkMpn.Sql4Cds.Engine\MarkMpn.Sql4Cds.Engine.csproj", "{C77B731D-E55C-4197-B96C-2B23EB9F56EF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkMpn.Sql4Cds.SSMS.21", "MarkMpn.Sql4Cds.SSMS.21\MarkMpn.Sql4Cds.SSMS.21.csproj", "{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkMpn.Sql4Cds.SSMS.22", "MarkMpn.Sql4Cds.SSMS.22\MarkMpn.Sql4Cds.SSMS.22.csproj", "{4DDE5E4D-A54A-4F69-BF78-F7053833E428}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkMpn.Sql4Cds.AIGitHubSponsorship", "MarkMpn.Sql4Cds.AIGitHubSponsorship\MarkMpn.Sql4Cds.AIGitHubSponsorship.csproj", "{82C21104-6DCA-49A3-B506-936792F4636E}"
@@ -233,21 +231,6 @@ Global
 		{C77B731D-E55C-4197-B96C-2B23EB9F56EF}.Release|x64.Build.0 = Release|Any CPU
 		{C77B731D-E55C-4197-B96C-2B23EB9F56EF}.Release|x86.ActiveCfg = Release|Any CPU
 		{C77B731D-E55C-4197-B96C-2B23EB9F56EF}.Release|x86.Build.0 = Release|Any CPU
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Debug|arm64.ActiveCfg = Debug|arm64
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Debug|arm64.Build.0 = Debug|arm64
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Debug|x64.Build.0 = Debug|Any CPU
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Debug|x86.ActiveCfg = Debug|x86
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Debug|x86.Build.0 = Debug|x86
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Release|arm64.ActiveCfg = Release|arm64
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Release|arm64.Build.0 = Release|arm64
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Release|x64.ActiveCfg = Release|Any CPU
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Release|x64.Build.0 = Release|Any CPU
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Release|x86.ActiveCfg = Release|x86
-		{01705E0A-F3CC-403B-A2C8-73C7D42CA44A}.Release|x86.Build.0 = Release|x86
 		{4DDE5E4D-A54A-4F69-BF78-F7053833E428}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4DDE5E4D-A54A-4F69-BF78-F7053833E428}.Debug|arm64.ActiveCfg = Debug|arm64
 		{4DDE5E4D-A54A-4F69-BF78-F7053833E428}.Debug|arm64.Build.0 = Debug|arm64
@@ -291,7 +274,6 @@ Global
 		SolutionGuid = {5E960561-7FE2-4022-964B-57E990767108}
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		MarkMpn.Sql4Cds.SSMS\MarkMpn.Sql4Cds.SSMS.projitems*{01705e0a-f3cc-403b-a2c8-73c7d42ca44a}*SharedItemsImports = 4
 		MarkMpn.Sql4Cds.Engine\MarkMpn.Sql4Cds.Engine.FetchXml.projitems*{460a4174-b9ea-413a-af83-c27c0686e98f}*SharedItemsImports = 13
 		MarkMpn.Sql4Cds.SSMS\MarkMpn.Sql4Cds.SSMS.projitems*{4dde5e4d-a54a-4f69-bf78-f7053833e428}*SharedItemsImports = 4
 		MarkMpn.Sql4Cds.Engine\MarkMpn.Sql4Cds.Engine.FetchXml.projitems*{69f7d111-3542-4e31-a0f8-e544f9ffa587}*SharedItemsImports = 4


### PR DESCRIPTION
Relaxed restrictions on allowable response types for invoking messages. Messages with more complex response types now return a single row with a `Value` column containing a JSON serialized representation of the result.
Fixes #796