### PR TITLE
Security & Compliance Hardening: Enforce TDS TLS Encryption and Suppress Raw Query Telemetry

### DIFF
--- a/MarkMpn.Sql4Cds.Engine/Ado/DefaultQueryExecutionOptions.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/DefaultQueryExecutionOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 #if NETCOREAPP
@@ -39,7 +39,7 @@ namespace MarkMpn.Sql4Cds.Engine
 
         public int BatchSize { get; set; } = 100;
 
-        public bool UseTDSEndpoint { get; set; } = true;
+        public bool UseTDSEndpoint { get; set; } = false;
 
         public int MaxDegreeOfParallelism { get; set; } = 10;
 

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsCommand.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -11,7 +11,6 @@ using System.Threading;
 using MarkMpn.Sql4Cds.Engine.ExecutionPlan;
 using MarkMpn.Sql4Cds.Engine.Visitors;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
-using Microsoft.ApplicationInsights.DataContracts;
 
 #if NETCOREAPP
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -112,16 +111,6 @@ namespace MarkMpn.Sql4Cds.Engine
 
         internal void OnStatementCompleted(IRootExecutionPlanNode node, int recordsAffected, string message)
         {
-            var evt = new EventTelemetry("Execute")
-            {
-                Properties =
-                {
-                    ["QueryType"] = node.GetType().Name,
-                    ["Source"] = _connection.ApplicationName,
-                }
-            };
-            _connection.TelemetryClient.TrackEvent(evt);
-
             var handler = StatementCompleted;
 
             if (handler != null)
@@ -232,40 +221,11 @@ namespace MarkMpn.Sql4Cds.Engine
                 {
                     Plan = plan;
                 }
-                else
-                {
-                    foreach (var query in plan)
-                    {
-                        var evt = new EventTelemetry("Convert")
-                        {
-                            Properties =
-                            {
-                                ["QueryType"] = query.GetType().Name,
-                                ["Source"] = _connection.ApplicationName,
-                            }
-                        };
-                        _connection.TelemetryClient.TrackEvent(evt);
-                    }
-                }
 
                 return plan;
             }
             catch (Exception ex)
             {
-                var exTelem = new ExceptionTelemetry(ex)
-                {
-                    Properties =
-                    {
-                        ["Sql"] = CommandText,
-                        ["Source"] = _connection.ApplicationName,
-                    }
-                };
-
-                if (ex is ISql4CdsErrorException sqlEx && sqlEx.Errors.Count > 0)
-                    exTelem.Properties["ErrorNumber"] = sqlEx.Errors[0].Number.ToString();
-
-                _connection.TelemetryClient.TrackException(exTelem);
-
                 if (ex is Sql4CdsException)
                     throw;
 
@@ -287,9 +247,7 @@ namespace MarkMpn.Sql4Cds.Engine
         {
             Prepare();
 
-            try
-            {
-                _cancelledManually = false;
+            _cancelledManually = false;
 
                 if (!_reuseCts)
                     _cts = CommandTimeout == 0 ? new CancellationTokenSource() : new CancellationTokenSource(TimeSpan.FromSeconds(CommandTimeout));
@@ -299,10 +257,10 @@ namespace MarkMpn.Sql4Cds.Engine
                     var dataSource = _connection.Session.DataSources[_connection.Database];
 #if NETCOREAPP
                     var svc = (ServiceClient)dataSource.Connection;
-                    var con = new SqlConnection("server=" + svc.ConnectedOrgUriActual.Host);
+                    var con = new SqlConnection("server=" + svc.ConnectedOrgUriActual.Host + ";Encrypt=True;TrustServerCertificate=False");
 #else
                     var svc = (CrmServiceClient)dataSource.Connection;
-                    var con = new SqlConnection("server=" + svc.CrmConnectOrgUriActual.Host);
+                    var con = new SqlConnection("server=" + svc.CrmConnectOrgUriActual.Host + ";Encrypt=True;TrustServerCertificate=False");
 #endif
                     // Try to get the access token from CurrentAccessToken first, then fall back to the AccessTokenProvider
                     var accessToken = svc.CurrentAccessToken;
@@ -353,24 +311,6 @@ namespace MarkMpn.Sql4Cds.Engine
                 var options = new CancellationTokenOptionsWrapper(_connection.Options, _cts, _reuseCts);
 
                 return new Sql4CdsDataReader(this, options, behavior);
-            }
-            catch (Exception ex)
-            {
-                var exTelem = new ExceptionTelemetry(ex)
-                {
-                    Properties =
-                    {
-                        ["Sql"] = CommandText,
-                        ["Source"] = _connection.ApplicationName,
-                    }
-                };
-
-                if (ex is ISql4CdsErrorException sqlEx && sqlEx.Errors.Count > 0)
-                    exTelem.Properties["ErrorNumber"] = sqlEx.Errors[0].Number.ToString();
-
-                _connection.TelemetryClient.TrackException(exTelem);
-                throw;
-            }
         }
 
         internal Sql4CdsCommand CreateChildCommand()

--- a/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
+++ b/MarkMpn.Sql4Cds.Engine/Ado/Sql4CdsConnection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -10,7 +10,6 @@ using MarkMpn.Sql4Cds.Engine.ExecutionPlan;
 using System.Threading;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 using System.Data.SqlTypes;
-using Microsoft.ApplicationInsights;
 using System.Reflection;
 #if NETCOREAPP
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -27,7 +26,6 @@ namespace MarkMpn.Sql4Cds.Engine
     public class Sql4CdsConnection : DbConnection
     {
         private readonly DefaultQueryExecutionOptions _options;
-        private readonly TelemetryClient _ai;
         private readonly SessionContext _session;
 
         /// <summary>
@@ -62,10 +60,6 @@ namespace MarkMpn.Sql4Cds.Engine
             _options = new DefaultQueryExecutionOptions(this, dataSources.First().Value, CancellationToken.None);
             _session = new SessionContext(dataSources, _options);
 
-            _ai = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
-            {
-                ConnectionString = "InstrumentationKey=79761278-a908-4575-afbf-2f4d82560da6"
-            });
 
             var app = System.Reflection.Assembly.GetEntryAssembly();
 
@@ -225,8 +219,6 @@ namespace MarkMpn.Sql4Cds.Engine
             get => _options.ColumnOrdering;
             set => _options.ColumnOrdering = value;
         }
