### PR TITLE
v10.5 golive fixes

### DIFF
--- a/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/ExecutionPlanTests.cs
@@ -5369,9 +5369,10 @@ UPDATE account SET employees = @employees WHERE name = @name";
             Assert.AreEqual(1, plans.Length);
 
             var select = AssertNode<SelectNode>(plans[0]);
-            var computeScalar = AssertNode<ComputeScalarNode>(select.Source);
+            var tryCatch = AssertNode<TryCatchNode>(select.Source);
+            var computeScalar = AssertNode<ComputeScalarNode>(tryCatch.TrySource);
             Assert.AreEqual(1, computeScalar.Columns.Count);
-            Assert.AreEqual("account_count", computeScalar.Columns["count"].ToSql());
+            Assert.AreEqual("CAST (account_count AS INT)", computeScalar.Columns["count"].ToSql());
             var count = AssertNode<RetrieveTotalRecordCountNode>(computeScalar.Source);
             Assert.AreEqual("account", count.EntityName);
         }

--- a/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
+++ b/MarkMpn.Sql4Cds.Engine.Tests/Sql2FetchXmlTests.cs
@@ -1812,7 +1812,8 @@ namespace MarkMpn.Sql4Cds.Engine.Tests
             var queries = planBuilder.Build(query, null, out _);
 
             var selectNode = (SelectNode)queries[0];
-            var computeScalarNode = (ComputeScalarNode)selectNode.Source;
+            var tryCastNode  = (TryCatchNode)selectNode.Source;
+            var computeScalarNode = (ComputeScalarNode)tryCastNode.TrySource;
             var count = (RetrieveTotalRecordCountNode)computeScalarNode.Source;
         }
 

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsDataReader.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsDataReader.cs
@@ -92,10 +92,19 @@ namespace MarkMpn.Sql4Cds.Engine
 
                     // If we are in a TRY block, store the exception information in the context and move to the CATCH block
                     var caught = false;
+                    var tryCount = 1;
 
                     while (_instructionPointer < _command.Plan.Length && !_options.CancellationToken.IsCancellationRequested)
                     {
-                        if (_command.Plan[_instructionPointer] is BeginCatchNode)
+                        if (_command.Plan[_instructionPointer] is BeginTryNode)
+                        {
+                            tryCount++;
+                        }
+                        else if (_command.Plan[_instructionPointer] is EndTryNode)
+                        {
+                            tryCount--;
+                        }
+                        else if (tryCount == 0 && _command.Plan[_instructionPointer] is BeginCatchNode)
                         {
                             caught = true;
                             break;

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/FetchXmlScan.cs
@@ -998,7 +998,7 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             // or for troublesome virtual entity providers, we might get values for attributes we're not expecting.
             foreach (var attribute in entity.Attributes.ToList())
             {
-                var entityName = entity.LogicalName;
+                var entityName = entity.LogicalName ?? Entity.name;
                 var attributeName = attribute.Key;
 
                 if (attribute.Value is AliasedValue alias)

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/HashMatchAggregateNode.cs
@@ -104,28 +104,45 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
                 var count = new RetrieveTotalRecordCountNode { DataSource = fetch.DataSource, EntityName = fetch.Entity.name };
                 var countName = count.GetSchema(context).Schema.Single().Key;
 
-                if (countName == Aggregates.Single().Key)
-                    return count;
-
+                // RetrieveTotalRecordCount returns a bigint, count(*) should return an int, so apply a cast
                 var rename = new ComputeScalarNode
                 {
                     Source = count,
                     Columns =
                     {
-                        [Aggregates.Single().Key] = new ColumnReferenceExpression
+                        [Aggregates.Single().Key] = new CastCall
                         {
-                            MultiPartIdentifier = new MultiPartIdentifier
+                            Parameter = new ColumnReferenceExpression
                             {
-                                Identifiers = { new Identifier { Value = countName } }
-                            }
+                                MultiPartIdentifier = new MultiPartIdentifier
+                                {
+                                    Identifiers = { new Identifier { Value = countName } }
+                                }
+                            },
+                            DataType = DataTypeHelpers.Int
                         }
                     }
                 };
                 count.Parent = rename;
 
-                return rename;
+                // RetrieveTotalRecordCount can fail with some entities, so wrap it in a try/catch and fall back to the normal aggregate
+                var tryCatch = new TryCatchNode
+                {
+                    TrySource = rename,
+                    CatchSource = FoldInner(context, hints)
+                };
+
+                tryCatch.TrySource.Parent = tryCatch;
+                tryCatch.CatchSource.Parent = tryCatch;
+
+                return tryCatch;
             }
 
+            return FoldInner(context, hints);
+        }
+
+        private IDataExecutionPlanNodeInternal FoldInner(NodeCompilationContext context, IList<OptimizerHint> hints)
+        {
             // If we're doing a GROUP BY without any aggregates, this is equivalent to a DISTINCT
             if (Aggregates.Count == 0)
             {

--- a/MarkMpn.Sql4Cds.Engine/ExecutionPlan/RetrieveTotalRecordCountNode.cs
+++ b/MarkMpn.Sql4Cds.Engine/ExecutionPlan/RetrieveTotalRecordCountNode.cs
@@ -32,6 +32,10 @@ namespace MarkMpn.Sql4Cds.Engine.ExecutionPlan
             if (!context.Session.DataSources.TryGetValue(DataSource, out var dataSource))
                 throw new QueryExecutionException("Missing datasource " + DataSource);
 
+            var meta = dataSource.Metadata[EntityName];
+            var progressMessage = $"Retrieving {GetDisplayName(0, meta)} count...";
+            context.Options.Progress(0, progressMessage);
+
             var count = ((RetrieveTotalRecordCountResponse)dataSource.Connection.Execute(new RetrieveTotalRecordCountRequest { EntityNames = new[] { EntityName } })).EntityRecordCountCollection[EntityName];
 
             var resultEntity = new Entity(EntityName)


### PR DESCRIPTION
- TRY/CATCH improvements
- Fixed retrieving values from virtual entity providers that do not populate the entity name on the returned values
- Handle failures from RetrieveTotalRecordCount with other methods of calculating the count
- Ensure values from RetrieveTotalRecordCount are returned as the expected `int` type
- Show progress messages when using RetrieveTotalRecordCount