-
-        internal TelemetryClient TelemetryClient => _ai;
 
         /// <summary>
         /// Triggered before one or more records are about to be deleted

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.csproj
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="XPath2.Extensions" Version="1.1.3" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' And '$(TargetFramework)' == 'net462' ">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(OS)' == 'Windows_NT' And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' And '$(TargetFramework)' == 'net462' ">
     <MakeDir Directories="$(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />
     <Exec Command="copy $(TargetDir)MarkMpn.Sql4Cds.Engine.dll $(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />
     <Exec Command="copy $(TargetDir)Microsoft.SqlServer.TransactSql.ScriptDom.dll $(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.csproj
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net462</TargetFrameworks>
@@ -36,7 +36,6 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.2" Condition=" '$(TargetFramework)' == 'net8.0' " />
     <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.49" Condition=" '$(TargetFramework)' == 'net462' " />
     <PackageReference Include="Microsoft.CrmSdk.XrmTooling.CoreAssembly" Version="9.1.1.32" Condition=" '$(TargetFramework)' == 'net462' " />
@@ -49,7 +48,6 @@
     <MakeDir Directories="$(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />
     <Exec Command="copy $(TargetDir)MarkMpn.Sql4Cds.Engine.dll $(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />
     <Exec Command="copy $(TargetDir)Microsoft.SqlServer.TransactSql.ScriptDom.dll $(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />
-    <Exec Command="copy $(TargetDir)Microsoft.ApplicationInsights.dll $(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />
     <Exec Command="copy $(TargetDir)XPath2.dll $(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />
     <Exec Command="copy $(TargetDir)XPath2.Extensions.dll $(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />
   </Target>

--- a/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
+++ b/MarkMpn.Sql4Cds.Engine/MarkMpn.Sql4Cds.Engine.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>MarkMpn.Sql4Cds.Engine</id>
@@ -28,7 +28,6 @@ Improvements:
         <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.49" />
         <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.1.1.32" />
         <dependency id="Microsoft.SqlServer.TransactSql.ScriptDom" version="170.64.0" />
-        <dependency id="Microsoft.ApplicationInsights" version="2.23.0" />
         <dependency id="System.Data.SqlClient" version="4.8.6" />
         <dependency id="XPath2.Extensions" version="1.1.3" />
       </group>
@@ -36,7 +35,6 @@ Improvements:
         <dependency id="CsvHelper" version="33.1.0" />
         <dependency id="Microsoft.PowerPlatform.Dataverse.Client" version="1.2.2" />
         <dependency id="Microsoft.SqlServer.TransactSql.ScriptDom" version="170.64.0" />
-        <dependency id="Microsoft.ApplicationInsights" version="2.23.0" />
         <dependency id="System.Data.SqlClient" version="4.8.6" />
         <dependency id="XPath2.Extensions" version="1.1.3" />
       </group>

--- a/MarkMpn.Sql4Cds.Engine/TDSEndpoint.cs
+++ b/MarkMpn.Sql4Cds.Engine/TDSEndpoint.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -145,12 +145,12 @@ namespace MarkMpn.Sql4Cds.Engine
             if (!(dataSource.Connection is ServiceClient svc))
                 throw new ArgumentOutOfRangeException(nameof(dataSource.Connection), "Only ServiceClient instances are supported");
 
-            var con = new SqlConnection("server=" + svc.ConnectedOrgUriActual.Host);
+            var con = new SqlConnection("server=" + svc.ConnectedOrgUriActual.Host + ";Encrypt=True;TrustServerCertificate=False");
 #else
             if (!(dataSource.Connection is CrmServiceClient svc))
                 throw new ArgumentOutOfRangeException(nameof(dataSource.Connection), "Only CrmServiceClient instances are supported");
 
-            var con = new SqlConnection("server=" + svc.CrmConnectOrgUriActual.Host);
+            var con = new SqlConnection("server=" + svc.CrmConnectOrgUriActual.Host + ";Encrypt=True;TrustServerCertificate=False");
 #endif
 
             // Try to get the access token from CurrentAccessToken first, then fall back to the AccessTokenProvider

--- a/MarkMpn.Sql4Cds.Export/MarkMpn.Sql4Cds.Export.csproj
+++ b/MarkMpn.Sql4Cds.Export/MarkMpn.Sql4Cds.Export.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net48</TargetFrameworks>
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\MarkMpn.Sql4Cds.Engine\MarkMpn.Sql4Cds.Engine.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' And '$(TargetFramework)' == 'net48' ">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(OS)' == 'Windows_NT' And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' And '$(TargetFramework)' == 'net48' ">
     <MakeDir Directories="$(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />
     <Exec Command="copy $(TargetDir)MarkMpn.Sql4Cds.Export.dll $(AppData)\MscrmTools\XrmToolBox\Plugins\MarkMpn.Sql4Cds" />
   </Target>

--- a/MarkMpn.Sql4Cds.LanguageServer/Scripting/ScriptingHandler.cs
+++ b/MarkMpn.Sql4Cds.LanguageServer/Scripting/ScriptingHandler.cs
@@ -1,10 +1,9 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.ServiceModel.Channels;
 using MarkMpn.Sql4Cds.LanguageServer.Connection;
 using Microsoft.SqlTools.ServiceLayer.Scripting.Contracts;
 using StreamJsonRpc;
-using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 
 namespace MarkMpn.Sql4Cds.LanguageServer.Scripting
 {


### PR DESCRIPTION
## Summary
First, thank you for creating and maintaining SQL 4 CDS. It is an exceptional, industry-standard piece of engineering that has become foundational to the Microsoft Dataverse and Dynamics 365 developer ecosystem.

This PR introduces targeted security and data privacy hardening to `MarkMpn.Sql4Cds.Engine` to meet modern enterprise compliance standards (e.g., SOC 2, HIPAA, GDPR):

1. **Enforce Mandatory TDS TLS Encryption**: Adds `Encrypt=True;TrustServerCertificate=False` to all underlying TDS `SqlConnection` connection strings and defaults `UseTDSEndpoint` to `false` for a defense-in-depth default.
2. **Remove Unredacted Query Telemetry**: Removes the hardcoded Application Insights client and error telemetry that previously attached raw SQL `CommandText` on planning and execution exceptions.

---

## Motivation & Context

During a formal security and compliance audit for integrating `MarkMpn.Sql4Cds.Engine` into an enterprise-facing developer tool, our security team identified two areas requiring hardening:

### 1. TDS Transport Encryption (SEC-01)
- **Observation**: When connecting to the Dataverse TDS endpoint via `System.Data.SqlClient`, connection strings specified `server=<host>` without explicitly enforcing encryption. In certain network environments, default client negotiation allows opportunistic TLS downgrades before federated Entra ID (Azure AD) bearer tokens are transmitted.
- **Change**: Updated the connection string constructors in `TDSEndpoint.cs` and `Sql4CdsCommand.cs` to mandate `Encrypt=True;TrustServerCertificate=False`. Additionally, `DefaultQueryExecutionOptions.UseTDSEndpoint` is set to `false` by default so standard, authenticated HTTPS FetchXML execution over the Dataverse SDK remains the fail-safe default unless explicitly opted into.

### 2. Query Text in Error Telemetry (SEC-02)
- **Observation**: `Sql4CdsConnection` initialized a private `TelemetryClient` with a hardcoded instrumentation key. When query planning or execution threw an exception, the catch handlers logged exception telemetry that included the complete, unredacted `CommandText`.
- **Impact**: In production or enterprise environments, developer and user SQL queries often contain sensitive information in literal filters (e.g., PII such as email addresses, national IDs, employee names, or internal proprietary secrets). Transmitting raw query strings externally without user consent or an opt-out configuration seam poses significant compliance challenges under GDPR, HIPAA, and corporate data governance policies.
- **Change in this PR**: Stripped the `Microsoft.ApplicationInsights` dependency and the associated event/exception tracking from `Sql4CdsConnection` and `Sql4CdsCommand`.

---

## Maintainer Considerations & Alternative Approaches

We completely understand and appreciate why error telemetry was originally introduced: for an advanced query translation engine and AST compiler, seeing the real-world T-SQL queries that fail is invaluable for discovering syntax gaps, planning bugs, and missing functions.

If retaining diagnostic telemetry is important for the ongoing maintenance of the project, we understand that there are alternative designs that preserve that utility while maintaining strict compliance:

* **Explicit Opt-in**: Telemetry could be gated behind an explicit configuration property (e.g., `options.EnableDiagnosticsTelemetry = false` by default) with an in-tool consent prompt in UI hosts like XrmToolBox.
* **SQL Redaction / Tokenization**: If telemetry is enabled, literals (strings, numbers, GUIDs) and table/column identifiers could be sanitized or hashed using a visitor so that only the structural query shape is transmitted rather than raw data.
* **Pluggable Diagnostics Seam**: Allowing callers to inject their own `ITelemetrySink` or logging handler rather than hardcoding an external sink.

This PR provides the clean-room, zero-telemetry approach as a baseline, and recognizes that this implementation may not fit your vision for the project.

Also, we understand that setting the UseTDSEndpoint default to false may impact existing users of this library and need to remain set to true to maintain compatibility, at least for non-breaking minor version updates.

---

## Verification & Testing
- Verified that all core execution, AST visitor, and FetchXML translation logic remains 100% functional.
- Verified that all existing unit tests in `MarkMpn.Sql4Cds.Engine.Tests` continue to pass.
- Verified that TDS connections cleanly reject unencrypted channels.

Thank you again for your time, review, and tremendous contribution to the community!